### PR TITLE
Expose x-rate-limit-problem header

### DIFF
--- a/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
+++ b/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
@@ -10,4 +10,16 @@ class RateLimitExceededException extends Exception
     protected $message = 'The API rate limit for your organisation/application pairing has been exceeded.';
 
     protected $code = Response::STATUS_RATE_LIMIT_EXCEEDED;
+
+    protected $rateLimitProblem = null;
+
+    public function setRateLimitProblem($rateLimitProblem)
+    {
+        $this->rateLimitProblem = strtolower($rateLimitProblem);
+    }
+
+    public function getRateLimitProblem()
+    {
+        return $this->rateLimitProblem;
+    }
 }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -98,6 +98,24 @@ class Request
             curl_setopt($ch, CURLOPT_POST, true);
         }
 
+        $headers = [];
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$headers) {
+            $len = strlen($header);
+            if (strpos($header, ':') === false) {
+                return $len;
+            }
+
+            list($name, $value) = explode(':', $header, 2);
+            $name = strtolower(trim($name));
+            $value = trim($value);
+            if (!array_key_exists($name, $headers)) {
+                $headers[$name] = [];
+            }
+            $headers[$name][] = $value;
+
+            return $len;
+        });
+
         $response = curl_exec($ch);
         $info = curl_getinfo($ch);
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -123,7 +123,7 @@ class Request
             throw new Exception('Curl error: ' . curl_error($ch));
         }
 
-        $this->response = new Response($this, $response, $info);
+        $this->response = new Response($this, $response, $info, $headers);
         $this->response->parse();
 
         return $this->response;

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -105,7 +105,7 @@ class Response
                 if (false !== stripos($response, 'Organisation is offline')) {
                     throw new OrganisationOfflineException();
                 } elseif (false !== stripos($response, 'Rate limit exceeded')) {
-                    $problem = isset($this->headers['x-rate-limit-problem']) ? array_pop($this->headers['x-rate-limit-problem']) : null;
+                    $problem = isset($this->headers['x-rate-limit-problem']) ? current($this->headers['x-rate-limit-problem']) : null;
                     $exception = new RateLimitExceededException();
                     $exception->setRateLimitProblem($problem);
                     throw $exception;


### PR DESCRIPTION
Extension of #353 that maintains compatibility. This change adds it as a field rather than to the exception message.

Our use case is to monitor the number of merchants we are routinely hitting the rate limit for and expose this info to our support team.

Fixes #352.