### PR TITLE
isPropertyDirty dose not exists should be isDirty

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -273,7 +273,7 @@ abstract class Application {
      */
     private function savePropertiesDirectly(Remote\Object $object){
         foreach($object::getProperties() as $property_name => $meta){
-            if($meta[Remote\Object::KEY_SAVE_DIRECTLY] && $object->isPropertyDirty($property_name)){
+            if($meta[Remote\Object::KEY_SAVE_DIRECTLY] && $object->isDirty($property_name)){
                 //Then actually save
                 $property_objects = $object->$property_name;
                 $property_type = get_class(current($property_objects));


### PR DESCRIPTION
In Your application you call a method isPropertyDirty
https://github.com/calcinai/xero-php/blob/master/src/XeroPHP/Application.php#L276

I tried to allocate a overpayment to an invoice. Since this Property is save Directly it tries to call this method.

But it should just be isDirty($porperty)

Alex