### PR TITLE
Moved authorize url query string logic to Client

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -81,14 +81,7 @@ abstract class Application
      */
     public function getAuthorizeURL($oauth_token = null)
     {
-        $authorize_url = $this->oauth_client->getAuthorizeURL();
-
-        if ($oauth_token !== null) {
-            $operator = parse_url($authorize_url, PHP_URL_QUERY) !== null ? '&' : '?';
-            $authorize_url .= sprintf('%soauth_token=%s', $operator, $oauth_token);
-        }
-
-        return $authorize_url;
+        return $this->oauth_client->getAuthorizeURL($oauth_token);
     }
 
     /**

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -295,11 +295,43 @@ class Client
     }
 
     /**
+     * @param string|null $oauth_token
      * @return string
      */
-    public function getAuthorizeURL()
+    public function getAuthorizeURL($oauth_token = null)
     {
-        return $this->config['authorize_url'];
+        if ($oauth_token == null) {
+            return $this->config['authorize_url'];
+        }
+
+        return $this->appendUrlQuery(
+            $this->config['authorize_url'], compact('oauth_token')
+        );
+    }
+
+    /**
+     * Prepend URL with query string.
+     *
+     * @param  string  $url
+     * @param  array  $query
+     * @return string
+     */
+    protected function appendUrlQuery($url, $query)
+    {
+        $glue = $this->urlHasQuery($url) ? '&' : '?';
+
+        return $url.$glue.http_build_query($query);
+    }
+
+    /**
+     * Determine if the URL has a query string.
+     *
+     * @param  string  $url
+     * @return bool
+     */
+    protected function urlHasQuery($url)
+    {
+        return (bool) parse_url($url, PHP_URL_QUERY);
     }
 
     //Populated during 3-legged auth

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -44,7 +44,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->instance()->validateModelClass('Unknown\\Namespaced\\Class');
     }
 
-
     public function test_oauth_client_instantiated_with_app_instantiation()
     {
         $app = $this->instance();

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -44,6 +44,13 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->instance()->validateModelClass('Unknown\\Namespaced\\Class');
     }
 
+    public function test_oauth_client_instantiated_with_app_instantiation()
+    {
+        $app = $this->instance();
+
+        $this->assertNotNull($app->getOAuthClient());
+    }
+
     protected function instance($config = [])
     {
         return new PrivateApplication(

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -87,7 +87,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(\Exception::class);
 
         $this->instance()->getConfig('non_existent_key');
-
     }
 
     protected function instance($config = [])

--- a/tests/Remote/OAuth/ClientTest.php
+++ b/tests/Remote/OAuth/ClientTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace XeroPHP\Tests\Remote\OAuth;
+
+use XeroPHP\Application\PrivateApplication;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_authorize_url_without_oauth_token()
+    {
+        $this->assertEquals(
+            $this->app()->getConfigOption('oauth', 'authorize_url'),
+            $this->client()->getAuthorizeURL()
+        );
+    }
+
+    public function test_authorize_url_appends_oauth_token_query_string()
+    {
+        $this->assertEquals(
+            $this->app()->getConfigOption('oauth', 'authorize_url').'?oauth_token=query_test',
+            $this->client()->getAuthorizeURL('query_test')
+        );
+    }
+
+    public function test_authorize_url_appends_oauth_token_query_string_to_existing_query_string()
+    {
+        $url = 'https://test.url/?example=query';
+
+        $this->assertEquals(
+            $url.'&oauth_token=query_test',
+            $this->client(['oauth' => ['authorize_url' => $url]])->getAuthorizeURL('query_test')
+        );
+    }
+
+    protected function client($config = [])
+    {
+        return $this->app($config)->getOAuthClient();
+    }
+
+    protected function app($config = [])
+    {
+        return  new PrivateApplication(
+            array_merge_recursive([
+                'oauth' => ['consumer_key' => 'CONSUMER_KEY'],
+            ], $config)
+        );
+    }
+}


### PR DESCRIPTION
So in the `Application` there was logic to prepare the url retrieved from the `Client` via the `getAuthorizeURL()` method. I figure that the URL logic is kinda best to be taken care of by the `Client`, and that the `Application` just has a `getAuthorizeURL()` method as a (proxy) convenience.

Also, if someone was to call:

```php
$application->getOAuthClient()->getAuthorizeURL('MY_TOKEN');
```

it would not have had the query string attached as previously the `Application` was doing that, with this PR however, the query string would now be attached correctly.

Could probably extract a URL Helper class to deal with the url stuff I moved, but its a bit cleaner now anyway.

+ Tests!