### PR TITLE
URL-encode filenames for attachments

### DIFF
--- a/src/XeroPHP/Traits/AttachmentTrait.php
+++ b/src/XeroPHP/Traits/AttachmentTrait.php
@@ -14,7 +14,7 @@ trait AttachmentTrait
         /**
          * @var Object $this
          */
-        $uri = sprintf('%s/%s/Attachments/%s', $this::getResourceURI(), $this->getGUID(), $attachment->getFileName());
+        $uri = sprintf('%s/%s/Attachments/%s', $this::getResourceURI(), $this->getGUID(), rawurlencode($attachment->getFileName()));
 
         $url = new URL($this->_application, $uri);
         $request = new Request($this->_application, $url, Request::METHOD_POST);


### PR DESCRIPTION
The filename of an attachment is not necessarily safe for use directly in a URL (may contain spaces, quotes, ampersands etc.), so it should be passed through rawurlencode() when building the request URL in AttachmentTrait->addAttachment().

Without this change, if you attempt to add an attachment with URL-invalid characters in the filename, it will simply fail with no explanation ("Validation error" with an empty response body).

This change will be slightly annoying for anyone who has already worked around this in their own code, by URL-encoding their filenames before passing them to the Attachment factory methods.  In this case, the filename will end up being doubly encoded, so Xero's copy of the filename may contain percent sequences.  However, I think it is a pretty blatant encapsulation violation to have the application anticipating the library's transport mechanism in this way, so the (mild) breakage is justified.