### PR TITLE
remove duplicate static vars

### DIFF
--- a/src/XeroPHP/Application/PartnerApplication.php
+++ b/src/XeroPHP/Application/PartnerApplication.php
@@ -6,5 +6,5 @@ use XeroPHP\Application;
 
 class PartnerApplication extends Application
 {
-    protected static $_type_config_defaults = [];
+    //
 }

--- a/src/XeroPHP/Application/PrivateApplication.php
+++ b/src/XeroPHP/Application/PrivateApplication.php
@@ -6,8 +6,6 @@ use XeroPHP\Application;
 
 class PrivateApplication extends Application
 {
-    protected static $_type_config_defaults = [];
-
     public function __construct($config)
     {
         //As we don't need to Authorize/RequestToken, it's populated here.


### PR DESCRIPTION
The base `XeroPHP\Application` class has a static variable `protected static $_type_config_defaults = [];` which allows classes that extend it to have class specific configuration variables preset.

In the extended classes which have no custom config values, the `XeroPHP\Application` empty array will be attached to that class so there is no need to include it in the class itself.

If a user has extended the class in their own code base and added configuration variables, they would replace any previously set config values, so there is no breaking changes with removing them.