### PR TITLE
Should be optional as per API doco

### DIFF
--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -173,7 +173,7 @@ class Item extends Remote\Object
         return array(
             'ItemID' => array (false, self::PROPERTY_TYPE_STRING, null, false, false),
             'Code' => array (true, self::PROPERTY_TYPE_STRING, null, false, false),
-            'InventoryAssetAccountCode' => array (true, self::PROPERTY_TYPE_STRING, null, false, false),
+            'InventoryAssetAccountCode' => array (false, self::PROPERTY_TYPE_STRING, null, false, false),
             'Name' => array (false, self::PROPERTY_TYPE_STRING, null, false, false),
             'IsSold' => array (false, self::PROPERTY_TYPE_BOOLEAN, null, false, false),
             'IsPurchased' => array (false, self::PROPERTY_TYPE_BOOLEAN, null, false, false),


### PR DESCRIPTION
Creating untracked item becomes impossible because InventoryAssetAccountCode object throws required Exception.

>XeroPHP\Models\Accounting\Item::$InventoryAssetAccountCode is mandatory and is either missing or empty. 

API states that it should be required only for tracked items. 

http://developer.xero.com/documentation/api/items/

>The following is required for a PUT / POST on **a tracked inventory item**
><InventoryAssetAccountCode> 	The inventory asset account for the item. The account must be of type INVENTORY. The COGSAccountCode in PurchaseDetails is also required to create a tracked item

There is no check for conditional validation in \XeroPHP\Remote\Object:validate() (i.e.  $meta[self::KEY_MANDATORY]; if $this->_data[$property] is set) so as stated, creating new item becomes impossible unless there is Inventory code, and COGSAccountCode accont code.