### PR TITLE
Added Payments property to CreditNote

### DIFF
--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -222,6 +222,7 @@ class CreditNote extends Remote\Object
             'Status' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LineAmountTypes' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'LineItems' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\Invoice\\LineItem', true, false],
+            'Payments' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\Payment', true, false],
             'SubTotal' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'TotalTax' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Total' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -363,6 +363,15 @@ class CreditNote extends Remote\Object
         $this->_data['LineItems'][] = $value;
         return $this;
     }
+    
+    /**
+     * @return LineItem[]|Remote\Collection
+     * Always returns a collection, switch is for type hinting
+     */
+    public function getPayments()
+    {
+        return $this->_data['Payments'];
+    }
 
     /**
      * @return float


### PR DESCRIPTION
Although the Xero docs do not document a `Payments` property exists on `CreditNotes`, it does, as credit notes get payments associated to them when you apply refunds to them.

Without this change you cannot see what refund payments have been made against the CreditNote. Fix for issue #252 