### PR TITLE
Add config files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto
+
+/docs export-ignore
+/tests export-ignore
+/examples export-ignore
+/generator export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/.travis.yml export-ignore
+/changelog.md export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,11 @@
+<?php
+
+return Symfony\CS\Config::create()
+    ->finder(
+        Symfony\CS\Finder::create()
+            ->in(__DIR__)
+            ->exclude('src/XeroPHP/Models')
+    )
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->setUsingCache(true)
+;

--- a/.php_cs
+++ b/.php_cs
@@ -1,4 +1,8 @@
 <?php
+//php-cs-fixer config file.
+//See: https://github.com/FriendsOfPHP/PHP-CS-Fixer
+//Run like this from the project root:
+//php-cs-fixer fix --config-file=.php_cs
 
 return Symfony\CS\Config::create()
     ->finder(


### PR DESCRIPTION
This PR includes a `.php_cs` config file for php-cs-fixer making it easier to run the fixer on the project source. It's configured to exclude the models folder as fixes for that should be done in the generator.

I also added a `.gitattributes` file which is used to suppress the inclusion of non-essential files when the library is pulled in from composer or downloaded as a zip file - for example it skips the examples, generator, and test folders which are not needed at runtime. This is considered a good practice by [the League](http://thephpleague.com).