### PR TITLE
Removed entrust ssl certificates

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -17,10 +17,7 @@ $config = [
         'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
     ],
     'curl' => [
-        CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
-        CURLOPT_SSLCERT         => 'certs/entrust-cert.pem',
-        CURLOPT_SSLKEYPASSWD    => '1234',
-        CURLOPT_SSLKEY          => 'certs/entrust-private.pem'
+        CURLOPT_CAINFO          => 'certs/ca-bundle.crt'
     ]
 ];
 

--- a/src/XeroPHP/Application/PartnerApplication.php
+++ b/src/XeroPHP/Application/PartnerApplication.php
@@ -6,10 +6,5 @@ use XeroPHP\Application;
 
 class PartnerApplication extends Application
 {
-    protected static $_type_config_defaults = [
-        'xero' => [
-            'site'     => 'https://api.xero.com',
-            'base_url' => 'https://api.xero.com',
-        ]
-    ];
+    protected static $_type_config_defaults = [];
 }

--- a/src/XeroPHP/Application/PartnerApplication.php
+++ b/src/XeroPHP/Application/PartnerApplication.php
@@ -8,8 +8,8 @@ class PartnerApplication extends Application
 {
     protected static $_type_config_defaults = [
         'xero' => [
-            'site'     => 'https://api-partner.network.xero.com',
-            'base_url' => 'https://api-partner.network.xero.com',
+            'site'     => 'https://api.xero.com',
+            'base_url' => 'https://api.xero.com',
         ]
     ];
 }

--- a/tests/Application/PartnerApplicationTest.php
+++ b/tests/Application/PartnerApplicationTest.php
@@ -17,10 +17,7 @@ class PartnerApplicationTest extends \PHPUnit_Framework_TestCase
                 //'signature_location'  => \XeroPHP\Remote\OAuth\Client::SIGN_LOCATION_QUERY
             ],
             'curl' => [
-                CURLOPT_CAINFO          => 'certs/ca-bundle.crt',
-                CURLOPT_SSLCERT         => 'certs/entrust-cert.pem',
-                CURLOPT_SSLKEYPASSWD    => '1234',
-                CURLOPT_SSLKEY          => 'certs/entrust-private.pem'
+                CURLOPT_CAINFO          => 'certs/ca-bundle.crt'
             ]
         ];
 


### PR DESCRIPTION
In 2017, Xero is deprecating the entrust ssl certificate requirement
for partner apps.  You can find more information at Xero's Dev Center - http://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation/