### PR TITLE
Inventory asset account code should not be mandatory

### DIFF
--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -173,7 +173,7 @@ class Item extends Remote\Object
         return [
             'ItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Code' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
-            'InventoryAssetAccountCode' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
+            'InventoryAssetAccountCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Name' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'IsSold' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'IsPurchased' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],


### PR DESCRIPTION
The xero API does not require it, and it can be safely ignore for people who are not using Xero's inventory tracking features