### PR TITLE
Travis: update targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ php:
     - 5.5
     - 5.6
     - hhvm
-    - 7
+    - 7.0
+    - 7.1
+    - 7.2
 
 matrix:
     allow_failures:
         - php: hhvm
-        - php: 7
 
 before_script:
     - composer install


### PR DESCRIPTION
Seems like it makes sense to remove 7.1 from the allowed failure list, and add all minor versions from 5.5 through 7.2

Any issues with expanding the .travis.yml as above?