### PR TITLE
getNonce(): Only use mt_rand to generate a random string

### DIFF
--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -227,11 +227,9 @@ class Client
      */
     private function getNonce($length = 20)
     {
-        // Add more uniqueness to the nonce
-        $parts = explode('.', microtime(true));
-        $nonce = base_convert($parts[1], 10, 36);
+        $nonce = "";
 
-        for ($i = 0; $i < $length - strlen($nonce); $i++) {
+        while (strlen($nonce) < $length) {
             $nonce .= base_convert(mt_rand(0, 35), 10, 36);
         }
 


### PR DESCRIPTION
Fixes #235 