### PR TITLE
Application loadByGUID handles payroll entities

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -128,8 +128,9 @@ abstract class Application {
         $class = $this->validateModelClass($model);
 
         $uri = sprintf('%s/%s', $class::getResourceURI(), $guid);
+        $api = $class::getAPIStem();
 
-        $url = new URL($this, $uri);
+        $url = new URL($this, $uri, $api);
         $request = new Request($this, $url, Request::METHOD_GET);
         $request->send();
 


### PR DESCRIPTION
Tried to use
```PHP
$xero->loadByGUID('PayrollAU\\Employee', $guid)
```
But it didn't use the Payroll API.  Hope this fixes it.  This is my first ever git pull request so hope it is right!