### PR TITLE
Standardise `setMethodName` return value

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -78,10 +78,13 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * but will have to be like this for BC until the next major version.
      *
      * @param Application $application
+     * @return $this
      */
     public function setApplication(Application $application)
     {
         $this->_application = $application;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Ahoy!

All of the models `setMethodName` methods return `$this` so you can chain them like a builder.

The only one that doesn't is `setApplication`. I know that this is not a bit different to the other setters - but I think adding it standardises the API as I personally was expecting to be able to chain...

`$invoice->asXeroInvoice()->setApplication($xeroClient)->getPDF();`

Like you can with other methods...

`$xeroInvoice->setContact($contact)->setDueDate($date)->....`

Where `$invoice` is the representation in my app. I can't see this being a breaking change for any apps myself.