### PR TITLE
Add support for downloading PDFs like invoices by adding an 'Accept' parameter for loadByGUID

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -101,29 +101,35 @@ abstract class Application {
 
 
     /**
-     * As you should never have a GUID for a non-existent object, will throw a NotFoundExceptioon
+     * As you should never have a GUID for a non-existent object, will throw a NotFoundException.
+     * You can also add the accept parameter to request PDFs (ie. of invoices)
      *
      * @param $model
      * @param $guid
+     * @param $accept
      * @return mixed
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
      */
-    public function loadByGUID($model, $guid) {
+    public function loadByGUID($model, $guid, $accept = Request::CONTENT_TYPE_XML) {
 
         $class = $this->validateModelClass($model);
 
         $uri = sprintf('%s/%s', $class::getResourceURI(), $guid);
 
         $url = new URL($this, $uri);
-        $request = new Request($this, $url, Request::METHOD_GET);
+        $request = new Request($this, $url, Request::METHOD_GET, $accept);
         $request->send();
 
-        //Return the first (if any) element from the response.
-        foreach($request->getResponse()->getElements() as $element){
-            $object = new $class();
-            $object->fromStringArray($element);
-            return $object;
+        if ($accept === Request::CONTENT_TYPE_XML) {
+          //Return the first (if any) element from the response.
+          foreach($request->getResponse()->getElements() as $element){
+              $object = new $class();
+              $object->fromStringArray($element);
+              return $object;
+          }
+        } else {
+          return $request->getResponse();
         }
 
     }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -40,7 +40,7 @@ class Request {
     private $response;
 
 
-    public function __construct(Application $app, URL $url, $method = self::METHOD_GET) {
+    public function __construct(Application $app, URL $url, $method = self::METHOD_GET, $accept = self::CONTENT_TYPE_XML) {
 
         $this->app = $app;
         $this->url = $url;
@@ -59,7 +59,7 @@ class Request {
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
-        $this->setHeader(self::HEADER_ACCEPT, self::CONTENT_TYPE_XML);
+        $this->setHeader(self::HEADER_ACCEPT, $accept);
 
     }
 
@@ -105,7 +105,9 @@ class Request {
         }
 
         $this->response = new Response($this, $response, $info);
-        $this->response->parse();
+        if ($this->getHeader(self::HEADER_ACCEPT) === self::CONTENT_TYPE_XML) {
+          $this->response->parse();
+        }
 
         return $this->response;
     }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -126,6 +126,10 @@ class Response {
         return $this->oauth_response;
     }
 
+    public function getResponse() {
+        return $this->response_body;
+    }
+
     public function parseBody() {
 
         if($this->request->getUrl()->isOAuth())
@@ -245,4 +249,4 @@ class Response {
     }
 
 
-} 
+}


### PR DESCRIPTION
This is a rather quick hack to make downloading PDFs work - maybe it would be better placed as a method of `Invoice` and other classes whose underlying endpoints permit PDF requests. However, it works fine.

To request a PDF Invoice:
```php
$response = $xero->loadByGUID('Accounting\\Invoice', $invoiceId, Request::CONTENT_TYPE_PDF);
$pdfBuffer = $response->getResponse(); // gets the PDF buffer, which you can save to a file or send as a download
```

Since the parameter is optional and has the default of `CONTENT_TYPE_XML`, nothing should break.