### PR TITLE
Handle Oauth errors returned as bad requests

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -116,7 +116,7 @@ class Response
      */
     private function parseBadRequest()
     {
-        if (isset($this->elements)) {
+        if (!empty($this->elements)) {
             $field_errors = [];
             foreach ($this->elements as $n => $element) {
                 if (isset($element['ValidationErrors'])) {
@@ -125,6 +125,11 @@ class Response
             }
             return "\nValidation errors:\n".implode("\n", $field_errors);
         }
+
+        if (isset($this->oauth_response['oauth_problem_advice'])) {
+            throw new UnauthorizedException($this->oauth_response['oauth_problem_advice']);
+        }
+
         return '';
     }
 


### PR DESCRIPTION
One of our users had accidentally setup a public app instead of private.

Xero was returning the error ` Public applications must use the HMAC-SHA1 signature method` as a bad request instead of unauthorised where Oauth errors are usually caught. 

This was returning a blank error so this PR corrects that.