### PR TITLE
added new trait to allow Invoices to be emailed

### DIFF
--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -4,6 +4,7 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Traits\PDFTrait;
 use XeroPHP\Traits\AttachmentTrait;
+use XeroPHP\Traits\SendEmailTrait;
 use XeroPHP\Models\Accounting\Invoice\LineItem;
 
 class Invoice extends Remote\Model
@@ -11,6 +12,7 @@ class Invoice extends Remote\Model
 
     use PDFTrait;
     use AttachmentTrait;
+    use SendEmailTrait;
 
     /**
      * See Invoice Types

--- a/src/XeroPHP/Traits/SendEmailTrait.php
+++ b/src/XeroPHP/Traits/SendEmailTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace XeroPHP\Traits;
+
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\URL;
+use XeroPHP\Exception;
+
+trait SendEmailTrait
+{
+    public function sendEmail()
+    {
+        /**
+         * @var Object $this
+         */
+        $uri = sprintf('%s/%s/Email', $this::getResourceURI(), $this->getGUID());
+        
+        $url = new URL($this->_application, $uri);
+        $request = new Request($this->_application, $url, Request::METHOD_POST);
+        
+        $request->send();
+        
+        $response = $request->getResponse();
+        
+        if (false !== $element = current($response->getElements())) {
+            $attachment->fromStringArray($element);
+        }
+        
+        return $this;
+    }
+}


### PR DESCRIPTION
The Xero API now allows for Invoices to be sent from the API itself. This PR adds this ability by adding a new trait to the Invoice model.

Usage:
$invoice->sendEmail();