### PR TITLE
Added getWarnings method to Invoice object to return any Xero warnings

### DIFF
--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -784,5 +784,13 @@ class Invoice extends Remote\Object
     }
 
 
+    /**
+    * Get any warnings from OAuth client when invoice is created
+    * @return string
+    */
+    public function getWarnings()
+    {
+        return $this->_application->getOAuthClient()->getRequest()->getResponse()->getElementWarnings();
+    }
 
 }

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -288,5 +288,9 @@ class Client {
         return null;
     }
 
+    public function getRequest(){
+        return $this->request;
+    }
+
 
 }


### PR DESCRIPTION
Added quick method of returning Xero warnings from Invoice object when creating an invoice without having to create a request object.


