### PR TITLE
Application getAuthorizeUrl returns whole URL + PHPUnit tests + .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 ehthumbs.db
 Thumbs.db
 composer.lock
+composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm
+    - 7
+
+matrix:
+    allow_failures:
+        - php: hhvm
+        - php: 7
+
+before_script:
+    - composer install

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,16 @@
+### x
+
+* Travis CI
+* PHPUnit testing
+
+### 1.2.0
+
+* Models generated with traits
+
+### 1.1.0
+
+* Files api
+
+### 1.0.0
+
+* First release

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "~4.7",
         "fabpot/goutte": "~2.0",
         "twig/twig": "1.16.2"
     },

--- a/examples/partner.php
+++ b/examples/partner.php
@@ -47,7 +47,7 @@ if($oauth_session === null){
 
     setOAuthSession($oauth_response['oauth_token'], $oauth_response['oauth_token_secret']);
 
-    printf('<a href="%s?oauth_token=%s">Click here to Authorize</a>', $xero->getAuthorizeURL(), $oauth_response['oauth_token']);
+    printf('<a href="%s">Click here to Authorize</a>', $xero->getAuthorizeURL($oauth_response['oauth_token']));
     exit;
 
 } elseif(isset($oauth_session['session_handle']) && !isset($oauth_session['expires'])) {

--- a/examples/public.php
+++ b/examples/public.php
@@ -39,7 +39,7 @@ if(null === $oauth_session = getOAuthSession()){
 
     setOAuthSession($oauth_response['oauth_token'], $oauth_response['oauth_token_secret']);
 
-    printf('<a href="%s?oauth_token=%s">Click here to Authorize</a>', $xero->getAuthorizeURL(), $oauth_response['oauth_token']);
+    printf('<a href="%s">Click here to Authorize</a>', $xero->getAuthorizeURL($oauth_response['oauth_token']));
     exit;
 
 } else {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+        >
+
+    <testsuites>
+        <testsuite name="testsuite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -40,8 +40,14 @@ abstract class Application {
         )
     );
 
-
+    /**
+     * @var array
+     */
     protected $config;
+
+    /**
+     * @var Client
+     */
     protected $oauth_client;
 
     /**
@@ -61,13 +67,21 @@ abstract class Application {
         return $this->oauth_client;
     }
 
-    public function getAuthorizeURL() {
-        return $this->oauth_client->getAuthorizeURL();
+    /**
+     * @param string|null $oAuthToken
+     * @return string
+     */
+    public function getAuthorizeURL($oAuthToken = null) {
+        $authorizeUrl = $this->oauth_client->getAuthorizeURL();
+        if ($oAuthToken) {
+            return sprintf('%s?oauth_token=%s', $authorizeUrl, $oAuthToken);
+        }
+
+        return $authorizeUrl;
     }
 
-
     /**
-     * @param $key
+     * @param mixed $key
      * @return mixed
      * @throws Exception
      */
@@ -83,7 +97,7 @@ abstract class Application {
     /**
      * Validates and expands the provided model class to a full PHP class
      *
-     * @param $class
+     * @param string $class
      * @return string
      * @throws Exception
      */

--- a/tests/Application/PartnerApplicationTest.php
+++ b/tests/Application/PartnerApplicationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace XeroPHP\Tests\Application;
+
+use XeroPHP\Application\PartnerApplication;
+
+class PartnerApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNewInstance()
+    {
+        $config = array(
+            'oauth' => array(
+                'callback'              => 'http://localhost/',
+                'consumer_key'          => 'k',
+                'consumer_secret'       => 's',
+                'rsa_private_key'       => 'file://certs/privatekey.pem',
+                //'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
+            ),
+            'curl' => array(
+                CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
+                CURLOPT_SSLCERT         => 'certs/entrust-cert.pem',
+                CURLOPT_SSLKEYPASSWD    => '1234',
+                CURLOPT_SSLKEY          => 'certs/entrust-private.pem'
+            )
+        );
+
+        new PartnerApplication($config);
+    }
+}

--- a/tests/Application/PrivateApplicationTest.php
+++ b/tests/Application/PrivateApplicationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace XeroPHP\Tests\Application;
+
+use XeroPHP\Application\PrivateApplication;
+
+class PrivateApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNewInstance()
+    {
+        $config = array(
+            'oauth' => array(
+                'callback'         => 'http://localhost/',
+                'consumer_key'     => 'k',
+                'consumer_secret'  => 's',
+                'rsa_private_key'  => 'file://certs/private.pem',
+                'rsa_public_key'   => 'file://certs/public.pem'
+            )
+        );
+
+        new PrivateApplication($config);
+    }
+}

--- a/tests/Application/PublicApplicationTest.php
+++ b/tests/Application/PublicApplicationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace XeroPHP\Tests\Application;
+
+use XeroPHP\Application\PublicApplication;
+
+class PublicApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNewInstance()
+    {
+        $config = array(
+            'oauth' => array(
+                'callback'    => 'http://localhost/',
+                'consumer_key'      => 'k',
+                'consumer_secret'   => 's',
+            ),
+            'curl' => array(
+                CURLOPT_CAINFO => __DIR__.'/certs/ca-bundle.crt',
+            ),
+        );
+
+        new PublicApplication($config);
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace XeroPHP\Tests;
+
+use XeroPHP\Application;
+use XeroPHP\Application\PrivateApplication;
+
+class ApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function setUp()
+    {
+        $config = array(
+            'oauth' => array(
+                'callback'    => 'oob',
+                'consumer_key'      => 'k',
+                'consumer_secret'   => 's',
+                'rsa_private_key'  => 'file://certs/private.pem',
+                'rsa_public_key'   => 'file://certs/public.pem'
+            )
+        );
+
+        $this->application = new PrivateApplication($config);
+    }
+
+    public function testGetAuthorizeURL()
+    {
+        $expectedUrl = $this->application->getOAuthClient()->getAuthorizeURL();
+        $this->assertEquals($expectedUrl, $this->application->getAuthorizeURL());
+        $this->assertEquals($expectedUrl . '?oauth_token=test', $this->application->getAuthorizeURL('test'));
+    }
+}


### PR DESCRIPTION
`XeroPHP\Application::getAuthorizeURL` if you pass argument to it then it will return whole authorize url.

``` php
echo $application->getAuthorizeURL('AABB');
// outputs https://api.xero.com/oauth/Authorize?oauth_token=AABB
```

I've also added `phpunit.xml.dist` and `.travis.yml`.

You can now run tests by simply writting `phpunit` inside project ;-).