### PR TITLE
Handling bad requests with messages for invalid fields

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -73,6 +73,7 @@ class Response {
                 //This catches actual app errors
                 if(isset($this->root_error)) {
                     $message = sprintf('%s (%s)', $this->root_error['message'], implode(', ', $this->element_errors));
+                    $message .= $this->parseBadRequest();
                     throw new BadRequestException($message, $this->root_error['code']);
                 } else {
                     throw new BadRequestException();
@@ -110,6 +111,22 @@ class Response {
                 }
         }
     }
+
+	/**
+	 * @return string
+	 */
+	private function parseBadRequest(){
+		if (isset($this->elements)){
+			$field_errors = [];
+			foreach ($this->elements as $n => $element){
+				if (isset($element['ValidationErrors'])){
+					$errors[] = $element['ValidationErrors'][0]['Message'];
+				}
+			}
+			return "\nValidation errors:\n".implode("\n", $errors);
+		}
+		return '';
+	}
 
     public function getResponseBody(){
         return $this->response_body;


### PR DESCRIPTION
I was finding it difficult to debug when receiving the following Exception:

> [XeroPHP\Remote\Exception\BadRequestException] A validation exception occurred (An error occurred in Xero. Check the API Status page http://status.developer.xero.com for current service status. Contact the API support team at api@xero.com for more assistance)

occurring and not being able to debug, as the response was not available in scope. This was a bit frustrating doing TDD through Codeception, as that test framework doesn't work well with Xdebug.

I made a quick change to parse the ValidationErrors into a set of messages that get appended to the root error.

It could likely have presentation or code style improvements and with some feedback I'd be happy to make them!

If there's an alternative way of doing the same thing please let me know too.