### PR TITLE
Collections for groups of objects

### DIFF
--- a/generator/templates/model.twig
+++ b/generator/templates/model.twig
@@ -122,7 +122,8 @@ class {{ model.ClassName }} extends Remote\Object {
 {#  getters and setters #}
 {% for property in model.properties %}
     /**
-     * @return {{ property.PHPType }}{% if property.isArray %}[]{% endif %}
+     * @return {{ property.PHPType }}{% if property.isArray %}[]|Collection
+     * Always returns a collection, switch is for type hinting{% endif %}
 
 {% if property.isDeprecated %}     * @deprecated
 {% endif %}

--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -262,7 +262,8 @@ class BankTransaction extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -483,7 +483,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return ContactPerson[]
+     * @return ContactPerson[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getContactPersons() {
         return $this->_data['ContactPersons'];
@@ -500,7 +501,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBankAccountDetails() {
         return $this->_data['BankAccountDetails'];
@@ -568,7 +570,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return Address[]
+     * @return Address[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAddresses() {
         return $this->_data['Addresses'];
@@ -585,7 +588,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return Phone[]
+     * @return Phone[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPhones() {
         return $this->_data['Phones'];
@@ -704,7 +708,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return TrackingCategory[]
+     * @return TrackingCategory[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSalesTrackingCategories() {
         return $this->_data['SalesTrackingCategories'];
@@ -721,7 +726,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return TrackingCategory[]
+     * @return TrackingCategory[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPurchasesTrackingCategories() {
         return $this->_data['PurchasesTrackingCategories'];
@@ -755,7 +761,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return ContactGroup[]
+     * @return ContactGroup[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getContactGroups() {
         return $this->_data['ContactGroups'];
@@ -806,7 +813,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBatchPayments() {
         return $this->_data['BatchPayments'];
@@ -840,7 +848,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBalances() {
         return $this->_data['Balances'];
@@ -857,7 +866,8 @@ class Contact extends Remote\Object {
     }
 
     /**
-     * @return PaymentTerm[]
+     * @return PaymentTerm[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPaymentTerms() {
         return $this->_data['PaymentTerms'];

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -165,7 +165,8 @@ e.g.
     }
 
     /**
-     * @return Contact[]
+     * @return Contact[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getContacts() {
         return $this->_data['Contacts'];

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -341,7 +341,8 @@ class CreditNote extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];
@@ -545,7 +546,8 @@ class CreditNote extends Remote\Object {
     }
 
     /**
-     * @return Allocation[]
+     * @return Allocation[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations() {
         return $this->_data['Allocations'];

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim.php
@@ -140,7 +140,8 @@ class ExpenseClaim extends Remote\Object {
     }
 
     /**
-     * @return Receipt[]
+     * @return Receipt[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReceipts() {
         return $this->_data['Receipts'];

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -357,7 +357,8 @@ class Invoice extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];
@@ -652,7 +653,8 @@ class Invoice extends Remote\Object {
 
 
     /**
-     * @return Payment[]
+     * @return Payment[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPayments() {
         return $this->_data['Payments'];
@@ -660,7 +662,8 @@ class Invoice extends Remote\Object {
 
 
     /**
-     * @return Prepayment[]
+     * @return Prepayment[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPrepayments() {
         return $this->_data['Prepayments'];
@@ -668,7 +671,8 @@ class Invoice extends Remote\Object {
 
 
     /**
-     * @return Overpayment[]
+     * @return Overpayment[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getOverpayments() {
         return $this->_data['Overpayments'];
@@ -716,7 +720,8 @@ class Invoice extends Remote\Object {
 
 
     /**
-     * @return CreditNote[]
+     * @return CreditNote[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getCreditNotes() {
         return $this->_data['CreditNotes'];

--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -176,7 +176,8 @@ class Item extends Remote\Object {
     }
 
     /**
-     * @return Purchase[]
+     * @return Purchase[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPurchaseDetails() {
         return $this->_data['PurchaseDetails'];
@@ -193,7 +194,8 @@ class Item extends Remote\Object {
     }
 
     /**
-     * @return Sale[]
+     * @return Sale[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSalesDetails() {
         return $this->_data['SalesDetails'];

--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -277,7 +277,8 @@ class Journal extends Remote\Object {
     }
 
     /**
-     * @return JournalLine[]
+     * @return JournalLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getJournalLines() {
         return $this->_data['JournalLines'];

--- a/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
@@ -351,7 +351,8 @@ class JournalLine extends Remote\Object {
     }
 
     /**
-     * @return TrackingCategory[]
+     * @return TrackingCategory[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories() {
         return $this->_data['TrackingCategories'];

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -188,7 +188,8 @@ class ManualJournal extends Remote\Object {
     }
 
     /**
-     * @return JournalLine[]
+     * @return JournalLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getJournalLines() {
         return $this->_data['JournalLines'];

--- a/src/XeroPHP/Models/Accounting/Organisation.php
+++ b/src/XeroPHP/Models/Accounting/Organisation.php
@@ -659,7 +659,8 @@ class Organisation extends Remote\Object {
     }
 
     /**
-     * @return Address[]
+     * @return Address[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAddresses() {
         return $this->_data['Addresses'];
@@ -676,7 +677,8 @@ class Organisation extends Remote\Object {
     }
 
     /**
-     * @return Phone[]
+     * @return Phone[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPhones() {
         return $this->_data['Phones'];
@@ -693,7 +695,8 @@ class Organisation extends Remote\Object {
     }
 
     /**
-     * @return ExternalLink[]
+     * @return ExternalLink[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getExternalLinks() {
         return $this->_data['ExternalLinks'];
@@ -710,7 +713,8 @@ class Organisation extends Remote\Object {
     }
 
     /**
-     * @return PaymentTerm[]
+     * @return PaymentTerm[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPaymentTerms() {
         return $this->_data['PaymentTerms'];

--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -92,7 +92,8 @@ class PaymentTerm extends Remote\Object {
     }
 
     /**
-     * @return Bill[]
+     * @return Bill[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBills() {
         return $this->_data['Bills'];
@@ -109,7 +110,8 @@ class PaymentTerm extends Remote\Object {
     }
 
     /**
-     * @return Sale[]
+     * @return Sale[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSales() {
         return $this->_data['Sales'];

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -325,7 +325,8 @@ class Overpayment extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];
@@ -495,7 +496,8 @@ class Overpayment extends Remote\Object {
     }
 
     /**
-     * @return Allocation[]
+     * @return Allocation[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations() {
         return $this->_data['Allocations'];

--- a/src/XeroPHP/Models/Accounting/Prepayment.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment.php
@@ -325,7 +325,8 @@ class Prepayment extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];
@@ -495,7 +496,8 @@ class Prepayment extends Remote\Object {
     }
 
     /**
-     * @return Allocation[]
+     * @return Allocation[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations() {
         return $this->_data['Allocations'];

--- a/src/XeroPHP/Models/Accounting/Receipt.php
+++ b/src/XeroPHP/Models/Accounting/Receipt.php
@@ -230,7 +230,8 @@ class Receipt extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
@@ -235,7 +235,8 @@ class RepeatingInvoice extends Remote\Object {
     }
 
     /**
-     * @return LineItem[]
+     * @return LineItem[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems() {
         return $this->_data['LineItems'];

--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -204,7 +204,8 @@ class TaxRate extends Remote\Object {
     }
 
     /**
-     * @return TaxComponent[]
+     * @return TaxComponent[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTaxComponents() {
         return $this->_data['TaxComponents'];
@@ -255,7 +256,8 @@ class TaxRate extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getCanApplyToAssets() {
         return $this->_data['CanApplyToAssets'];
@@ -271,7 +273,8 @@ class TaxRate extends Remote\Object {
 
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getCanApplyToExpenses() {
         return $this->_data['CanApplyToExpenses'];
@@ -279,7 +282,8 @@ class TaxRate extends Remote\Object {
 
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getCanApplyToLiabilities() {
         return $this->_data['CanApplyToLiabilities'];

--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -162,7 +162,8 @@ class TrackingCategory extends Remote\Object {
     }
 
     /**
-     * @return TrackingOption[]
+     * @return TrackingOption[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getOptions() {
         return $this->_data['Options'];

--- a/src/XeroPHP/Models/Files/Folder.php
+++ b/src/XeroPHP/Models/Files/Folder.php
@@ -218,7 +218,8 @@ class Folder extends Remote\Object {
     }
 
     /**
-     * @return File[]
+     * @return File[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getFiles() {
         return $this->_data['Files'];

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -361,7 +361,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getMiddleNames() {
         return $this->_data['MiddleNames'];
@@ -565,7 +566,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return BankAccount[]
+     * @return BankAccount[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBankAccounts() {
         return $this->_data['BankAccounts'];
@@ -599,7 +601,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return OpeningBalance[]
+     * @return OpeningBalance[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getOpeningBalances() {
         return $this->_data['OpeningBalances'];
@@ -616,7 +619,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return SuperMembership[]
+     * @return SuperMembership[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSuperMemberships() {
         return $this->_data['SuperMemberships'];

--- a/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
@@ -220,7 +220,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return EarningsLine[]
+     * @return EarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -237,7 +238,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -254,7 +256,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSuperLines() {
         return $this->_data['SuperLines'];
@@ -271,7 +274,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];
@@ -288,7 +292,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveLines() {
         return $this->_data['LeaveLines'];
@@ -424,7 +429,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -255,7 +255,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -272,7 +273,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -289,7 +291,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSuperLines() {
         return $this->_data['SuperLines'];
@@ -306,7 +309,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];
@@ -323,7 +327,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveLines() {
         return $this->_data['LeaveLines'];
@@ -561,7 +566,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getMinimumMonthlyEarnings() {
         return $this->_data['MinimumMonthlyEarnings'];
@@ -629,7 +635,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAnnualNumberOfUnits() {
         return $this->_data['AnnualNumberOfUnits'];
@@ -663,7 +670,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
@@ -249,7 +249,8 @@ class TaxDeclaration extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAustralianResidentForTaxPurposes() {
         return $this->_data['AustralianResidentForTaxPurposes'];

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -259,7 +259,8 @@ class LeaveApplication extends Remote\Object {
     }
 
     /**
-     * @return LeavePeriod[]
+     * @return LeavePeriod[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeavePeriods() {
         return $this->_data['LeavePeriods'];

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
@@ -106,7 +106,8 @@ class LeavePeriod extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -112,7 +112,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return EarningsRate[]
+     * @return EarningsRate[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsRates() {
         return $this->_data['EarningsRates'];
@@ -129,7 +130,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return DeductionType[]
+     * @return DeductionType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionTypes() {
         return $this->_data['DeductionTypes'];
@@ -146,7 +148,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return LeaveType[]
+     * @return LeaveType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveTypes() {
         return $this->_data['LeaveTypes'];
@@ -163,7 +166,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementType[]
+     * @return ReimbursementType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementTypes() {
         return $this->_data['ReimbursementTypes'];

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -232,7 +232,8 @@ class EarningsRate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTypeOfUnits() {
         return $this->_data['TypeOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -146,7 +146,8 @@ class LeaveType extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTypeOfUnits() {
         return $this->_data['TypeOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/PayRun.php
+++ b/src/XeroPHP/Models/PayrollAU/PayRun.php
@@ -288,7 +288,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return Payslip[]
+     * @return Payslip[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPayslips() {
         return $this->_data['Payslips'];
@@ -296,7 +297,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getWages() {
         return $this->_data['Wages'];
@@ -304,7 +306,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions() {
         return $this->_data['Deductions'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip.php
@@ -262,7 +262,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return EarningsLine[]
+     * @return EarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -279,7 +280,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return TimesheetEarningsLine[]
+     * @return TimesheetEarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetEarningsLines() {
         return $this->_data['TimesheetEarningsLines'];
@@ -296,7 +298,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -313,7 +316,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return LeaveAccrualLine[]
+     * @return LeaveAccrualLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveAccrualLines() {
         return $this->_data['LeaveAccrualLines'];
@@ -330,7 +334,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];
@@ -347,7 +352,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return SuperannuationLine[]
+     * @return SuperannuationLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSuperannuationLines() {
         return $this->_data['SuperannuationLines'];
@@ -364,7 +370,8 @@ class Payslip extends Remote\Object {
     }
 
     /**
-     * @return TaxLine[]
+     * @return TaxLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTaxLines() {
         return $this->_data['TaxLines'];
@@ -413,7 +420,8 @@ class Payslip extends Remote\Object {
 
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getWages() {
         return $this->_data['Wages'];
@@ -421,7 +429,8 @@ class Payslip extends Remote\Object {
 
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions() {
         return $this->_data['Deductions'];
@@ -453,7 +462,8 @@ class Payslip extends Remote\Object {
 
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursements() {
         return $this->_data['Reimbursements'];
@@ -461,7 +471,8 @@ class Payslip extends Remote\Object {
 
 
     /**
-     * @return LeaveEarningsLine[]
+     * @return LeaveEarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveEarningsLines() {
         return $this->_data['LeaveEarningsLines'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
@@ -157,7 +157,8 @@ class DeductionLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
@@ -140,7 +140,8 @@ class EarningsLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
@@ -116,7 +116,8 @@ class LeaveAccrualLine extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
@@ -133,7 +133,8 @@ class LeaveEarningsLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
@@ -192,7 +192,8 @@ class SuperannuationLine extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getMinimumMonthlyEarnings() {
         return $this->_data['MinimumMonthlyEarnings'];

--- a/src/XeroPHP/Models/PayrollAU/Setting.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting.php
@@ -103,7 +103,8 @@ class Setting extends Remote\Object {
     }
 
     /**
-     * @return Account[]
+     * @return Account[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAccounts() {
         return $this->_data['Accounts'];
@@ -120,7 +121,8 @@ class Setting extends Remote\Object {
     }
 
     /**
-     * @return TrackingCategory[]
+     * @return TrackingCategory[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories() {
         return $this->_data['TrackingCategories'];

--- a/src/XeroPHP/Models/PayrollAU/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet.php
@@ -185,7 +185,8 @@ class Timesheet extends Remote\Object {
     }
 
     /**
-     * @return TimesheetLine[]
+     * @return TimesheetLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetLines() {
         return $this->_data['TimesheetLines'];
@@ -219,7 +220,8 @@ class Timesheet extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getHours() {
         return $this->_data['Hours'];

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -134,7 +134,8 @@ class TimesheetLine extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -352,7 +352,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getMiddleNames() {
         return $this->_data['MiddleNames'];
@@ -624,7 +625,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return SalaryAndWage[]
+     * @return SalaryAndWage[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getSalaryAndWages() {
         return $this->_data['SalaryAndWages'];
@@ -641,7 +643,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return WorkLocation[]
+     * @return WorkLocation[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getWorkLocations() {
         return $this->_data['WorkLocations'];
@@ -692,7 +695,8 @@ class Employee extends Remote\Object {
     }
 
     /**
-     * @return OpeningBalance[]
+     * @return OpeningBalance[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getOpeningBalances() {
         return $this->_data['OpeningBalances'];

--- a/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
@@ -152,7 +152,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return EarningsLine[]
+     * @return EarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -169,7 +170,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return BenefitLine[]
+     * @return BenefitLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines() {
         return $this->_data['BenefitLines'];
@@ -186,7 +188,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -203,7 +206,8 @@ class OpeningBalance extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];

--- a/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
@@ -193,7 +193,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -210,7 +211,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -227,7 +229,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];
@@ -244,7 +247,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return BenefitLine[]
+     * @return BenefitLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines() {
         return $this->_data['BenefitLines'];
@@ -278,7 +282,8 @@ class PayTemplate extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getUnitsOrHours() {
         return $this->_data['UnitsOrHours'];

--- a/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
@@ -113,7 +113,8 @@ class PaymentMethod extends Remote\Object {
     }
 
     /**
-     * @return BankAccount[]
+     * @return BankAccount[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBankAccounts() {
         return $this->_data['BankAccounts'];

--- a/src/XeroPHP/Models/PayrollUS/PayItem.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem.php
@@ -120,7 +120,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return EarningsType[]
+     * @return EarningsType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsTypes() {
         return $this->_data['EarningsTypes'];
@@ -137,7 +138,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return BenefitType[]
+     * @return BenefitType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitTypes() {
         return $this->_data['BenefitTypes'];
@@ -154,7 +156,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return DeductionType[]
+     * @return DeductionType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionTypes() {
         return $this->_data['DeductionTypes'];
@@ -171,7 +174,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementType[]
+     * @return ReimbursementType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementTypes() {
         return $this->_data['ReimbursementTypes'];
@@ -188,7 +192,8 @@ class PayItem extends Remote\Object {
     }
 
     /**
-     * @return TimeOffType[]
+     * @return TimeOffType[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimeOffTypes() {
         return $this->_data['TimeOffTypes'];

--- a/src/XeroPHP/Models/PayrollUS/PayRun.php
+++ b/src/XeroPHP/Models/PayrollUS/PayRun.php
@@ -248,7 +248,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarnings() {
         return $this->_data['Earnings'];
@@ -256,7 +257,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions() {
         return $this->_data['Deductions'];
@@ -288,7 +290,8 @@ class PayRun extends Remote\Object {
 
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getPayStubs() {
         return $this->_data['PayStubs'];

--- a/src/XeroPHP/Models/PayrollUS/Paystub.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub.php
@@ -322,7 +322,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarnings() {
         return $this->_data['Earnings'];
@@ -339,7 +340,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions() {
         return $this->_data['Deductions'];
@@ -373,7 +375,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursements() {
         return $this->_data['Reimbursements'];
@@ -424,7 +427,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return EarningsLine[]
+     * @return EarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines() {
         return $this->_data['EarningsLines'];
@@ -441,7 +445,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return LeaveEarningsLine[]
+     * @return LeaveEarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveEarningsLines() {
         return $this->_data['LeaveEarningsLines'];
@@ -458,7 +463,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return TimesheetEarningsLine[]
+     * @return TimesheetEarningsLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetEarningsLines() {
         return $this->_data['TimesheetEarningsLines'];
@@ -475,7 +481,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return DeductionLine[]
+     * @return DeductionLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines() {
         return $this->_data['DeductionLines'];
@@ -492,7 +499,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return ReimbursementLine[]
+     * @return ReimbursementLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines() {
         return $this->_data['ReimbursementLines'];
@@ -509,7 +517,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return BenefitLine[]
+     * @return BenefitLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines() {
         return $this->_data['BenefitLines'];
@@ -526,7 +535,8 @@ class Paystub extends Remote\Object {
     }
 
     /**
-     * @return TimeOffLine[]
+     * @return TimeOffLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimeOffLines() {
         return $this->_data['TimeOffLines'];

--- a/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
@@ -133,7 +133,8 @@ class EarningsLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
@@ -133,7 +133,8 @@ class LeaveEarningsLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
@@ -116,7 +116,8 @@ class TimeOffLine extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getHours() {
         return $this->_data['Hours'];

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
@@ -133,7 +133,8 @@ class TimesheetEarningsLine extends Remote\Object {
     }
 
     /**
-     * @return float[]
+     * @return float[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Models/PayrollUS/Setting.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting.php
@@ -95,7 +95,8 @@ class Setting extends Remote\Object {
     }
 
     /**
-     * @return Account[]
+     * @return Account[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getAccounts() {
         return $this->_data['Accounts'];
@@ -112,7 +113,8 @@ class Setting extends Remote\Object {
     }
 
     /**
-     * @return TrackingCategory[]
+     * @return TrackingCategory[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories() {
         return $this->_data['TrackingCategories'];

--- a/src/XeroPHP/Models/PayrollUS/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet.php
@@ -185,7 +185,8 @@ class Timesheet extends Remote\Object {
     }
 
     /**
-     * @return TimesheetLine[]
+     * @return TimesheetLine[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetLines() {
         return $this->_data['TimesheetLines'];
@@ -236,7 +237,8 @@ class Timesheet extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getHours() {
         return $this->_data['Hours'];

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -134,7 +134,8 @@ class TimesheetLine extends Remote\Object {
     }
 
     /**
-     * @return string[]
+     * @return string[]|Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits() {
         return $this->_data['NumberOfUnits'];

--- a/src/XeroPHP/Remote/Collection.php
+++ b/src/XeroPHP/Remote/Collection.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace XeroPHP\Remote;
+
+class Collection extends \ArrayObject {
+
+    /**
+     * Holds a list of objects that hold child references to the collection.
+     * todo - 2.x make this more elegant.
+     *
+     * @var Object[]
+     */
+    protected $_associated_objects;
+
+
+    public function addAssociatedObject($parent_property, Object $object){
+        $this->_associated_objects[$parent_property] = $object;
+    }
+
+    /**
+     * Remove an item at a specific index
+     *
+     * @param $index
+     */
+    public function removeAt($index){
+        if(isset($this[$index])){
+            foreach($this->_associated_objects as $parent_property => $object){
+                /** @var Object $object */
+                $object->setDirty($parent_property);
+            }
+            unset($this[$index]);
+        }
+    }
+
+    /**
+     * Remove a specific object from the collection
+     *
+     * @param \XeroPHP\Remote\Object $object
+     */
+    public function remove(Object $object){
+        foreach($this as $index => $item){
+            if($item === $object){
+                $this->removeAt($index);
+            }
+        }
+    }
+
+    /**
+     *  Remove all of the values int he collection
+     */
+    public function removeAll(){
+        foreach($this->_associated_objects as $parent_property => $object){
+            /** @var Object $object */
+            $object->setDirty($parent_property);
+        }
+        $this->exchangeArray([]);
+    }
+
+}

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -113,7 +113,7 @@ class Query {
     }
 
     /**
-     * @return array
+     * @return Collection
      */
     public function execute() {
 
@@ -145,12 +145,12 @@ class Query {
 
         $request->send();
 
-        $elements = array();
+        $elements = new Collection();
         foreach($request->getResponse()->getElements() as $element) {
             /** @var Object $built_element */
             $built_element = new $from_class($this->app);
             $built_element->fromStringArray($element);
-            $elements[] = $built_element;
+            $elements->append($built_element);
         }
 
         return $elements;


### PR DESCRIPTION
This introduces the use of collections instead of returned arrays of objects.  It's used in both the query and the child relations of existing objects.