### PR TITLE
Isset, getter & setter tests for Object + Object ArrayAcces

### DIFF
--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -10,7 +10,7 @@ use XeroPHP\Helpers;
  * Class Object
  * @package XeroPHP\Remote
  */
-abstract class Object implements ObjectInterface, \JsonSerializable {
+abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAccess {
 
     /**
      * Keys for the meta properties array
@@ -129,16 +129,19 @@ abstract class Object implements ObjectInterface, \JsonSerializable {
     }
 
     /**
-     *
      * @return string
      */
     public function getGUID() {
-        return $this->_data[static::getGUIDProperty()];
+        return $this->__get(static::getGUIDProperty());
     }
 
-
+    /**
+     * @param string $guid
+     * @return $this
+     */
     public function setGUID($guid) {
-        $this->_data[static::getGUIDProperty()] = $guid;
+        $this->__set(static::getGUIDProperty(), $guid);
+
         return $this;
     }
 
@@ -425,4 +428,39 @@ abstract class Object implements ObjectInterface, \JsonSerializable {
         return $this->toStringArray();
     }
 
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return $this->__isset($offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->__get($offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     * @return mixed
+     */
+    public function offsetSet($offset, $value)
+    {
+        return $this->__set($offset, $value);
+    }
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->_data[$offset]);
+    }
 }

--- a/tests/Remote/ObjectTest.php
+++ b/tests/Remote/ObjectTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace XeroPHP\Tests\Remote;
+
+use XeroPHP\Application;
+use XeroPHP\Remote\Object;
+
+class ObjectTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAccessorMethods()
+    {
+        $object = new SimpleObject(null);
+        $this->assertFalse(isset($object->test));
+        $this->assertNull($object->test);
+        $this->assertFalse(isset($object->TeST));
+        $this->assertNull($object->TeST);
+        $this->assertFalse(isset($object['test']));
+        $this->assertNull($object['test']);
+        $this->assertFalse(isset($object['TeST']));
+        $this->assertNull($object['TeST']);
+
+        $object->test = 'something';
+
+        $this->assertTrue(isset($object->test));
+        $this->assertEquals('something', $object->test);
+        $this->assertTrue(isset($object['test']));
+        $this->assertEquals('something', $object['TeST']);
+        $this->assertEquals('something', $object->TeST);
+        $this->assertEquals('something', $object['TeST']);
+
+        $this->assertFalse(isset($object->TeST), '__isset is case sensitive');
+        $this->assertFalse(isset($object['TeST']), 'offsetExists is case sensitive');
+    }
+
+    public function testGUIDMethods()
+    {
+        $object = new SimpleObject();
+        $this->assertNull($object->getGUID());
+        $this->assertFalse($object->hasGUID());
+
+        $object->setGUID('5b96e86b-418e-48e8-8949-308c14aec278');
+
+        $this->assertEquals('5b96e86b-418e-48e8-8949-308c14aec278', $object->getGUID());
+        $this->assertTrue($object->hasGUID());
+    }
+}
+
+class SimpleObject extends Object
+{
+    static function getGUIDProperty()
+    {
+        return 'test';
+    }
+
+    static function getProperties()
+    {
+        return ['test'];
+    }
+
+    static function getSupportedMethods()
+    {
+        return ['test'];
+    }
+
+    static function getResourceURI()
+    {
+        return 'test';
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTest()
+    {
+        return isset($this->_data['test']) ? $this->_data['test'] : null;
+    }
+
+    /**
+     * @param mixed $test
+     */
+    public function setTest($test)
+    {
+        $this->_data['test'] = $test;
+    }
+}


### PR DESCRIPTION
1. Adds tests for #59 + getters and setters in general.
2. Adds ArrayAccess to object, to allow accessing Object values like Array `$contact['Name']`

@calcinai @steveh I found out that newly added `__isset` is case sensitive, while `__get` & `__set` is not. The reason behind is that methods in PHP are not case sensitive, but arrays are.