### PR TITLE
Make inventory asset account code not compulsory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "calcinai/xero-php",
+    "name": "futura-group/xero-php",
     "type": "library",
     "description": "A client implementation of the Xero API, with a cleaner OAuth interface and ORM-like abstraction.",
     "homepage": "https://github.com/calcinai/xero-php",

--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -173,7 +173,7 @@ class Item extends Remote\Object
         return [
             'ItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Code' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
-            'InventoryAssetAccountCode' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
+            'InventoryAssetAccountCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Name' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'IsSold' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'IsPurchased' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],


### PR DESCRIPTION
Xero API doesn't require it for saving new Items.