### PR TITLE
Fix comment typo in Object->setApplication()

### DIFF
--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -74,7 +74,7 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
     }
 
     /**
-     * This should be compulsory in the constructor int he future,
+     * This should be compulsory in the constructor in the future,
      * but will have to be like this for BC until the next major version.
      *
      * @param Application $application


### PR DESCRIPTION
Fix a misplaced space in the header comments for method Remote\Object->setApplication().