### PR TITLE
add functions for TrackingCategoryName and TrackingCategoryOption

### DIFF
--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -112,6 +112,8 @@ class TrackingCategory extends Remote\Model
         return [
             'TrackingCategoryID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Name' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'TrackingCategoryName' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'TrackingOptionName' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Status' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Options' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\TrackingCategory\\TrackingOption', true, true],
             'Option' => [false, self::PROPERTY_TYPE_STRING, null, false, true]
@@ -158,6 +160,44 @@ class TrackingCategory extends Remote\Model
     {
         $this->propertyUpdated('Name', $value);
         $this->_data['Name'] = $value;
+        return $this;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getTrackingCategoryName()
+    {
+        return $this->_data['TrackingCategoryName'];
+    }
+
+    /**
+     * @param string $value
+     * @return TrackingCategory
+     */
+    public function setTrackingCategoryName($value)
+    {
+        $this->propertyUpdated('TrackingCategoryName', $value);
+        $this->_data['TrackingCategoryName'] = $value;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTrackingOptionName()
+    {
+        return $this->_data['TrackingOptionName'];
+    }
+
+    /**
+     * @param string $value
+     * @return TrackingCategory
+     */
+    public function setTrackingOptionName($value)
+    {
+        $this->propertyUpdated('TrackingOptionName', $value);
+        $this->_data['TrackingOptionName'] = $value;
         return $this;
     }
 


### PR DESCRIPTION
If contact has a tracking option set then the xml returns something like the following:
```

 <SalesTrackingCategories>
        <SalesTrackingCategory>
          <TrackingCategoryName>Example Name</TrackingCategoryName>
          <TrackingOptionName>Example Name</TrackingOptionName>
        </SalesTrackingCategory>
```

If you then save the contact you get the following validation error:
A validation exception occurred (There is no ACTIVE tracking category with the name '') Validation errors: SalesCategory is missing a TrackingCategoryName

and if you attempt to create an invoice with the contact you get the following validation erorr:
A validation exception occurred (An error occurred in Xero. Check the API Status page http://status.developer.xero.com for current service status. Contact the API support team at api@xero.com for more assistance)

This error occur when the SalesTrackingCategories node is included within the XML, but no category is specified:

<SalesTrackingCategories>
    <SalesTrackingCategory/>
</SalesTrackingCategories>