### PR TITLE
Changing initial array variable name in case no errors are found

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -117,7 +117,7 @@ class Response {
 	 */
 	private function parseBadRequest(){
 		if (isset($this->elements)){
-			$field_errors = [];
+			$errors = [];
 			foreach ($this->elements as $n => $element){
 				if (isset($element['ValidationErrors'])){
 					$errors[] = $element['ValidationErrors'][0]['Message'];


### PR DESCRIPTION
It turns out the initial variable had the wrong name. I must have been too tired when I looked at it yesterday.