### PR TITLE
Update LineItem under recurring Invoice to include the Line Item ID

### DIFF
--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
@@ -144,6 +144,7 @@ class LineItem extends Remote\Model
     public static function getProperties()
     {
         return [
+            'LineItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Description' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Quantity' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'UnitAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],


### PR DESCRIPTION
The LineItem under a normal invoice has this attribute, but it's missing from the recurring invoice. It does exist and was needed for my project.