### PR TITLE
Standardise constructors

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -57,12 +57,12 @@ abstract class Application
     protected static $_type_config_defaults = [];
 
     /**
-     * @param array $user_config
+     * @param array $config
      */
-    public function __construct(array $user_config)
+    public function __construct(array $config)
     {
         //better here for overriding
-        $this->setConfig($user_config);
+        $this->setConfig($config);
 
         $this->oauth_client = new Client($this->config['oauth']);
     }

--- a/src/XeroPHP/Application/PrivateApplication.php
+++ b/src/XeroPHP/Application/PrivateApplication.php
@@ -8,7 +8,10 @@ class PrivateApplication extends Application
 {
     protected static $_type_config_defaults = [];
 
-    public function __construct($config)
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config)
     {
         //As we don't need to Authorize/RequestToken, it's populated here.
         $config['oauth']['token'] = $config['oauth']['consumer_key'];


### PR DESCRIPTION
Soooo...you might remember me from the other two PRs I just sent...sorry haha

I have standardised the constructors. The base `XeroPHP\Application` constructor has an `array` type hint but the extended class does not. The base class also had a different name for the `$config` variable name.

Although these changes have no real world outcome, it does make things more consistent.