### PR TITLE
Save multiple Units on timesheets, use correct api

### DIFF
--- a/generator/objects/Property.php
+++ b/generator/objects/Property.php
@@ -234,7 +234,7 @@ class Property
             $type = Object::PROPERTY_TYPE_BOOLEAN;
         }
 
-        if (preg_match('/(^sum\b|decimal|the\stotal|total\s(of|tax)|rate\b|amount\b)/i', $this->description)) {
+        if (preg_match('/(^sum\b|decimal|the\stotal|total\s(of|tax)|rate\b|amount\b|timesheet\sline)/i', $this->description)) {
             //If not the name of the field itself and not an 'amount type'
             if (stripos($this->name, 'name') === false &&
                 stripos($this->name, 'description') === false &&

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -211,7 +211,7 @@ abstract class Application
 
         //Put in an array with the first level containing only the 'root node'.
         $data = [$object::getRootNodeName() => $object->toStringArray()];
-        $url = new URL($this, $uri);
+        $url = new URL($this, $uri, $object::getAPIStem());
         $request = new Request($this, $url, $method);
 
         $request->setBody(Helpers::arrayToXML($data))->send();

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -22,7 +22,7 @@ class TimesheetLine extends Remote\Object
     /**
      * Number of units of a Timesheet line
      *
-     * @property string NumberOfUnits
+     * @property float[] NumberOfUnits
      */
 
 
@@ -96,7 +96,7 @@ class TimesheetLine extends Remote\Object
         return [
             'EarningsRateID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'TrackingItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'NumberOfUnits' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
+            'NumberOfUnits' => [false, self::PROPERTY_TYPE_FLOAT, null, true, false]
         ];
     }
 
@@ -144,7 +144,8 @@ class TimesheetLine extends Remote\Object
     }
 
     /**
-     * @return string
+     * @return float[]|Remote\Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {
@@ -152,13 +153,16 @@ class TimesheetLine extends Remote\Object
     }
 
     /**
-     * @param string $value
+     * @param float $value
      * @return TimesheetLine
      */
-    public function setNumberOfUnit($value)
+    public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        $this->_data['NumberOfUnits'] = $value;
+        if (!isset($this->_data['NumberOfUnits'])) {
+            $this->_data['NumberOfUnits'] = new Remote\Collection();
+        }
+        $this->_data['NumberOfUnits'][] = $value;
         return $this;
     }
 

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -103,7 +103,7 @@ class TimesheetLine extends Remote\Object
         return [
             'EarningsTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'TrackingItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'NumberOfUnits' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'NumberOfUnits' => [false, self::PROPERTY_TYPE_STRING, null, true, false],
             'WorkLocationID' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
@@ -166,7 +166,10 @@ class TimesheetLine extends Remote\Object
     public function setNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        $this->_data['NumberOfUnits'] = $value;
+        if (!isset($this->_data['NumberOfUnits'])) {
+            $this->_data['NumberOfUnits'] = new Remote\Collection();
+        }
+        $this->_data['NumberOfUnits'][] = $value;
         return $this;
     }
 

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -22,7 +22,7 @@ class TimesheetLine extends Remote\Object
     /**
      * Number of units of a Timesheet line
      *
-     * @property string NumberOfUnits
+     * @property float[] NumberOfUnits
      */
 
     /**
@@ -103,7 +103,7 @@ class TimesheetLine extends Remote\Object
         return [
             'EarningsTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'TrackingItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'NumberOfUnits' => [false, self::PROPERTY_TYPE_STRING, null, true, false],
+            'NumberOfUnits' => [false, self::PROPERTY_TYPE_FLOAT, null, true, false],
             'WorkLocationID' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
@@ -152,7 +152,8 @@ class TimesheetLine extends Remote\Object
     }
 
     /**
-     * @return string
+     * @return float[]|Remote\Collection
+     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {
@@ -160,10 +161,10 @@ class TimesheetLine extends Remote\Object
     }
 
     /**
-     * @param string $value
+     * @param float $value
      * @return TimesheetLine
      */
-    public function setNumberOfUnit($value)
+    public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
         if (!isset($this->_data['NumberOfUnits'])) {


### PR DESCRIPTION
NumberOfUnits is now a collection can be used like the following:
```
$timesheet = new Timesheet($xero);
$timesheet->setEmployeeID("someguid");
$timesheet->setStartDate(new \DateTime('2016-12-16'));
$timesheet->setEndDate(new \DateTime('2016-12-31'));
$timesheetLine = new Timesheet\TimesheetLine($xero);
$timesheetLine->setEarningsTypeID('someguid');
$timesheetLine->setNumberOfUnit(10);
$timesheetLine->setNumberOfUnit(9);
$timesheetLine->setNumberOfUnit(8);
$timesheetLine->setNumberOfUnit(7);
$timesheetLine->setNumberOfUnit(6);
$timesheetLine->setNumberOfUnit(5);
$timesheetLine->setNumberOfUnit(4);
$timesheetLine->setNumberOfUnit(3);
$timesheetLine->setNumberOfUnit(2);
$timesheetLine->setNumberOfUnit(1);
$timesheetLine->setNumberOfUnit(6);
$timesheetLine->setNumberOfUnit(5);
$timesheetLine->setNumberOfUnit(4);
$timesheetLine->setNumberOfUnit(3);
$timesheetLine->setNumberOfUnit(2);
$timesheetLine->setNumberOfUnit(1);
$timesheet->addTimesheetLine($timesheetLine);
$timesheet->save();
```
Allows you to call save() on an object and have the correct endpoint be used.