### PR TITLE
Refactor exceptions

### DIFF
--- a/src/XeroPHP/Exception.php
+++ b/src/XeroPHP/Exception.php
@@ -4,4 +4,5 @@ namespace XeroPHP;
 
 class Exception extends \Exception
 {
+    //
 }

--- a/src/XeroPHP/Remote/Exception.php
+++ b/src/XeroPHP/Remote/Exception.php
@@ -4,4 +4,5 @@ namespace XeroPHP\Remote;
 
 class Exception extends \XeroPHP\Exception
 {
+    //
 }

--- a/src/XeroPHP/Remote/Exception/BadRequestException.php
+++ b/src/XeroPHP/Remote/Exception/BadRequestException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class BadRequestException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'Bad Request';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_BAD_REQUEST;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'Bad Request';
+
+    protected $code = Response::STATUS_BAD_REQUEST;
 }

--- a/src/XeroPHP/Remote/Exception/InternalErrorException.php
+++ b/src/XeroPHP/Remote/Exception/InternalErrorException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class InternalErrorException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'An unhandled error with the Xero API. Contact the Xero API team if problems persist.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_INTERNAL_ERROR;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'An unhandled error with the Xero API. Contact the Xero API team if problems persist.';
+
+    protected $code = Response::STATUS_INTERNAL_ERROR;
 }

--- a/src/XeroPHP/Remote/Exception/NotAvailableException.php
+++ b/src/XeroPHP/Remote/Exception/NotAvailableException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class NotAvailableException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'API is currently unavailable.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_NOT_AVAILABLE;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'API is currently unavailable.';
+
+    protected $code = Response::STATUS_NOT_AVAILABLE;
 }

--- a/src/XeroPHP/Remote/Exception/NotFoundException.php
+++ b/src/XeroPHP/Remote/Exception/NotFoundException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class NotFoundException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'Resource Not Found';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_NOT_FOUND;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'Resource Not Found';
+
+    protected $code = Response::STATUS_NOT_FOUND;
 }

--- a/src/XeroPHP/Remote/Exception/NotImplementedException.php
+++ b/src/XeroPHP/Remote/Exception/NotImplementedException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class NotImplementedException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'The method you have called has not been implemented.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_INTERNAL_ERROR;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'The method you have called has not been implemented.';
+
+    protected $code = Response::STATUS_INTERNAL_ERROR;
 }

--- a/src/XeroPHP/Remote/Exception/OrganisationOfflineException.php
+++ b/src/XeroPHP/Remote/Exception/OrganisationOfflineException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class OrganisationOfflineException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'The organisation temporarily cannot be connected to.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_ORGANISATION_OFFLINE;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'The organisation temporarily cannot be connected to.';
+
+    protected $code = Response::STATUS_ORGANISATION_OFFLINE;
 }

--- a/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
+++ b/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class RateLimitExceededException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'The API rate limit for your organisation/application pairing has been exceeded.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_RATE_LIMIT_EXCEEDED;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'The API rate limit for your organisation/application pairing has been exceeded.';
+
+    protected $code = Response::STATUS_RATE_LIMIT_EXCEEDED;
 }

--- a/src/XeroPHP/Remote/Exception/UnauthorizedException.php
+++ b/src/XeroPHP/Remote/Exception/UnauthorizedException.php
@@ -7,14 +7,7 @@ use XeroPHP\Remote\Response;
 
 class UnauthorizedException extends Exception
 {
-    public function __construct($message = null, $code = null, $previous = null)
-    {
-        if ($message === null) {
-            $message = 'Invalid authorization credentials.';
-        }
-        if ($code === null) {
-            $code = Response::STATUS_UNAUTHORISED;
-        }
-        parent::__construct($message, $code, $previous);
-    }
+    protected $message = 'Invalid authorization credentials.';
+
+    protected $code = Response::STATUS_UNAUTHORISED;
 }

--- a/src/XeroPHP/Remote/OAuth/Exception.php
+++ b/src/XeroPHP/Remote/OAuth/Exception.php
@@ -4,4 +4,5 @@ namespace XeroPHP\Remote\OAuth;
 
 class Exception extends \XeroPHP\Exception
 {
+    //
 }


### PR DESCRIPTION
Hey,

Just removed a bit logic that isn't needed in these exceptions. The message and code are still able to be overridden by passing the the values to the constructor when throwing an exception, this is just a nicer way to set defaults.

I also added the blank comment `//` to empty classes. This is totally just a personal preference thing. If you don't like it, happy to remove it and stick to whatever standard you prefer.

I didn't add any tests, as we would just be testing PHP behaviour and it didn't seem needed.

Again, tell me to slow down if this is unwanted stuff or whatever. Just enjoying working through a code base and seeing what I can help out on.