### PR TITLE
Don't make ReportTaxType mandatory

### DIFF
--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -159,7 +159,7 @@ class TaxRate extends Remote\Object
             'TaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'TaxComponents' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\TaxRate\\TaxComponent', true, false],
             'Status' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
-            'ReportTaxType' => [true, self::PROPERTY_TYPE_ENUM, null, false, false],
+            'ReportTaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'CanApplyToAssets' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'CanApplyToEquity' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'CanApplyToExpenses' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],


### PR DESCRIPTION
This setting is not permitted for Global organizations, but is mandatory for regional organization such as UK, AUS, NZ

See https://github.com/calcinai/xero-php/pull/323/ (not sure why it was closed) and https://github.com/calcinai/xero-php/issues/285