### PR TITLE
Change example for getting journal data to a valid version

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -101,9 +101,10 @@ if($oauth_session === null){
 // We are in! Grab some journals...
 $journals = $xero->load('Accounting\\Journal')->execute();
 echo sprintf('Found %s journals', count($journals));
-/*foreach ($journals as $journal) {
-    json_encode($journal);
-}*/
+
+foreach ($journals as $journal) {
+    json_encode($journal->toStringArray());
+}
 
 
 //The following two functions are just for a demo - you should use a more robust mechanism of storing tokens than this!


### PR DESCRIPTION
As the _data property of remote/object is protected, trying to use json_encode() on it will just return an empty object.