### PR TITLE
Update TaxRate.php

### DIFF
--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -33,6 +33,8 @@ class TaxRate extends Remote\Object
 
     /**
      * See ReportTaxTypes
+     * This setting is not permitted for Global oraganisations, but is mandatory
+     * for regionalised organisation such as UK, AUS, NZ
      *
      * @property string ReportTaxType
      */
@@ -159,7 +161,7 @@ class TaxRate extends Remote\Object
             'TaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'TaxComponents' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\TaxRate\\TaxComponent', true, false],
             'Status' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
-            'ReportTaxType' => [true, self::PROPERTY_TYPE_ENUM, null, false, false],
+            'ReportTaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'CanApplyToAssets' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'CanApplyToEquity' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'CanApplyToExpenses' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],


### PR DESCRIPTION
The ReportTaxType value is not permitted when creating a tax type for a global organisation.
Change the mandatory flag to false.