### PR TITLE
Added basic events class and triggers for request and response

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -43,11 +43,14 @@ abstract class Application {
 
     protected $config;
     protected $oauth_client;
+    protected $events;
 
     /**
      * @param array $user_config
      */
     public function __construct(array $user_config) {
+        $this->events = new Events();
+
         //better here for overriding
         $this->config = array_replace_recursive(self::$_config_defaults, static::$_type_config_defaults, $user_config);
 
@@ -65,6 +68,12 @@ abstract class Application {
         return $this->oauth_client->getAuthorizeURL();
     }
 
+    /**
+     * @return Events
+     */
+    public function events() {
+        return $this->events;
+    }
 
     /**
      * @param $key

--- a/src/XeroPHP/Events.php
+++ b/src/XeroPHP/Events.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace XeroPHP;
+
+class Events {
+
+    private $_callbacks = array();
+
+    public function listen($event, $callback)
+    {
+        if(!isset($this->_callbacks[$event])) {
+            $this->_callbacks[$event] = array();
+        }
+
+        $this->_callbacks[$event][] = $callback;
+    }
+
+    public function fire($event, $args)
+    {
+        if(isset($this->_callbacks[$event])) {
+            foreach ($this->_callbacks[$event] as $callback) {
+                $callback($args);
+            }
+        }
+    }
+
+}

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -89,13 +89,18 @@ class Request {
         //build parameter array - the only time there's a post body is with the XML, only escape at this point
         $query_string = Helpers::flattenAssocArray($this->getParameters(), '%s=%s', '&', true);
 
-        if(strlen($query_string) > 0)
+        if(strlen($query_string) > 0) {
             $full_uri .= "?$query_string";
+        }
 
         curl_setopt($ch, CURLOPT_URL, $full_uri);
 
-        if($this->method === self::METHOD_POST || $this->method === self::METHOD_POST)
+        if($this->method === self::METHOD_POST || $this->method === self::METHOD_POST) {
             curl_setopt($ch, CURLOPT_POST, true);
+        }
+
+        // Fire event containing request state before request sent
+        $this->app->events()->fire('onRequest', $this);
 
         $response = curl_exec($ch);
         $info = curl_getinfo($ch);
@@ -105,6 +110,10 @@ class Request {
         }
 
         $this->response = new Response($this, $response, $info);
+
+        // Fire event containing response state before response is parsed
+        $this->app->events()->fire('onResponse', $this->response);
+
         $this->response->parse();
 
         return $this->response;
@@ -171,6 +180,12 @@ class Request {
         return $this->url;
     }
 
+    /**
+     * @return string
+     */
+    public function getBody() {
+        return $this->body;
+    }
 
     public function setBody($body, $content_type = self::CONTENT_TYPE_XML) {
 

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -110,6 +110,10 @@ class Response {
         return $this->oauth_response;
     }
 
+    public function getResponseBody() {
+        return $this->response_body;
+    }
+
     public function parseBody() {
 
         if($this->request->getUrl()->isOAuth())


### PR DESCRIPTION
We have a requirement to be able to get at the raw request and response objects to enable us to log them and use them for debugging in the event of an error.

Using the original Xero library this is pretty easy because you have direct access to the request method and can basically log what you send and receive from it... this Library has abstracted the raw request method away (which is a good thing!) and so its now no longer possible to do what we need... at least I think thats the case...

I am proposing the following as a solution but I am very open to other suggestions - it is just one of many possible solutions I am sure and may not fit in at all with where you want to take this Library...

So yeah feel free to tell me its a crap idea... or let me know how you would rather it is done...

With what I have done it is now possible to listen for events like this:

```php
<?php 

use XeroPHP\Application\PartnerApplication;
use XeroPHP\Remote\Request;
use XeroPHP\Remote\Response;

$xero = new PartnerApplication($config);

// Request event
$xero->events()->listen('onRequest', function(Request $request) {
	echo $request->getBody();
});

// Response event
$xero->events()->listen('onResponse', function(Response $response) {
	echo $response->getResponseBody();
});

$contact = $xero->loadByGUID('Accounting\\Contact', [GUID]);
```