### PR TITLE
Make inaccessable private key exception more informative

### DIFF
--- a/src/XeroPHP/Remote/OAuth/SignatureMethod/RSASHA1.php
+++ b/src/XeroPHP/Remote/OAuth/SignatureMethod/RSASHA1.php
@@ -9,8 +9,9 @@ class RSASHA1 implements SignatureMethodInterface {
 
     public static function generateSignature(array $config, $sbs, $secret) {
         // Fetch the private key
-        if(false === $private_key_id = openssl_pkey_get_private($config['rsa_private_key']))
-            throw new Exception('Cannot access private key for signing');
+        if(false === $private_key_id = openssl_pkey_get_private($config['rsa_private_key'])){
+            throw new Exception("Cannot access private key for signing: openssl_pkey_get_private('${config['rsa_private_key']}') returned false");
+        }
 
         // Sign using the key
         if(false === openssl_sign($sbs, $signature, $private_key_id)) {


### PR DESCRIPTION
Previously, setting
```php
$config['rsa_private_key'] = 'file://full/path/to/key.pem'
```
(note two slashes instead of three) or other variations that are incompatible with openssl_pkey_private(), would just give the user "Cannot access private key for signing". However investigation will lead to confusion as the file is accessible, just not in the correct format. The additional info I've added allows the user to go straight to the manual instead of spending time thinking it's a permissions issue.