### PR TITLE
use assertSame in tests instead of assertEquals

### DIFF
--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace XeroPHP\tests\Application;
 
+use XeroPHP\Application\PartnerApplication;
 use XeroPHP\Application\PrivateApplication;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
@@ -11,7 +12,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app = $this->instance();
         $class = 'Accounting\\Invoice';
 
-        $this->assertEquals(
+        $this->assertSame(
             $app->validateModelClass($class),
             $app->getConfig('xero')['model_namespace'].'\\'.$class
         );
@@ -21,7 +22,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $class = \XeroPHP\Models\Accounting\Invoice::class;
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->instance()->validateModelClass($class),
             $class
         );
@@ -31,7 +32,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $class = '\XeroPHP\Models\Accounting\Invoice';
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->instance()->validateModelClass($class),
             $class
         );
@@ -66,7 +67,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app = $this->instance();
         $app->setConfigOption($key, $subkey, $expected);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $app->getConfigOption($key, $subkey, $expected)
         );
@@ -77,7 +78,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $key = 'test_key';
         $expected = ['sub_test_key' => 'test_value'];
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->instance([$key => $expected])->getConfig($key)
         );
@@ -89,7 +90,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $subKey = 'sub_test_key';
         $expected = 'test_value';
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->instance([$key => [$subKey => $expected]])->getConfigOption($key, $subKey)
         );

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -30,8 +30,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     public function testGetAuthorizeURL()
     {
         $expectedUrl = $this->application->getOAuthClient()->getAuthorizeURL();
-        $this->assertEquals($expectedUrl, $this->application->getAuthorizeURL());
-        $this->assertEquals(
+        $this->assertSame($expectedUrl, $this->application->getAuthorizeURL());
+        $this->assertSame(
             $expectedUrl . '?oauth_token=test',
             $this->application->getAuthorizeURL('test')
         );

--- a/tests/Remote/ModelTest.php
+++ b/tests/Remote/ModelTest.php
@@ -21,11 +21,11 @@ class ModelTest extends \PHPUnit_Framework_TestCase
         $object->test = 'something';
 
         $this->assertTrue(isset($object->test));
-        $this->assertEquals('something', $object->test);
+        $this->assertSame('something', $object->test);
         $this->assertTrue(isset($object['test']));
-        $this->assertEquals('something', $object['TeST']);
-        $this->assertEquals('something', $object->TeST);
-        $this->assertEquals('something', $object['TeST']);
+        $this->assertSame('something', $object['TeST']);
+        $this->assertSame('something', $object->TeST);
+        $this->assertSame('something', $object['TeST']);
 
         $this->assertFalse(isset($object->TeST), '__isset is case sensitive');
         $this->assertFalse(isset($object['TeST']), 'offsetExists is case sensitive');
@@ -39,7 +39,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase
 
         $object->setGUID('5b96e86b-418e-48e8-8949-308c14aec278');
 
-        $this->assertEquals('5b96e86b-418e-48e8-8949-308c14aec278', $object->getGUID());
+        $this->assertSame('5b96e86b-418e-48e8-8949-308c14aec278', $object->getGUID());
         $this->assertTrue($object->hasGUID());
     }
 }

--- a/tests/Remote/OAuth/ClientTest.php
+++ b/tests/Remote/OAuth/ClientTest.php
@@ -8,7 +8,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 {
     public function test_authorize_url_without_oauth_token()
     {
-        $this->assertEquals(
+        $this->assertSame(
             $this->app()->getConfigOption('oauth', 'authorize_url'),
             $this->client()->getAuthorizeURL()
         );
@@ -16,7 +16,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function test_authorize_url_appends_oauth_token_query_string()
     {
-        $this->assertEquals(
+        $this->assertSame(
             $this->app()->getConfigOption('oauth', 'authorize_url').'?oauth_token=query_test',
             $this->client()->getAuthorizeURL('query_test')
         );
@@ -26,7 +26,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $url = 'https://test.url/?example=query';
 
-        $this->assertEquals(
+        $this->assertSame(
             $url.'&oauth_token=query_test',
             $this->client(['oauth' => ['authorize_url' => $url]])->getAuthorizeURL('query_test')
         );

--- a/tests/Webhook/EventTest.php
+++ b/tests/Webhook/EventTest.php
@@ -49,7 +49,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals($webhook, $evt->getWebhook());
+            $this->assertSame($webhook, $evt->getWebhook());
         }
     }
 
@@ -60,7 +60,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('https://api.xero.com/api.xro/2.0/Invoices/44aa0707-f718-4f1c-8d53-f2da9ca59533', $evt->getResourceUrl());
+            $this->assertSame('https://api.xero.com/api.xro/2.0/Invoices/44aa0707-f718-4f1c-8d53-f2da9ca59533', $evt->getResourceUrl());
         }
     }
 
@@ -71,7 +71,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('44aa0707-f718-4f1c-8d53-f2da9ca59533', $evt->getResourceId());
+            $this->assertSame('44aa0707-f718-4f1c-8d53-f2da9ca59533', $evt->getResourceId());
         }
     }
 
@@ -83,10 +83,10 @@ class EventTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
             $string = $evt->getEventDateUtc();
-            $this->assertEquals('2018-02-09T09:18:28.917Z', $string);
+            $this->assertSame('2018-02-09T09:18:28.917Z', $string);
 
             $obj = $evt->getEventDate();
-            $this->assertEquals(strtotime($string), $obj->getTimestamp());
+            $this->assertSame(strtotime($string), $obj->getTimestamp());
         }
     }
 
@@ -97,7 +97,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('UPDATE', $evt->getEventType());
+            $this->assertSame('UPDATE', $evt->getEventType());
         }
     }
 
@@ -108,7 +108,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('INVOICE', $evt->getEventCategory());
+            $this->assertSame('INVOICE', $evt->getEventCategory());
         }
     }
 
@@ -123,10 +123,10 @@ class EventTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($evt->getEventClass());
 
         $evt = array_pop($events);
-        $this->assertEquals(\XeroPHP\Models\Accounting\Contact::class, $evt->getEventClass());
+        $this->assertSame(\XeroPHP\Models\Accounting\Contact::class, $evt->getEventClass());
 
         $evt = array_pop($events);
-        $this->assertEquals(\XeroPHP\Models\Accounting\Invoice::class, $evt->getEventClass());
+        $this->assertSame(\XeroPHP\Models\Accounting\Invoice::class, $evt->getEventClass());
     }
 
     public function testGetTenantId()
@@ -136,7 +136,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('e629a03c-7ffe-4913-bd94-ff2fdb36a702', $evt->getTenantId());
+            $this->assertSame('e629a03c-7ffe-4913-bd94-ff2fdb36a702', $evt->getTenantId());
         }
     }
 
@@ -147,7 +147,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($webhook->getEvents());
         foreach ($webhook->getEvents() as $evt) {
-            $this->assertEquals('ORGANISATION', $evt->getTenantType());
+            $this->assertSame('ORGANISATION', $evt->getTenantType());
         }
     }
 }

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -70,8 +70,8 @@ class WebhookTest extends \PHPUnit_Framework_TestCase
         $payload = '{"events":[],"firstEventSequence": 0,"lastEventSequence": 2, "entropy": "ZGJDWFZBUNMATYWGAROW"}';
         $webhook = new Webhook($this->application, $payload);
 
-        $this->assertEquals(0, $webhook->getFirstEventSequence());
-        $this->assertEquals(2, $webhook->getLastEventSequence());
+        $this->assertSame(0, $webhook->getFirstEventSequence());
+        $this->assertSame(2, $webhook->getLastEventSequence());
     }
 
     public function testGetApplication()
@@ -79,7 +79,7 @@ class WebhookTest extends \PHPUnit_Framework_TestCase
         $payload = '{"events":[],"firstEventSequence": 0,"lastEventSequence": 2, "entropy": "ZGJDWFZBUNMATYWGAROW"}';
         $webhook = new Webhook($this->application, $payload);
 
-        $this->assertEquals($this->application, $webhook->getApplication());
+        $this->assertSame($this->application, $webhook->getApplication());
     }
 
     public function testGetEvents()


### PR DESCRIPTION
Hey @calcinai - long time no PR 🙂

I'm back with a simple one here. In our tests, many of which I wrote, so my bad, we have `assertEquals`, however this is like using `==` but `assertSame` is like using `===`. 

This means you can get weird side effects if you are not careful, and `assertSame` is the better way to go.

`$this->assertEquals(3, true);` this will PASS !! which we don't want
`$this->assertSame(3, true);` this will FAIL !! which we definitely would want

So I've migrated all the tests to use `assertSame`.

You'll see a lot of people recommending this on Twitter: https://twitter.com/search?q=phpunit%20assertSame&src=typd

You can even see in the PHPUnit introduction they specifically change it to `assertSame` https://github.com/sebastianbergmann/phpunit-documentation-english/issues/3

