### PR TITLE
Remove non-minimum config settings

### DIFF
--- a/examples/private.php
+++ b/examples/private.php
@@ -10,9 +10,6 @@ $config = [
         'consumer_secret'  => 's',
         'rsa_private_key'  => 'file://certs/private.pem',
     ],
-    'curl' => [
-        CURLOPT_CAINFO => __DIR__.'/certs/ca-bundle.crt',
-    ],
 ];
 
 $xero = new PrivateApplication($config);


### PR DESCRIPTION
When I was digging into this, I was a bit confused as to what I was reading on Xero and in this config file, then I realised this was not actually apart of the minimum config for a private application. Thought removing it might help people in the future coming to this.