### PR TITLE
Public.php Demo & Query Logic

### DIFF
--- a/examples/public.php
+++ b/examples/public.php
@@ -79,7 +79,7 @@ print_r($xero->load('Accounting\\Organisation')->execute());
 function setOAuthSession($token, $secret, $expires = null){
     // expires sends back an int
     if($expires !== null) {
-        $expires = time() + $expires;
+        $expires = time() + intval($expires);
     }
 
     $_SESSION['oauth'] = array(

--- a/examples/public.php
+++ b/examples/public.php
@@ -77,6 +77,11 @@ print_r($xero->load('Accounting\\Organisation')->execute());
 
 //The following two functions are just for a demo - you should use a more robust mechanism of storing tokens than this!
 function setOAuthSession($token, $secret, $expires = null){
+    // expires sends back an int
+    if($expires !== null) {
+        $expires = time() + $expires;
+    }
+
     $_SESSION['oauth'] = array(
         'token' => $token,
         'token_secret' => $secret,

--- a/examples/public.php
+++ b/examples/public.php
@@ -60,7 +60,7 @@ if(null === $oauth_session = getOAuthSession()){
         $request->send();
         $oauth_response = $request->getResponse()->getOAuthResponse();
 
-        setOAuthSession($oauth_response['oauth_token'], $oauth_response['oauth_token_secret'], $oauth_response['expires']);
+        setOAuthSession($oauth_response['oauth_token'], $oauth_response['oauth_token_secret'], $oauth_response['oauth_expires_in']);
 
         //drop the qs
         $uri_parts = explode('?', $_SERVER['REQUEST_URI']);

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -47,6 +47,15 @@ class Query {
         $args = func_get_args();
 
         if(func_num_args() === 2) {
+            if($args[1] === true) {
+                $this->where[] = sprintf('%s=%s', $args[0], 'true');
+            } elseif($args[1] === false) {
+                $this->where[] = sprintf('%s=%s', $args[0], 'false');
+            } elseif(preg_match('/^(\'|")?(true|false)("|\')?$/i', $args[1])) {
+                $this->where[] = sprintf('%s=%s', $args[0], $args[1]);
+            } else {
+                $this->where[] = sprintf('%s==%s', $args[0], $args[1]);
+            }            
             $this->where[] = sprintf('%s=="%s"', $args[0], $args[1]);
         } else {
             $this->where[] = $args[0];

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -47,10 +47,12 @@ class Query {
         $args = func_get_args();
 
         if(func_num_args() === 2) {
-            if($args[1] === true) {
-                $this->where[] = sprintf('%s=%s', $args[0], 'true');
-            } elseif($args[1] === false) {
-                $this->where[] = sprintf('%s=%s', $args[0], 'false');
+            if(is_bool($args[1]) === true) {
+                if($args[1] === true) {
+                    $this->where[] = sprintf('%s=%s', $args[0], 'true');
+                } elseif($args[1] === false) {
+                    $this->where[] = sprintf('%s=%s', $args[0], 'false');
+                }
             } elseif(preg_match('/^(\'|")?(true|false)("|\')?$/i', $args[1])) {
                 $this->where[] = sprintf('%s=%s', $args[0], $args[1]);
             } else {


### PR DESCRIPTION
Updated logic in `examples/public.php`

- `getOAuthSession` compares the expires session to the current time. Variable wasn't a timestamp it was an integer of how many seconds until the token expired. Logic updated to save session as `time() + seconds`.
- Array key doesn't exist in example, changed `expires` to `oauth_expires_in`.

Updated logic in  `src/XeroPHP/Remote/Query.php`

- `where` expected query to be `==` but if a boolean is passed for queries like `Contact.IsCustomer = "TRUE"` only request one `=` operator. [Could use `->where('IsCustomer="TRUE"')` if this request isn't merged].
