### PR TITLE
[Fix] 'getConfigOption' method issues

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -112,10 +112,10 @@ abstract class Application
     * @throws Exception
     */
     public function getConfigOption($config, $option) {
-        if (!isset($this->config[$config])) {
-            throw new Exception("Invalid configuration key [$key]");
+        if (!isset($this->getConfig($config)[$option])) {
+            throw new Exception("Invalid configuration option [$option]");
         }
-        return $this->config[$config][$option];
+        return $this->getConfig($config)[$option];
     }
 
     /**


### PR DESCRIPTION
Hey,

Couple of things with this method were broken. The exception message was referencing a non existent  `$key` variable. Also, it wasn't actually checking if the `$option` was set before attempting to retrieve it.