### PR TITLE
Mark that BankTransaction is pageable

### DIFF
--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -247,7 +247,7 @@ class BankTransaction extends Remote\Object
 
     public static function isPageable()
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Currently the generator is incorrectly marking that BankTransaction is not pageable.

After a fair bit of digging, it seems this is because the Xero API docs have invalid HTML in the table at  https://developer.xero.com/documentation/api/banktransactions/#title15 - there's a missing `<tr>` tag in the table so the `page` property is never found by the crawler.

I've flagged this to Xero support - not sure what your policy is on merging temporary fixes to the models themselves ahead of the docs being fixed? I couldn't see any logical way to fix/override the generator to fix this.