### PR TITLE
Payroll payslip fix

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -268,6 +268,11 @@ class Response {
                 case 'Message':
                     $this->root_error['message'] = $root_child;
                     break;
+                case 'Payslip':
+                    // payslip API always returns Payslip as a single node rather than array of nodes
+                    // as a result we need to parse it straight away without looping through it
+                    $this->elements[] = $root_child;
+                    break;
 
                 default:
                     //Happy to make the assumption that there will only be one root node with > than 2D children.

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -238,6 +238,11 @@ class Response {
                 case 'Message':
                     $this->root_error['message'] = (string) $root_child;
                     break;
+                case 'Payslip':
+                    // payslip API always returns Payslip as a single node rather than array of nodes
+                    // as a result we need to parse it straight away without looping through it
+                    $this->elements[] = Helpers::XMLToArray($root_child);
+                    break;
 
                 default:
                     //Happy to make the assumption that there will only be one root node with > than 2D children.


### PR DESCRIPTION
Hi there,

found an issue with Payroll/Payslip endpoint. 

It was trying to parse api response as if it was nested inside of the root node.

For example the Payroll/Payrun response would look like this:
```
<Response xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
  <Id>...</Id>
  <Status>OK</Status>
  <ProviderName>Xero API Previewer</ProviderName>
  <DateTimeUTC>...</DateTimeUTC>
  <PayRuns>
    <PayRun>
      ...
    </PayRun>
  </PayRuns>
</Response>
```

While payslip api response is very different, it does not have root node and just returns entire payslip as a single node. Example:
```
<Response xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
  <Id>...</Id>
  <Status>OK</Status>
  <ProviderName>Xero API Previewer</ProviderName>
  <DateTimeUTC>...</DateTimeUTC>
  <Payslip>
    ...
  </Payslip>
</Response>
```

Basically, I've added exception rule into both parseJSON and parseXML methods. 

Thank you,
Alex