### PR TITLE
Fix incorrect example of loadByGUID in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $xero->load('Accounting\\Invoice')->where('
 
 Load something by its GUID
 ```php
-$contact = $xero->loadByGUID('Accounting\\Contact', [GUID]);
+$contact = $xero->loadByGUID('Accounting\\Contact', $guid);
 ```
 
 Or create & populate it


### PR DESCRIPTION
The example previously appeared to pass the GUID in an array: `[GUID]`, whereas loadByGUID actually expects a single GUID as string.