### PR TITLE
Make Partner example use query signing

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -14,7 +14,7 @@ $config = array(
         'consumer_key'          => 'k',
         'consumer_secret'       => 's',
         'rsa_private_key'       => 'file://certs/privatekey.pem',
-        //'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
+        'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
     ),
     'curl' => array(
         CURLOPT_CAINFO          => 'certs/ca-bundle.crt',


### PR DESCRIPTION
Header signing does not seem to be working reliably... sign in the query string instead