### PR TITLE
Return Response object from save and delete shorthand methods

### DIFF
--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -372,6 +372,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
     /**
      * Shorthand save an object if it is instantiated with app context.
      *
+     * @return Response|null
      * @throws Exception
      */
     public function save()
@@ -381,12 +382,14 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
                 '->save() is only available on objects that have an injected application context.'
             );
         }
-        $this->_application->save($this);
+
+        return $this->_application->save($this);
     }
 
     /**
      * Shorthand delete an object if it is instantiated with app context.
      *
+     * @return Response|null
      * @throws Exception
      */
     public function delete()
@@ -396,7 +399,8 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
                 '->delete() is only available on objects that have an injected application context.'
             );
         }
-        $this->_application->delete($this);
+
+        return $this->_application->delete($this);
     }
 
     /**


### PR DESCRIPTION
Currently:

```php
// 😆 (grinning face with tightly closed eyes)
$invoice = new Invoice();
/** @var Response $response */
$response = $xero->save($invoice);

// 😫 (distraught face)
$invoice = new Invoice($xero);
/** @var null $response */
$response = $invoice->save();
```

A merge of this pull request will turn 😫 into 😆.

NB: A fellow coder who uses Linux reported he couldn't see the emojis in the comments in the above code – I added text comments.

I think @netmit had similar emotions when opening https://github.com/calcinai/xero-php/issues/140.