### PR TITLE
Add methods to get and set config options

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -126,7 +126,7 @@ abstract class Application
         $this->config = array_replace_recursive(
             self::$_config_defaults,
             static::$_type_config_defaults,
-            $user_config
+            $config
         );
 
         return $this->config;
@@ -272,7 +272,7 @@ abstract class Application
     public function saveAll($objects)
     {
         $objects = array_values($objects);
-        
+
         //Just get one type to compare with, doesn't matter which.
         $current_object = $objects[0];
         /**

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -62,11 +62,7 @@ abstract class Application
     public function __construct(array $user_config)
     {
         //better here for overriding
-        $this->config = array_replace_recursive(
-            self::$_config_defaults,
-            static::$_type_config_defaults,
-            $user_config
-        );
+        $this->setConfig($user_config);
 
         $this->oauth_client = new Client($this->config['oauth']);
     }
@@ -108,6 +104,48 @@ abstract class Application
         return $this->config[$key];
     }
 
+    /**
+    * @param string $config
+    * @param mixed $option
+    * @param mixed $value
+    * @return mixed
+    * @throws Exception
+    */
+    public function getConfigOption($config, $option) {
+        if (!isset($this->config[$config])) {
+            throw new Exception("Invalid configuration key [$key]");
+        }
+        return $this->config[$config][$option];
+    }
+
+    /**
+     * @param array $config
+     * @return array
+     */
+    public function setConfig($config) {
+        $this->config = array_replace_recursive(
+            self::$_config_defaults,
+            static::$_type_config_defaults,
+            $user_config
+        );
+
+        return $this->config;
+    }
+
+    /**
+     * @param string $config
+     * @param mixed $option
+     * @param mixed $value
+     * @return array
+     * @throws Exception
+     */
+    public function setConfigOption($config, $option, $value) {
+        if (!isset($this->config[$config])) {
+            throw new Exception("Invalid configuration key [$key]");
+        }
+        $this->config[$config][$option] = $value;
+        return $this->config;
+    }
 
     /**
      * Validates and expands the provided model class to a full PHP class


### PR DESCRIPTION
It can be useful for us to check and update config options on the fly without having to re-instantiate the Application. We do this at the moment to try and workaround Xero timeouts by selectively increasing the curl timeouts when performing an important operation.