### PR TITLE
Support HistoryRecords on Contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,27 @@ XeroPHP
 [![Latest Stable Version](https://poser.pugx.org/calcinai/xero-php/v/stable)](https://packagist.org/packages/calcinai/xero-php)
 [![Total Downloads](https://poser.pugx.org/calcinai/xero-php/downloads)](https://packagist.org/packages/calcinai/xero-php)
 
-A client library for the [Xero API](<http://developer.xero.com>), including an OAuth interface and ORM-like abstraction.
- 
+A client implementation of the [Xero API](<http://developer.xero.com>), with a cleaner OAuth interface and ORM-like abstraction.
+
+## Background
+
+I hate reinventing the wheel, but this was written out of desperation. I wasn't comfortable putting the implementation that's recommended by Xero in to production, even after persisting with extending it.
+
 This is loosely based on the functional flow of XeroAPI/XeroOAuth-PHP, but is split logically into more of an OO design.
 
-This library has been tested with Private, Public and Partner applications.
+## Main changes
+* Variables are named clearly and only defined if actually used
+* Methods are only defined in one place
+* Project is split into useful components rather than one massive class
+* Organised methods so it's more clear what's going on and how to debug
+* More robust implementation of signing methods
+* Removal of countless semantic issues
+
+This library has been tested with Private, Public and Partner apps but is still a WIP, I'd love contributions/fixes from anyone that is keen to join the cause!
 
 ### Model Generation
 
-All the models were historically generated from the Xero developer docs. This has become too hard to maintain, as there is some key data missing in some cases. If you spot something wrong, feel free to make a PR.
+Any files in the XeroPHP/Models directory are system generated.  Ideally, these shouldn't be modified directly, as it will be difficult to track/update.  Instead, if you notice something wrong with them, have a look at the ```generate/``` folder.  This contains the generation code, which actually just scrapes <http://developer.xero.com/documentation/> and parses out model/property/relation information.
 
 ## Requirements
 * PHP 5.5+
@@ -32,8 +44,6 @@ Otherwise just download the package and add it to your autoloader.  Namespaces a
 
 ## Usage
 
-All the examples below refer to models in the `XeroPHP\Models\Accounting` namespace. Additionally, there are models for `PayrollAU`, `PayrollUS`, `Files`, and `Assets`
-
 Create a XeroPHP instance (sample config included):
 
 ```php
@@ -42,8 +52,7 @@ $xero = new \XeroPHP\Application\PrivateApplication($config);
 
 Load a collection of objects and loop through them
 ```php
-$contacts = $xero->load(Contact::class)->execute();
-
+$contacts = $xero->load('Accounting\\Contact')->execute();
 foreach ($contacts as $contact) {
     print_r($contact);
 }
@@ -51,8 +60,7 @@ foreach ($contacts as $contact) {
 
 Load collection of objects, for a single page, and loop through them [(Why?)](<https://developer.xero.com/documentation/auth-and-limits/xero-api-limits#Systemlimits>)
 ```php
-$contacts = $xero->load(Contact::class)->page(1)->execute();
-
+$contacts = $xero->load('Accounting\\Contact')->page(1)->execute();
 foreach ($contacts as $contact) {
     print_r($contact);
 }
@@ -60,21 +68,27 @@ foreach ($contacts as $contact) {
 
 Search for objects meeting certain criteria
 ```php
-$xero->load(Invoice::class)
-    ->where('Status', Invoice::INVOICE_STATUS_AUTHORISED)
-    ->where('Type', Invoice::INVOICE_TYPE_ACCREC)
+$xero->load('Accounting\\Invoice')
+    ->where('Status', \XeroPHP\Models\Accounting\Invoice::INVOICE_STATUS_AUTHORISED)
+    ->where('Type', \XeroPHP\Models\Accounting\Invoice::INVOICE_TYPE_ACCREC)
     ->execute();
+```
+or
+```php
+$xero->load('Accounting\\Invoice')->where('
+    Status=="' . \XeroPHP\Models\Accounting\Invoice::INVOICE_STATUS_AUTHORISED . '" AND
+    Type=="' . \XeroPHP\Models\Accounting\Invoice::INVOICE_TYPE_ACCREC . '"
+')->execute();
 ```
 
 Load something by its GUID
 ```php
-$contact = $xero->loadByGUID(Contact::class, $guid);
+$contact = $xero->loadByGUID('Accounting\\Contact', $guid);
 ```
 
 Or create & populate it
 ```php
-$contact = new Contact($xero);
-
+$contact = new \XeroPHP\Models\Accounting\Contact($xero);
 $contact->setName('Test Contact')
     ->setFirstName('Test')
     ->setLastName('Contact')
@@ -92,7 +106,7 @@ From v1.2.0+, Xero context can be injected directly when creating the objects th
 
 Nested objects
 ```php
-$invoice = $xero->loadByGUID(Invoice::class, '[GUID]');
+$invoice = $xero->loadByGUID('Accounting\\Invoice', '[GUID]');
 $invoice->setContact($contact);
 ```
 
@@ -105,7 +119,7 @@ foreach ($attachment as $attachment) {
 }
 
 //You can also upload attachemnts
-$attachment = Attachment::createFromLocalFile('/path/to/image.jpg');
+$attachment = \XeroPHP\Models\Accounting\Attachment::createFromLocalFile('/path/to/image.jpg');
 $invoice->addAttachment($attachment);
 ```
 
@@ -113,4 +127,4 @@ To set the `IncludeOnline` flag on the attachment, pass `true` as the second par
 
 PDF - Models that support PDF export will inherit a ```->getPDF()``` method, which returns the raw content of the PDF.  Currently this is limited to Invoices and CreditNotes.
 
-Refer to the [examples](examples) for more complex usage and nested/related objects.  There's also [a sample PHP app](https://github.com/XeroAPI/xero-php-sample-app) using this library.
+Refer to the [examples](examples) for more complex usage and nested/related objects.

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -3,13 +3,13 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 use XeroPHP\Traits\AttachmentTrait;
+use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Models\Accounting\Contact\ContactPerson;
 use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 
 class Contact extends Remote\Model
 {
-
-    use AttachmentTrait;
+    use AttachmentTrait, HistoryTrait;
 
     /**
      * Xero identifier

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -664,6 +664,7 @@ class CreditNote extends Remote\Model
         if (isset($this->_data['New_Allocations'])) {
             $this->_data['Old_Allocations'] = $this->_data['Allocations'];
             $this->_data['Allocations'] = $this->_data['New_Allocations'];
+            unset($this->_data['New_Allocations']);
             $return_value = parent::save();
             $this->_data['Allocations'] = new Remote\Collection(
                 array_merge(
@@ -671,7 +672,6 @@ class CreditNote extends Remote\Model
                     isset($this->_data['Old_Allocations']) ? $this->_data['Old_Allocations']->getArrayCopy(): []
                 )
             );
-            unset($this->_data['New_Allocations']);
             return $return_value;
         }
         return parent::save();

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -1,0 +1,138 @@
+<?php
+//This class is a pseudo-model to represent an attachment.  Can't be directly put ot fetched.
+
+
+namespace XeroPHP\Models\Accounting;
+
+use XeroPHP\Application;
+use XeroPHP\Remote\Model;
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\URL;
+
+class History extends Model
+{
+    /**
+     * The type of change recorded against the document.
+     *
+     * @property string Changes
+     */
+
+    /**
+     * UTC date that the history record was created
+     *
+     * @property \DateTimeInterface DateUTC
+     */
+
+    /**
+     * The user responsible for the change ("System Generated" when the change happens via API)
+     *
+     * @property string User
+     */
+
+    /**
+     * Description of the change event or transaction
+     *
+     * @property string Details
+     */
+
+    /**
+     * Get the GUID Property if it exists
+     *
+     * @return string
+     */
+    static function getGUIDProperty()
+    {
+        return '';
+    }
+
+    /**
+     * Get a list of properties
+     *
+     * @return array
+     */
+    static function getProperties()
+    {
+        return array(
+            'Changes' => array(false, self::PROPERTY_TYPE_STRING, null, false, false),
+            'DateUTC' => [false, self::PROPERTY_TYPE_TIMESTAMP, '\\DateTimeInterface', false, false],
+            'User' => array(false, self::PROPERTY_TYPE_STRING, null, false, false),
+            'Details' => array(true, self::PROPERTY_TYPE_STRING, null, false, false)
+        );
+    }
+
+    /**
+     * Get a list of the supported HTTP Methods
+     *
+     * @return array
+     */
+    static function getSupportedMethods()
+    {
+        return array(
+            Request::METHOD_GET,
+            Request::METHOD_PUT
+        );
+    }
+
+    /**
+     * return the URI of the resource (if any)
+     *
+     * @return string
+     */
+    static function getResourceURI()
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getChanges()
+    {
+        return $this->_data['Changes'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getUser()
+    {
+        return $this->_data['User'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDetails()
+    {
+        return $this->_data['Details'];
+    }
+
+    /**
+     * @param string $value
+     * @return History
+     */
+    public function setDetails($value)
+    {
+        $this->propertyUpdated('Details', $value);
+        $this->_data['Details'] = $value;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function isPageable()
+    {
+        return false;
+    }
+
+    static function getAPIStem()
+    {
+        return '';
+    }
+
+    static function getRootNodeName()
+    {
+        // TODO: Implement getRootNodeName() method.
+    }
+}

--- a/src/XeroPHP/Traits/HistoryTrait.php
+++ b/src/XeroPHP/Traits/HistoryTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace XeroPHP\Traits;
+
+use XeroPHP\Models\Accounting\History;
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\URL;
+use XeroPHP\Exception;
+use XeroPHP\Helpers;
+
+trait HistoryTrait
+{
+    public function addHistory(History $history)
+    {
+        /**
+         * @var Object $this
+         */
+        $uri = sprintf('%s/%s/History', $this::getResourceURI(), $this->getGUID());
+
+        $url = new URL($this->_application, $uri);
+        $request = new Request($this->_application, $url, Request::METHOD_POST);
+
+        $request->setBody(Helpers::arrayToXML(['HistoryRecords' => [($history->toStringArray())]]));
+        $request->send();
+
+        $response = $request->getResponse();
+
+        return $this;
+    }
+
+    public function getHistory()
+    {
+        /**
+         * @var Object $this
+         */
+        if ($this->hasGUID() === false) {
+            throw new Exception(
+                'History/Notes are only available to objects that exist remotely.'
+            );
+        }
+
+        $uri = sprintf(
+            '%s/%s/History',
+            $this::getResourceURI(),
+            $this->getGUID()
+        );
+
+        $url = new URL($this->_application, $uri);
+        $request = new Request($this->_application, $url, Request::METHOD_GET);
+        $request->send();
+
+        $historyEntries = [];
+        foreach ($request->getResponse()->getElements() as $element) {
+            $history = new History($this->_application);
+            $history->fromStringArray($element);
+            $historyEntries[] = $history;
+        }
+
+        return $historyEntries;
+    }
+}


### PR DESCRIPTION
This PR adds support for HistoryRecords (a.k.a Notes) on Contacts in Xero. 

Xero API docs: https://developer.xero.com/documentation/api/history-and-notes

It should be fairly easy to extend this to the other objects which support HistoryRecords by adding the HistoryTrait to those models.