### PR TITLE
Add __isset magic function to Remote\Object

### DIFF
--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -346,6 +346,17 @@ abstract class Object implements ObjectInterface, \JsonSerializable {
 
 
     /**
+     * Magic method for testing if properties exist
+     *
+     * @param $property
+     * @return bool
+     */
+    public function __isset($property) {
+        return isset($this->_data[$property]);
+    }
+
+
+    /**
      * Magic getter for accessing properties directly
      *
      * @param $property
@@ -414,4 +425,4 @@ abstract class Object implements ObjectInterface, \JsonSerializable {
         return $this->toStringArray();
     }
 
-} 
+}


### PR DESCRIPTION
Some properties are not sent from the Xero API, for example `Contact.AccountNumber`.

If you try and call `getAccountNumber()`you will receive a notice that the index doesn't exist on `_data`. Overloading this function means you can test it first.

The alternative option would be for the getters to test if the property exists and return `NULL` if it doesn't.