### PR TITLE
Fix set config option incorrect variable

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -141,7 +141,7 @@ abstract class Application
      */
     public function setConfigOption($config, $option, $value) {
         if (!isset($this->config[$config])) {
-            throw new Exception("Invalid configuration key [$key]");
+            throw new Exception("Invalid configuration key [$config]");
         }
         $this->config[$config][$option] = $value;
         return $this->config;

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -44,6 +44,13 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->instance()->validateModelClass('Unknown\\Namespaced\\Class');
     }
 
+    public function test_setting_missing_config_option_throws_exception()
+    {
+        $this->setExpectedException(\Exception::class);
+
+        $this->instance()->setConfigOption('non_exitant_key', 'sub_key', 'value');
+    }
+
     public function test_set_config_option_updates_configuration()
     {
         $key = 'oauth';

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -44,6 +44,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->instance()->validateModelClass('Unknown\\Namespaced\\Class');
     }
 
+    public function test_set_config_option_updates_configuration()
+    {
+        $key = 'oauth';
+        $subkey = 'test_sub_key';
+        $expected = 'test_value';
+        $app = $this->instance();
+        $app->setConfigOption($key, $subkey, $expected);
+
+        $this->assertEquals(
+            $expected,
+            $app->getConfigOption($key, $subkey, $expected)
+        );
+    }
+
     protected function instance($config = [])
     {
         return new PrivateApplication(


### PR DESCRIPTION
The `setConfigOption` references a variable that doesn't exist when throwing exception. Fixed that and added tests for the method.