### PR TITLE
Code cleanup

### DIFF
--- a/examples/config-test.php
+++ b/examples/config-test.php
@@ -10,23 +10,23 @@ use XeroPHP\Application\PartnerApplication;
 
 require '../vendor/autoload.php';
 
-$config = array(
-    'oauth' => array(
+$config = [
+    'oauth' => [
         'callback'    => 'http://localhost/',
 
         'consumer_key'      => 'k',
         'consumer_secret'   => 's',
 
-    ),
+    ],
 
-    'curl' => array(
+    'curl' => [
         CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
 
         CURLOPT_SSLCERT         => 'certs/entrust-cert-RQ3.pem',
         CURLOPT_SSLKEYPASSWD    => '1234',
         CURLOPT_SSLKEY          => 'certs/entrust-private-RQ3.pem'
-    )
-);
+    ]
+];
 
 $xero = new PartnerApplication($config);
 

--- a/examples/config.php
+++ b/examples/config.php
@@ -1,15 +1,15 @@
 <?php
 
-$xero_base_config = array(
+$xero_base_config = [
 
-    'xero' => array(
+    'xero' => [
         // API versions can be overridden if necessary for some reason.
         //'core_version'     => '2.0',
         //'payroll_version'  => '1.0',
         //'file_version'     => '1.0'
-    ),
+    ],
 
-    'oauth' => array(
+    'oauth' => [
         'callback'    => 'oob',
 
         'consumer_key'      => 'k',
@@ -22,10 +22,10 @@ $xero_base_config = array(
         //For certs on disk or a string - allows anything that is valid with openssl_pkey_get_(private|public)
         'rsa_private_key'  => 'file://certs/private.pem',
         'rsa_public_key'   => 'file://certs/public.pem'
-    ),
+    ],
 
     //These are raw curl options.  I didn't see the need to obfuscate these through methods
-    'curl' => array(
+    'curl' => [
         CURLOPT_USERAGENT   => 'XeroPHP Test App',
 
         //Only for partner apps - unfortunately need to be files on disk only.
@@ -35,5 +35,5 @@ $xero_base_config = array(
         //CURLOPT_SSLKEYPASSWD    => '1234',
         //CURLOPT_SSLKEY          => 'certs/entrust-private-RQ3.pem'
 
-    )
-);
+    ]
+];

--- a/examples/partner.php
+++ b/examples/partner.php
@@ -8,21 +8,21 @@ use XeroPHP\Remote\URL;
 session_start();
 
 //These are the minimum settings - for more options, refer to examples/config.php
-$config = array(
-    'oauth' => array(
+$config = [
+    'oauth' => [
         'callback'              => 'http://localhost/',
         'consumer_key'          => 'k',
         'consumer_secret'       => 's',
         'rsa_private_key'       => 'file://certs/privatekey.pem',
         'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
-    ),
-    'curl' => array(
+    ],
+    'curl' => [
         CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
         CURLOPT_SSLCERT         => 'certs/entrust-cert.pem',
         CURLOPT_SSLKEYPASSWD    => '1234',
         CURLOPT_SSLKEY          => 'certs/entrust-private.pem'
-    )
-);
+    ]
+];
 
 $xero = new PartnerApplication($config);
 
@@ -103,12 +103,12 @@ print_r($xero->load('Accounting\\Organisation')->execute());
 
 //The following two functions are just for a demo - you should use a more robust mechanism of storing tokens than this!
 function setOAuthSession($token, $secret, $expires = null, $session_handle = null){
-    $_SESSION['oauth'] = array(
+    $_SESSION['oauth'] = [
         'token' => $token,
         'token_secret' => $secret,
         'expires' => $expires,
         'session_handle' => $session_handle
-    );
+    ];
 }
 
 function getOAuthSession(){

--- a/examples/private.php
+++ b/examples/private.php
@@ -3,17 +3,17 @@
 use XeroPHP\Application\PrivateApplication;
 
 //These are the minimum settings - for more options, refer to examples/config.php
-$config = array(
-    'oauth' => array(
+$config = [
+    'oauth' => [
         'callback'         => 'http://localhost/',
         'consumer_key'     => 'k',
         'consumer_secret'  => 's',
         'rsa_private_key'  => 'file://certs/private.pem',
-    ),
-    'curl' => array(
+    ],
+    'curl' => [
         CURLOPT_CAINFO => __DIR__.'/certs/ca-bundle.crt',
-    ),
-);
+    ],
+];
 
 $xero = new PrivateApplication($config);
 

--- a/examples/public.php
+++ b/examples/public.php
@@ -8,16 +8,16 @@ use XeroPHP\Remote\URL;
 session_start();
 
 //These are the minimum settings - for more options, refer to examples/config.php
-$config = array(
-    'oauth' => array(
+$config = [
+    'oauth' => [
         'callback'        => 'http://localhost/',
         'consumer_key'    => 'k',
         'consumer_secret' => 's',
-    ),
-    'curl' => array(
+    ],
+    'curl' => [
         CURLOPT_CAINFO => __DIR__.'/certs/ca-bundle.crt',
-    ),
-);
+    ],
+];
 
 
 $xero = new PublicApplication($config);
@@ -82,11 +82,11 @@ function setOAuthSession($token, $secret, $expires = null){
         $expires = time() + intval($expires);
     }
 
-    $_SESSION['oauth'] = array(
+    $_SESSION['oauth'] = [
         'token' => $token,
         'token_secret' => $secret,
         'expires' => $expires
-    );
+    ];
 }
 
 function getOAuthSession(){

--- a/generator/generate
+++ b/generator/generate
@@ -23,14 +23,14 @@ require GEN_ROOT.'/objects/Property.php';
 require GEN_ROOT.'/objects/Enum.php';
 
 $documentation_base = 'http://developer.xero.com/documentation';
-$scrape_apis = array(
-    array(
+$scrape_apis = [
+    [
         'name' => 'Accounting API',
         'uri' => 'api',
         'types' => 'types',
         'namespace' => 'Accounting',
         'api_stem_constant' => 'API_CORE',
-        'model_uris' => array(
+        'model_uris' => [
             //'attachments',
             'accounts',
             //'bankstatements',
@@ -60,15 +60,15 @@ $scrape_apis = array(
             'tax-rates',
             'tracking-categories',
             'users'
-        )
-    ),
-    array(
+        ]
+    ],
+    [
         'name' => 'Payroll - AU',
         'uri' => 'payroll-api',
         'types' => 'types-and-codes',
         'namespace' => 'PayrollAU',
         'api_stem_constant' => 'API_PAYROLL',
-        'model_uris' => array(
+        'model_uris' => [
             'employees',
             'leaveapplications',
             'payitems',
@@ -79,15 +79,15 @@ $scrape_apis = array(
             'superfunds',
             'superfundproducts',
             'timesheets'
-        )
-    ),
-    array(
+        ]
+    ],
+    [
         'name' => 'Payroll - US',
         'uri' => 'payroll-api-us',
         'types' => 'types-codes',
         'namespace' => 'PayrollUS',
         'api_stem_constant' => 'API_PAYROLL',
-        'model_uris' => array(
+        'model_uris' => [
             'employees',
             'pay-items',
             'pay-runs',
@@ -96,38 +96,38 @@ $scrape_apis = array(
             'settings',
             'timesheets',
             'work-locations'
-        )
-    ),
-    array(
+        ]
+    ],
+    [
         'name' => 'Files API',
         'uri' => 'files-api',
         'types' => 'types',
         'namespace' => 'Files',
         'api_stem_constant' => 'API_FILE',
-        'model_uris' => array(
+        'model_uris' => [
             'files',
             'folders',
             'associations'
-        )
-    ),
-    array(
+        ]
+    ],
+    [
         'name' => 'Assets API',
         'uri' => 'assets-api',
         'types' => 'types',
         'namespace' => 'Assets',
         'api_stem_constant' => 'API_ASSET',
-        'model_uris' => array(
+        'model_uris' => [
             'asset',
             'asset-types',
             'settings'
-        )
-    )
+        ]
+    ]
 
-);
+];
 
 
 
-$apis = array();
+$apis = [];
 
 $client = new Goutte\Client();
 
@@ -146,7 +146,7 @@ foreach($scrape_apis as $scrape_api) {
         $current_tag = $node->getNode(0)->tagName;
 
         //don't start till there's a section
-        if(!isset($section_name) && !in_array($current_tag, array('h3', 'h4')))
+        if(!isset($section_name) && !in_array($current_tag, ['h3', 'h4']))
             return false;
 
         switch($current_tag){
@@ -199,7 +199,7 @@ foreach($scrape_apis as $scrape_api) {
                     $description =  $has_description ? $children->eq(1)->text() : null;
 
                     if($swap_name_description)
-                        list($name, $description) = array($description, $name);
+                        list($name, $description) = [$description, $name];
 
                     if($current_object instanceof Model){
                         //if there are commas in the name, it needs splitting.  eg. AddressLine 1,2,3,4
@@ -471,7 +471,7 @@ foreach($scrape_apis as $scrape_api) {
 
             // Do some processing once we are at the last node.
             if($node->getNode(0)->nodeValue === $last->getNode(0)->nodeValue && $primary_model instanceof ParsedObjectInterface) {
-                $models = array($primary_model);
+                $models = [$primary_model];
                 if($primary_model->getName() !== $current_model->getName()) {$models[] = $current_model;}
                 foreach($models as $model) {
                     /** @var Model $model */
@@ -499,7 +499,7 @@ foreach($scrape_apis as $scrape_api) {
 }
 
 $loader = new Twig_Loader_Filesystem('generator/templates/');
-$twig = new Twig_Environment($loader, array());
+$twig = new Twig_Environment($loader, []);
 $twig->addFilter(new Twig_SimpleFilter('wordwrap', 'wordwrap'));
 $twig->addFilter(new Twig_SimpleFilter('addslashes', 'addslashes'));
 
@@ -525,25 +525,25 @@ foreach($apis as $api){
             }
         }
 
-        $dir = sprintf('%s/%s', GEN_OUTPUT, strtr($model->getNamespace(), array('\\' => '/')));
+        $dir = sprintf('%s/%s', GEN_OUTPUT, strtr($model->getNamespace(), ['\\' => '/']));
         if(!is_dir($dir))
             mkdir($dir);
 
-        $template = $twig->render('model.twig', array(
+        $template = $twig->render('model.twig', [
             'model' => $model,
-        ));
+        ]);
         $filename = sprintf('%s/%s.php', $dir, $model->getClassName());
         file_put_contents($filename, $template);
     }
 
     foreach($api->getStrayEnums() as $class_name => $enums){
-        $dir = sprintf('%s/%s', GEN_OUTPUT, strtr($api->getNamespace(), array('\\' => '/')));
+        $dir = sprintf('%s/%s', GEN_OUTPUT, strtr($api->getNamespace(), ['\\' => '/']));
 
-        $template = $twig->render('enum.twig', array(
+        $template = $twig->render('enum.twig', [
             'class_name' => $class_name,
             'enums' => $enums,
             'api' => $api
-        ));
+        ]);
         $filename = sprintf('%s/%s.php', $dir, $class_name);
         file_put_contents($filename, $template);
 

--- a/generator/objects/API.php
+++ b/generator/objects/API.php
@@ -32,12 +32,12 @@ class API {
         $this->namespace = $namespace;
         $this->stem_constant  = $stem;
 
-        $this->models = array();
-        $this->enums = array();
+        $this->models = [];
+        $this->enums = [];
 
-        $this->model_aliases = array();
+        $this->model_aliases = [];
 
-        $this->search_keys = array();
+        $this->search_keys = [];
         $this->is_indexed = false;
 
     }
@@ -49,7 +49,7 @@ class API {
      * @return array
      */
     public function getEnumsByGroup($group){
-        $enums = array();
+        $enums = [];
         foreach($this->getEnums() as $enum){
             if($enum->getGroup() == $group)
                 $enums[] = $enum;
@@ -64,13 +64,13 @@ class API {
      * @return array
      */
     public function getStrayEnums(){
-        $names = array();
+        $names = [];
         foreach($this->getModels() as $model){
             //just so we're comparing apples with apples
             $names[] = Helpers::singularize($model->getName());
         }
 
-        $strays = array();
+        $strays = [];
         foreach($this->getEnums() as $enum){
             //just so we're comparing apples with apples
             $singular_group = Helpers::singularize($enum->getGroup());
@@ -135,10 +135,10 @@ class API {
      * @param $class_name
      */
     public function addModelAlias(Model $model, $class_name){
-        $this->model_aliases[] = array(
+        $this->model_aliases[] = [
             'name' => $class_name,
             'model' => $model
-        );
+        ];
     }
 
     /**
@@ -257,7 +257,7 @@ class API {
         if(!$this->isIndexed())
             $this->buildSearchIndex();
 
-        $keys = array();
+        $keys = [];
         foreach($this->search_keys as $key => $model){
             $keys[$key] = sprintf('%s\\%s', get_class($model), $model->getName());
         }

--- a/generator/objects/Enum.php
+++ b/generator/objects/Enum.php
@@ -36,10 +36,10 @@ class Enum implements ParsedObjectInterface {
      * @param $description
      */
     public function addValue($name, $description){
-        $this->values[$name] = array(
+        $this->values[$name] = [
             'name' => $name,
             'description' => $description
-        );
+        ];
 
         $name_length = strlen($name);
         if($name_length > $this->longest_name)
@@ -50,7 +50,6 @@ class Enum implements ParsedObjectInterface {
      * Remove an the Enum set.  This requires at least a name
      *
      * @param $name
-     * @param $description
      */
     public function removeValue($name){
         unset($this->values[$name]);
@@ -63,13 +62,13 @@ class Enum implements ParsedObjectInterface {
      */
     public function getValues(){
 
-        $values = array();
+        $values = [];
         foreach($this->values as $value){
-            $values[] = array(
+            $values[] = [
                 'constant_name' => $this->getConstantName($value['name']),
                 'value' => $value['name'],
                 'description' > $value['description']
-            );
+            ];
         }
         return $values;
     }
@@ -103,7 +102,7 @@ class Enum implements ParsedObjectInterface {
     }
 
     /**
-     * @param The raw name
+     * @param string $name The raw name
      */
     public function setRawName($name) {
         $this->raw_name = $name;

--- a/generator/objects/Model.php
+++ b/generator/objects/Model.php
@@ -21,6 +21,11 @@ class Model implements ParsedObjectInterface {
     private $parent_model;
 
     /**
+     * @var Model[] $sub_models
+     */
+    private $sub_models = [];
+
+    /**
      * @var Property of the object that holds the GUID
      */
     private $guid_property;
@@ -29,6 +34,11 @@ class Model implements ParsedObjectInterface {
      * @var bool $supports_pdf
      */
     private $supports_pdf;
+
+    /**
+     * @var bool $supports_page
+     */
+    private $supports_page;
 
     /**
      * @var bool $supports_page
@@ -43,9 +53,9 @@ class Model implements ParsedObjectInterface {
      */
     public function __construct(){
 
-        $this->properties = array();
-        $this->methods = array();
-        $this->sub_models = array();
+        $this->properties = [];
+        $this->methods = [];
+        $this->sub_models = [];
         $this->supports_pdf = false;
         $this->supports_page = false;
     }
@@ -126,7 +136,7 @@ class Model implements ParsedObjectInterface {
      */
     public function getUsedClasses(){
 
-        $classes = array();
+        $classes = [];
         foreach($this->getProperties() as $property){
             if($property->getType() === Object::PROPERTY_TYPE_OBJECT) {
                 if($property->getRelatedObject()->getNamespace() !== $this->getNamespace()){
@@ -144,8 +154,8 @@ class Model implements ParsedObjectInterface {
      * It's not crucial that the order stays the same either.
      *
      * @param Property $property
-	 * @param null $insert_position
-	 * @param boolean $get_only
+     * @param null $insert_position
+     * @param boolean $get_only
      */
     public function addProperty(Property $property, $insert_position = null, $get_only = false) {
         $key_name = strtolower($property->getName());
@@ -158,7 +168,7 @@ class Model implements ParsedObjectInterface {
 
         //This is so it can be retrospectively added in the case of deprecation.
         if($insert_position !== null){
-            $properties = array();
+            $properties = [];
             $property_position = 0;
             foreach($this->properties as $existing_name => $existing_property){
                 if($property_position++ === $insert_position){
@@ -354,11 +364,11 @@ class Model implements ParsedObjectInterface {
      *
      */
     public function printPropertyTable(){
-        $rows = array();
-        $column_sizes = array();
+        $rows = [];
+        $column_sizes = [];
 
         foreach($this->getProperties() as $key => $property){
-            $rows[$key] = array($property->getName(), $string = substr(preg_replace('/[^\w\s.\-\(\)]|\n/', '', $property->getDescription()), 0, 100));
+            $rows[$key] = [$property->getName(), $string = substr(preg_replace('/[^\w\s.\-\(\)]|\n/', '', $property->getDescription()), 0, 100)];
 
             foreach($rows[$key] as $column_index => $column){
                 $column_sizes[$column_index] = max(isset($column_sizes[$column_index]) ? $column_sizes[$column_index] : 0, iconv_strlen($column));

--- a/generator/objects/Property.php
+++ b/generator/objects/Property.php
@@ -35,7 +35,7 @@ class Property {
         $this->is_read_only = $read_only;
         $this->name = $name;
         $this->description = $description;
-        $this->links = array();
+        $this->links = [];
         $this->related_object = null;
         $this->save_directly = false;
 
@@ -108,10 +108,10 @@ class Property {
      * @param $href
      */
     public function addLink($text, $href){
-        $this->links[] = array(
+        $this->links[] = [
             'text' => $text,
             'href' => $href
-        );
+        ];
     }
 
     /**
@@ -157,6 +157,7 @@ class Property {
     }
 
     /**
+     * @param bool $with_ns
      * @return string
      */
     public function getPHPType($with_ns = false) {

--- a/generator/templates/model.twig
+++ b/generator/templates/model.twig
@@ -90,12 +90,12 @@ class {{ model.ClassName }} extends Remote\Object
      */
     public static function getSupportedMethods()
     {
-        return array(
+        return [
 {% for method in model.Methods %}
             Remote\Request::METHOD_{{ method }}{% if not loop.last %},{% endif %}
 
 {% endfor %}
-        );
+        ];
     }
 
     /**
@@ -111,12 +111,12 @@ class {{ model.ClassName }} extends Remote\Object
      */
     public static function getProperties()
     {
-        return array(
+        return [
 {% for property in model.Properties %}
-            '{{ property.name }}' => array ({% if property.isMandatory %}true{% else %}false{% endif %}, self::{{ property.getTypeConstant }}, {% if property.isHintable %}'{{ property.getPHPType(true)|addslashes }}'{% else %}null{% endif %}, {% if property.isArray %}true{% else %}false{% endif %}, {% if property.save_directly %}true{% else %}false{% endif %}){% if not loop.last %},{% endif %}
+            '{{ property.name }}' => [{% if property.isMandatory %}true{% else %}false{% endif %}, self::{{ property.getTypeConstant }}, {% if property.isHintable %}'{{ property.getPHPType(true)|addslashes }}'{% else %}null{% endif %}, {% if property.isArray %}true{% else %}false{% endif %}, {% if property.save_directly %}true{% else %}false{% endif %}]{% if not loop.last %},{% endif %}
 
 {% endfor %}
-        );
+        ];
     }
 
     public static function isPageable()

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -12,24 +12,24 @@ use XeroPHP\Remote\URL;
 
 abstract class Application {
 
-    protected static $_config_defaults = array(
-        'xero'  => array(
+    protected static $_config_defaults = [
+        'xero'  => [
             'site'            => 'https://api.xero.com',
             'base_url'        => 'https://api.xero.com',
             'core_version'    => '2.0',
             'payroll_version' => '1.0',
             'file_version'    => '1.0',
             'model_namespace' => '\\XeroPHP\\Models'
-        ),
+        ],
         //OAuth config
-        'oauth' => array(
+        'oauth' => [
             'signature_method'   => Client::SIGNATURE_RSA_SHA1,
             'signature_location' => Client::SIGN_LOCATION_HEADER,
             'authorize_url'      => 'https://api.xero.com/oauth/Authorize',
             'request_token_path' => 'oauth/RequestToken',
             'access_token_path'  => 'oauth/AccessToken'
-        ),
-        'curl'  => array(
+        ],
+        'curl'  => [
             CURLOPT_USERAGENT      => 'XeroPHP',
             CURLOPT_CONNECTTIMEOUT => 30,
             CURLOPT_TIMEOUT        => 20,
@@ -39,8 +39,8 @@ abstract class Application {
             CURLOPT_PROXY          => false,
             CURLOPT_PROXYUSERPWD   => false,
             CURLOPT_ENCODING       => '',
-        )
-    );
+        ]
+    ];
 
     /**
      * @var array
@@ -194,7 +194,7 @@ abstract class Application {
         }
 
         //Put in an array with the first level containing only the 'root node'.
-        $data = array($object::getRootNodeName() => $object->toStringArray());
+        $data = [$object::getRootNodeName() => $object->toStringArray()];
         $url = new URL($this, $uri);
         $request = new Request($this, $url, $method);
 
@@ -222,7 +222,7 @@ abstract class Application {
         $current_object = current($objects);
         $type = get_class($current_object);
         $has_guid =  $current_object->hasGUID();
-        $object_arrays = array();
+        $object_arrays = [];
 
         foreach($objects as $object) {
             if($type !== get_class($object)) {
@@ -244,7 +244,7 @@ abstract class Application {
 
         //This might need to be parsed and stored some day.
         $root_node_name = Helpers::pluralize($type::getRootNodeName());
-        $data = array($root_node_name => $object_arrays);
+        $data = [$root_node_name => $object_arrays];
 
         $request->setBody(Helpers::arrayToXML($data));
         $request->setParameter('SummarizeErrors', 'false');
@@ -281,13 +281,13 @@ abstract class Application {
                 $url = new URL($this, sprintf('%s/%s/%s', $object::getResourceURI(), $object->getGUID(), $property_type::getResourceURI()));
                 $request = new Request($this, $url, Request::METHOD_PUT);
 
-                $property_array = array();
+                $property_array = [];
                 foreach($property_objects as $property_object){
                     $property_array[] = $property_object->toStringArray();
                 }
 
                 $root_node_name = Helpers::pluralize($property_type::getRootNodeName());
-                $request->setBody(Helpers::arrayToXML(array($root_node_name => $property_array)));
+                $request->setBody(Helpers::arrayToXML([$root_node_name => $property_array]));
 
                 $request->send();
 

--- a/src/XeroPHP/Application/PartnerApplication.php
+++ b/src/XeroPHP/Application/PartnerApplication.php
@@ -6,10 +6,10 @@ use XeroPHP\Application;
 
 class PartnerApplication extends Application {
 
-    protected static $_type_config_defaults = array(
-        'xero' => array(
+    protected static $_type_config_defaults = [
+        'xero' => [
             'site'     => 'https://api-partner.network.xero.com',
             'base_url' => 'https://api-partner.network.xero.com',
-        )
-    );
+        ]
+    ];
 }

--- a/src/XeroPHP/Application/PrivateApplication.php
+++ b/src/XeroPHP/Application/PrivateApplication.php
@@ -6,7 +6,7 @@ use XeroPHP\Application;
 
 class PrivateApplication extends Application {
 
-    protected static $_type_config_defaults = array();
+    protected static $_type_config_defaults = [];
 
     public function __construct($config) {
         //As we don't need to Authorize/RequestToken, it's populated here.

--- a/src/XeroPHP/Application/PublicApplication.php
+++ b/src/XeroPHP/Application/PublicApplication.php
@@ -7,9 +7,9 @@ use XeroPHP\Remote\OAuth\Client;
 
 class PublicApplication extends Application {
 
-    protected static $_type_config_defaults = array(
-        'oauth' => array(
+    protected static $_type_config_defaults = [
+        'oauth' => [
             'signature_method' => Client::SIGNATURE_HMAC_SHA1,
-        ),
-    );
+        ],
+    ];
 }

--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -42,13 +42,13 @@ class Helpers {
                 //Full DOMDocument not really necessary as we don't use attributes (which are more strict)
                 $element = strtr(
                     $element,
-                    array(
+                    [
                         '<' => '&lt;',
                         '>' => '&gt;',
                         '"' => '&quot;',
                         "'" => '&apos;',
                         '&' => '&amp;',
-                    )
+                    ]
                 );
             }
 
@@ -63,7 +63,7 @@ class Helpers {
 
     public static function XMLToArray(\SimpleXMLElement $sxml) {
 
-        $output = array();
+        $output = [];
         $singular_node_name = self::singularize($sxml->getName());
 
         foreach($sxml->children() as $child_name => $child) {
@@ -93,7 +93,7 @@ class Helpers {
      * @return mixed
      */
     public static function singularize($string) {
-        $singular = array(
+        $singular = [
             '/(vert|ind)ices$/i'    => "$1ex",
             '/(alias)es$/i'         => "$1",
             '/(x|ch|ss|sh)es$/i'    => "$1",
@@ -105,7 +105,7 @@ class Helpers {
             '/(us)es$/i'            => "$1",
             '/(basis)$/i'           => "$1",
             '/([^s])s$/i'           => "$1"
-        );
+        ];
 
         // check for matches using regular expressions
         foreach($singular as $pattern => $result) {
@@ -119,7 +119,7 @@ class Helpers {
 
     public static function pluralize($string) {
 
-        $plural = array(
+        $plural = [
             '/(quiz)$/i'                     => "$1zes",
             '/(matr|vert|ind)ix|ex$/i'       => "$1ices",
             '/(x|ch|ss|sh)$/i'               => "$1es",
@@ -136,7 +136,7 @@ class Helpers {
             '/(us)$/i'                       => "$1es",
             '/s$/i'                          => "s",
             '/$/'                            => "s"
-        );
+        ];
 
         // check for matches using regular expressions
         foreach($plural as $pattern => $result) {
@@ -163,7 +163,7 @@ class Helpers {
      */
     public static function flattenAssocArray(array $array, $format, $glue = null, $escape = false) {
 
-        $pairs = array();
+        $pairs = [];
         foreach($array as $key => $val) {
             if($escape) {
                 $key = self::escape($key);

--- a/src/XeroPHP/Models/Accounting/Report/Report.php
+++ b/src/XeroPHP/Models/Accounting/Report/Report.php
@@ -125,7 +125,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setReportID($value)
     {
@@ -144,7 +144,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setReportName($value)
     {
@@ -163,7 +163,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setReportType($value)
     {
@@ -182,7 +182,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setReportTitles($value)
     {
@@ -201,7 +201,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setReportDate($value)
     {
@@ -220,7 +220,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setUpdatedDateUTC($value)
     {
@@ -239,7 +239,7 @@ abstract class Report extends Remote\Object
 
     /**
      * @param string $value
-     * @return BalanceSheet
+     * @return Report
      */
     public function setRows($value)
     {

--- a/src/XeroPHP/Remote/Collection.php
+++ b/src/XeroPHP/Remote/Collection.php
@@ -35,7 +35,7 @@ class Collection extends \ArrayObject {
     /**
      * Remove a specific object from the collection
      *
-     * @param \XeroPHP\Remote\Object $object
+     * @param Object $object
      */
     public function remove(Object $object){
         foreach($this as $index => $item){

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -104,14 +104,14 @@ class Client {
     private function getOAuthParams() {
         //this needs to be stateful until the request is signed, then it gets unset
         if(!isset($this->oauth_params)) {
-            $this->oauth_params = array(
+            $this->oauth_params = [
                 'oauth_consumer_key'     => $this->getConsumerKey(),
                 'oauth_signature_method' => $this->getSignatureMethod(),
                 'oauth_timestamp'        => $this->getTimestamp(),
                 'oauth_nonce'            => $this->getNonce(),
                 'oauth_callback'         => $this->getCallback(),
                 'oauth_version'          => self::OAUTH_VERSION
-            );
+            ];
 
             if(null !== $token = $this->getToken())
                 $this->oauth_params['oauth_token'] = $token;

--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -153,7 +153,6 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
      *
      * @param $input_array
      * @param $replace_data
-     * @return Object
      */
     public function fromStringArray($input_array, $replace_data = false) {
 
@@ -372,7 +371,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
 
     /**
      * @param string $property
-     * @param self $object
+     * @param Object $object
      */
     public function addAssociatedObject($property, Object $object) {
         $this->_associated_objects[$property] = $object;

--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -67,9 +67,9 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
 
     public function __construct(Application $application = null) {
         $this->_application = $application;
-        $this->_dirty = array();
-        $this->_data = array();
-        $this->_associated_objects = array();
+        $this->_dirty = [];
+        $this->_data = [];
+        $this->_associated_objects = [];
     }
 
     /**
@@ -114,7 +114,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
      */
     public function setClean($property = null) {
         if($property === null)
-            $this->_dirty = array();
+            $this->_dirty = [];
         else
             unset($this->_dirty[$property]);
 
@@ -201,7 +201,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
      * @return array
      */
     public function toStringArray() {
-        $out = array();
+        $out = [];
         foreach(static::getProperties() as $property => $meta) {
 
             if(!isset($this->_data[$property]))
@@ -210,7 +210,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
             $type = $meta[self::KEY_TYPE];
 
             if($this->_data[$property] instanceof Collection) {
-                $out[$property] = array();
+                $out[$property] = [];
                 foreach($this->_data[$property] as $assoc_property) {
                     $out[$property][] = self::castToString($type, $assoc_property);
                 }
@@ -280,7 +280,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
                 return floatval($value);
 
             case self::PROPERTY_TYPE_BOOLEAN:
-                return in_array(strtolower($value), array('true', '1', 'yes'));
+                return in_array(strtolower($value), ['true', '1', 'yes']);
 
             case self::PROPERTY_TYPE_TIMESTAMP:
                 $timezone = new \DateTimeZone('UTC');
@@ -426,7 +426,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
     protected function propertyUpdated($property, $value) {
         if(!isset($this->_data[$property]) || $this->_data[$property] !== $value){
             //If this object can update itself, set its own dirty flag, otherwise, set its parent's.
-            if(count(array_intersect($this::getSupportedMethods(), array(Request::METHOD_PUT, Request::METHOD_POST))) > 0){
+            if(count(array_intersect($this::getSupportedMethods(), [Request::METHOD_PUT, Request::METHOD_POST])) > 0){
                 //Object can update itself
                 $this->setDirty($property);
             } else {

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -25,7 +25,7 @@ class Query {
 
     public function __construct(Application $app) {
         $this->app = $app;
-        $this->where = array();
+        $this->where = [];
         $this->order = null;
         $this->modifiedAfter = null;
         $this->page = null;

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -72,10 +72,12 @@ class Query {
     public function andWhere() {
         return $this->addWhere('AND', func_get_args());
     }
-    
+
     /**
+     * @param string $operator
+     * @param array $args
      * @return $this
-     **/
+     */
     public function addWhere($operator, $args)
     {
         // Add operator unless this is the first where statement
@@ -106,7 +108,7 @@ class Query {
      * Concatenates the array of where statements stored in $this->where and returns
      * them as a string
      *
-     * @return $string
+     * @return string
      **/
     public function getWhere()
     {

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -41,8 +41,8 @@ class Request {
 
         $this->app = $app;
         $this->url = $url;
-        $this->headers = array();
-        $this->parameters = array();
+        $this->headers = [];
+        $this->parameters = [];
 
         switch($method) {
             case self::METHOD_GET:

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -166,10 +166,10 @@ class Response {
             return;
         }
 
-        $this->elements = array();
-        $this->element_errors = array();
-        $this->element_warnings = array();
-        $this->root_error = array();
+        $this->elements = [];
+        $this->element_errors = [];
+        $this->element_warnings = [];
+        $this->root_error = [];
 
         switch($this->content_type) {
             case Request::CONTENT_TYPE_XML:

--- a/src/XeroPHP/Traits/AttachmentTrait.php
+++ b/src/XeroPHP/Traits/AttachmentTrait.php
@@ -45,7 +45,7 @@ trait AttachmentTrait {
         $request = new Request($this->_application, $url, Request::METHOD_GET);
         $request->send();
 
-        $attachments = array();
+        $attachments = [];
         foreach($request->getResponse()->getElements() as $element) {
             $attachment = new Attachment($this->_application);
             $attachment->fromStringArray($element);

--- a/src/XeroPHP/Traits/AttachmentTrait.php
+++ b/src/XeroPHP/Traits/AttachmentTrait.php
@@ -5,6 +5,7 @@ namespace XeroPHP\Traits;
 use XeroPHP\Models\Accounting\Attachment;
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
+use XeroPHP\Exception;
 
 trait AttachmentTrait {
 
@@ -35,7 +36,7 @@ trait AttachmentTrait {
         /** @var Object $this */
 
         if($this->hasGUID() === false){
-            throw new \XeroPHP\Exception('Attachments are only available to objects that exist remotely.');
+            throw new Exception('Attachments are only available to objects that exist remotely.');
         }
 
         $uri = sprintf('%s/%s/Attachments', $this::getResourceURI(), $this->getGUID());

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -4,6 +4,7 @@ namespace XeroPHP\Traits;
 
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
+use XeroPHP\Exception;
 
 trait PDFTrait {
 
@@ -12,7 +13,7 @@ trait PDFTrait {
         /** @var Object $this */
 
         if($this->hasGUID() === false){
-            throw new \XeroPHP\Exception('PDF files are only available to objects that exist remotely.');
+            throw new Exception('PDF files are only available to objects that exist remotely.');
         }
 
         $uri = sprintf('%s/%s', $this::getResourceURI(), $this->getGUID());

--- a/tests/Application/PartnerApplicationTest.php
+++ b/tests/Application/PartnerApplicationTest.php
@@ -8,21 +8,21 @@ class PartnerApplicationTest extends \PHPUnit_Framework_TestCase
 {
     public function testNewInstance()
     {
-        $config = array(
-            'oauth' => array(
+        $config = [
+            'oauth' => [
                 'callback'              => 'http://localhost/',
                 'consumer_key'          => 'k',
                 'consumer_secret'       => 's',
                 'rsa_private_key'       => 'file://certs/privatekey.pem',
                 //'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
-            ),
-            'curl' => array(
+            ],
+            'curl' => [
                 CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
                 CURLOPT_SSLCERT         => 'certs/entrust-cert.pem',
                 CURLOPT_SSLKEYPASSWD    => '1234',
                 CURLOPT_SSLKEY          => 'certs/entrust-private.pem'
-            )
-        );
+            ]
+        ];
 
         new PartnerApplication($config);
     }

--- a/tests/Application/PrivateApplicationTest.php
+++ b/tests/Application/PrivateApplicationTest.php
@@ -8,15 +8,15 @@ class PrivateApplicationTest extends \PHPUnit_Framework_TestCase
 {
     public function testNewInstance()
     {
-        $config = array(
-            'oauth' => array(
+        $config = [
+            'oauth' => [
                 'callback'         => 'http://localhost/',
                 'consumer_key'     => 'k',
                 'consumer_secret'  => 's',
                 'rsa_private_key'  => 'file://certs/private.pem',
                 'rsa_public_key'   => 'file://certs/public.pem'
-            )
-        );
+            ]
+        ];
 
         new PrivateApplication($config);
     }

--- a/tests/Application/PublicApplicationTest.php
+++ b/tests/Application/PublicApplicationTest.php
@@ -8,16 +8,16 @@ class PublicApplicationTest extends \PHPUnit_Framework_TestCase
 {
     public function testNewInstance()
     {
-        $config = array(
-            'oauth' => array(
+        $config = [
+            'oauth' => [
                 'callback'    => 'http://localhost/',
                 'consumer_key'      => 'k',
                 'consumer_secret'   => 's',
-            ),
-            'curl' => array(
+            ],
+            'curl' => [
                 CURLOPT_CAINFO => __DIR__.'/certs/ca-bundle.crt',
-            ),
-        );
+            ],
+        ];
 
         new PublicApplication($config);
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -14,15 +14,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $config = array(
-            'oauth' => array(
+        $config = [
+            'oauth' => [
                 'callback'    => 'oob',
                 'consumer_key'      => 'k',
                 'consumer_secret'   => 's',
                 'rsa_private_key'  => 'file://certs/private.pem',
                 'rsa_public_key'   => 'file://certs/public.pem'
-            )
-        );
+            ]
+        ];
 
         $this->application = new PrivateApplication($config);
     }


### PR DESCRIPTION
I've done some small non-functional changes in this PR. Mainly conversion to short array syntax and correction of some phpdocs. Some of this will help with #46. I did not do any conversions to the models, but I amended the generator template to use short array syntax so that they will be done next time that's run.

In `save()` I made it return early if the Object is not dirty, helps reduce unneeded indenting.

There were a couple of undeclared properties in the generator (`sub_models` and `supports_page`) which I added declarations for.

These changes help spot errors in IDEs like PHPStorm.