### PR TITLE
Fixed invalid XML creation for purchases and sales details

### DIFF
--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -364,7 +364,7 @@ class Item extends Remote\Object
         if (!isset($this->_data['PurchaseDetails'])) {
             $this->_data['PurchaseDetails'] = new Remote\Collection();
         }
-        $this->_data['PurchaseDetails'][] = $value;
+        $this->_data['PurchaseDetails'] = $value;
         return $this;
     }
 
@@ -387,7 +387,7 @@ class Item extends Remote\Object
         if (!isset($this->_data['SalesDetails'])) {
             $this->_data['SalesDetails'] = new Remote\Collection();
         }
-        $this->_data['SalesDetails'][] = $value;
+        $this->_data['SalesDetails'] = $value;
         return $this;
     }
 


### PR DESCRIPTION
When adding purchase and sales details as array elements the `arrayToXML` method in `Helpers.php` creates the following invalid XML:

```XML
<PurchaseDetails>
  <PurchaseDetail>
    <COGSAccountCode>300</COGSAccountCode>
  </PurchaseDetail>
</PurchaseDetails>
```

Setting both the purchase details and sales details as proposed in the pull request fixes this issue. This may however cause compatibility issues if adding multiple purchase or sales details but I don't think this is possible so shouldn't be an issue.