### PR TITLE
Add a request callback and a method of adding other callbacks

### DIFF
--- a/examples/config.php
+++ b/examples/config.php
@@ -35,5 +35,17 @@ $xero_base_config = array(
         //CURLOPT_SSLKEYPASSWD    => '1234',
         //CURLOPT_SSLKEY          => 'certs/entrust-private-RQ3.pem'
 
+    ),
+
+    // Functions which will be invoked at certain points during execution
+    // Currently supports xero_request($method, $uri) which is called every time
+    // a request is sent to Xero
+    'callbacks' => array(
+        // 'xero_request'         => function($method, $uri) {
+        //     This function could include code for saving the request to a log,
+        //     adding to your daily request counter (given the xero limit of one thousad per day),
+        //     automated testing or any other situation where monitoring Xero requests is useful.
+        //     e.g. \YourApp\XeroTransactions::log($method, $uri);
+        // }
     )
 );

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -93,6 +93,25 @@ abstract class Application {
         return $this->config[$key];
     }
 
+    /**
+     * Fetch the requested callback function from the callbacks array, if it exists
+     *
+     * Callbacks are optional functions that the user can supply, which are then called at
+     * associated times. For instance, the xero_request callback is called when we are making
+     * a request against Xero and to it we pass the request's method and url.
+     *
+     * @param $key
+     * @return mixed
+     */
+    public function getCallback($key) {
+        $callback = null;
+
+        if(isset($this->config['callbacks'][$key])){
+            $callback = $this->config['callbacks'][$key];
+        }
+
+        return $callback;
+    }
 
     /**
      * Validates and expands the provided model class to a full PHP class

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -95,6 +95,8 @@ class Request {
         if($this->method === self::METHOD_POST || $this->method === self::METHOD_PUT)
             curl_setopt($ch, CURLOPT_POST, true);
 
+        $this->callRequestCallback($this->method, $full_uri);
+
         $response = curl_exec($ch);
         $info = curl_getinfo($ch);
 
@@ -180,5 +182,15 @@ class Request {
         return $this;
     }
 
-
+    /**
+     * Invoke the Request callback if one has been configured and send to it the details
+     * of the Xero request that we are about to make
+     * @param $method string The HTTP method for the request being sent to Xero (e.g. POST, GET etc.)
+     * @param $uri string The URI that we are making the request against
+     */
+    protected function callRequestCallback($method, $uri){
+        if($requestCallback = $this->app->getCallback('xero_request')){
+            $requestCallback($method, $uri);
+        }
+    }
 }


### PR DESCRIPTION
I've added a user callback for when we are making requests to Xero

This is useful for users in the following instances:

* allowing counting of the number of requests being made to Xero (important due to the very low 1000 requests per day limit)
* logging requests being made
* automated sanity checks to make sure their code is resulting in the desired requests

I'm sure others will find other uses for this that I haven't thought of. 

Note: I know I could have made this a lot more flexible, such as allowing multiple callbacks per event, having the return affect weather the call to xero is actually executed, etc. But instead I have opted for keeping the changes small and easy to understand. I haven't added a test for this yet but will.