### PR TITLE
Refactor PDF trait

### DIFF
--- a/src/XeroPHP/Remote/Object.php
+++ b/src/XeroPHP/Remote/Object.php
@@ -85,6 +85,16 @@ abstract class Object implements ObjectInterface, \JsonSerializable, \ArrayAcces
     }
 
     /**
+     * Get the application.
+     *
+     * @return \XeroPHP\Application
+     */
+    protected function getApplication()
+    {
+        return $this->_application;
+    }
+
+    /**
      * If there have been any properties changed since load
      *
      * @param null $property

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -65,7 +65,7 @@ trait PDFTrait
      *
      * @return string
      */
-    abstract public static function getResourceURI();
+    // abstract public static function getResourceURI();
 
     /**
      * Determine if the resource has a GUID.

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -2,29 +2,82 @@
 
 namespace XeroPHP\Traits;
 
-use XeroPHP\Remote\Request;
-use XeroPHP\Remote\URL;
 use XeroPHP\Exception;
+use XeroPHP\Remote\URL;
+use XeroPHP\Remote\Request;
 
 trait PDFTrait
 {
+    /**
+     * Get the raw content of the resource's PDF file.
+     *
+     * @return string
+     * @throws \XeroPHP\Exception
+     */
     public function getPDF()
     {
-        /**
-         * @var Object $this
-         */
-        if ($this->hasGUID() === false) {
+        if (!$this->hasGUID()) {
             throw new Exception('PDF files are only available to objects that exist remotely.');
         }
 
-        $uri = sprintf('%s/%s', $this::getResourceURI(), $this->getGUID());
-
-        $url = new URL($this->_application, $uri);
-        $request = new Request($this->_application, $url, Request::METHOD_GET);
-        $request->setHeader(Request::HEADER_ACCEPT, Request::CONTENT_TYPE_PDF);
-
-        $request->send();
-
-        return $request->getResponse()->getResponseBody();
+        return $this->buildPDFRequest()->send()->getResponseBody();
     }
+
+    /**
+     * Build a request for the resources PDF.
+     *
+     * @return \XeroPHP\Remote\Request
+     */
+    protected function buildPDFRequest()
+    {
+        return (new Request(
+            $this->getApplication(),
+            $this->buildPDFURL(),
+            Request::METHOD_GET
+        ))->setHeader(
+            Request::HEADER_ACCEPT,
+            Request::CONTENT_TYPE_PDF
+        );
+    }
+
+    /**
+     * Build a URL to the resource's PDF.
+     *
+     * @return \XeroPHP\Remote\URL
+     */
+    protected function buildPDFURL()
+    {
+        return new URL(
+            $this->getApplication(),
+            static::getResourceURI().'/'.$this->getGUID()
+        );
+    }
+
+    /**
+     * Get the resource's application.
+     *
+     * @return \XeroPHP\Application
+     */
+    abstract protected function getApplication();
+
+    /**
+     * Get the resource's URI.
+     *
+     * @return string
+     */
+    abstract public static function getResourceURI();
+
+    /**
+     * Determine if the resource has a GUID.
+     *
+     * @return bool
+     */
+    abstract public function hasGUID();
+
+    /**
+     * Get the resource's GUID.
+     *
+     * @return string
+     */
+    abstract public function getGUID();
 }


### PR DESCRIPTION
Pretty straightforward refactor of this trait. Just makes it a little cleaner (I think).

Because we are newing up in the methods I'm not sure of anyway to write unit tests for this trait yet, but I've added it to my list to work out and implement perhaps in a future major version. I've manually tested and it seems all sweet, but go over it if you are keen on the PR.

- made property access reply on abstract methods - that way we don't need to document what `$this` is as we don't care, all we care is it has the methods implemented.
- added `getApplication` to the remote object to satisfy the abstract method.
- methods docs
- extracted 2 smaller, more focused methods for building the `URL` and `Request`. I've called these `buildXYZ` so you know what they are doing i.e. they aren't accessing an already existent object, they are building a new one. Just a convention I've been using recently that I think I like...tell me if you hate it and would prefer something else.
- rearranged the `use` statements longest to shortest. This is totally a personal preference - if you prefer alphabetical or some other conversion let me know and I'll fix it up.