### PR TITLE
Allow FQNs for models

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -156,16 +156,29 @@ abstract class Application
      */
     public function validateModelClass($class)
     {
-        $config = $this->getConfig('xero');
-
-        if ($class[0] !== '\\') {
-            $class = sprintf('%s\\%s', $config['model_namespace'], $class);
+        if (class_exists($class)) {
+            return $class;
         }
+
+        $class = $this->prependConfigNamespace($class);
+
         if (!class_exists($class)) {
             throw new Exception("Class does not exist [$class]");
         }
 
         return $class;
+    }
+
+
+    /**
+     * Prepend the configuration namespace to the class.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function prependConfigNamespace($class)
+    {
+        return $this->getConfig('xero')['model_namespace'].'\\'.$class;
     }
 
 

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace XeroPHP\tests\Application;
+
+use XeroPHP\Application\PrivateApplication;
+
+class ApplicationTest extends \PHPUnit_Framework_TestCase
+{
+    const CONFIG = [
+        'oauth' => [
+            'consumer_key' => 'CONSUMER_KEY',
+        ],
+    ];
+
+    public function test_prepends_config_namespace_when_validating_model_class()
+    {
+        $app = $this->instance();
+        $class = 'Accounting\\Invoice';
+
+        $this->assertEquals(
+            $app->validateModelClass($class),
+            $app->getConfig('xero')['model_namespace'].'\\'.$class
+        );
+    }
+
+    public function test_allows_FQN_when_validating_model_class()
+    {
+        $class = \XeroPHP\Models\Accounting\Invoice::class;
+
+        $this->assertEquals(
+            $this->instance()->validateModelClass($class),
+            $class
+        );
+    }
+
+    public function test_throws_exception_when_unable_to_validate_class()
+    {
+        $this->setExpectedException(\Exception::class);
+
+        $this->instance()->validateModelClass('Unknown\\Namespaced\\Class');
+    }
+
+    protected function instance($config = [])
+    {
+        return new PrivateApplication(
+            array_merge_recursive(static::CONFIG, $config)
+        );
+    }
+}

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -6,12 +6,6 @@ use XeroPHP\Application\PrivateApplication;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
 {
-    const CONFIG = [
-        'oauth' => [
-            'consumer_key' => 'CONSUMER_KEY',
-        ],
-    ];
-
     public function test_prepends_config_namespace_when_validating_model_class()
     {
         $app = $this->instance();
@@ -43,7 +37,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     protected function instance($config = [])
     {
         return new PrivateApplication(
-            array_merge_recursive(static::CONFIG, $config)
+            array_merge_recursive([
+                'oauth' => ['consumer_key' => 'CONSUMER_KEY'],
+            ], $config)
         );
     }
 }

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -27,6 +27,16 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_allows_FQN_beginning_with_backslash_when_validating_model_class()
+    {
+        $class = '\XeroPHP\Models\Accounting\Invoice';
+
+        $this->assertEquals(
+            $this->instance()->validateModelClass($class),
+            $class
+        );
+    }
+
     public function test_throws_exception_when_unable_to_validate_class()
     {
         $this->setExpectedException(\Exception::class);


### PR DESCRIPTION
I think it would be nice to allow the use of [FQNs using the class constant](http://php.net/manual/en/language.oop5.constants.php#example-184)

```php
$xero->load(Contact::class)
```

I personally prefer this style over:

```php
$xero->load('Accounting\Contact')
```

I've added the ability to use the FQN, but also fallback to appending the config namespace. I added some tests for this as well.

**Note** I removed the `$class[0] !== '\\'` condition as I figure it's going to fail whether that check is there or not, and it just clutters the method (I personally feel) - but let me know if you want me to add it back in.