### PR TITLE
Fix 'Undefined index: message'

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -70,7 +70,7 @@ class Response
         switch ($this->status) {
             case Response::STATUS_BAD_REQUEST:
                 //This catches actual app errors
-                if (isset($this->root_error)) {
+                if (isset($this->root_error) && !empty($this->root_error)) {
                     $message = sprintf('%s (%s)', $this->root_error['message'], implode(', ', $this->element_errors));
                     $message .= $this->parseBadRequest();
                     throw new BadRequestException($message, $this->root_error['code']);


### PR DESCRIPTION
`$this->root_error` sometimes equals to empty array, so we need to check this case