### PR TITLE
Add `getAPIStem()` to `saveAll()`

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -297,7 +297,7 @@ abstract class Application
 
         $request_method = $has_guid ? Request::METHOD_POST : Request::METHOD_PUT;
 
-        $url = new URL($this, $type::getResourceURI());
+        $url = new URL($this, $type::getResourceURI(), $type::getAPIStem());
         $request = new Request($this, $url, $request_method);
 
         //This might need to be parsed and stored some day.


### PR DESCRIPTION
Just tried to push multiple Timesheets to Xero at once when I realised that `saveAll()` was trying to submit the data to the Core API rather than the Payroll API.

Unlike the `save()` method, `saveAll()` does not currently get the API stem for the objects you try to save. Since the API is not explicitly passed into the URL object when it is being created, it defaults to `self::API_CORE`.

My change includes a call to `$type::getAPIStem()` and passes the result into the URL object (just like `save()` does) so your data ends up in the right place.