### PR TITLE
Add HistoryRecord support

### DIFF
--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -3,13 +3,13 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 use XeroPHP\Traits\AttachmentTrait;
+use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Models\Accounting\Contact\ContactPerson;
 use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 
 class Contact extends Remote\Model
 {
-
-    use AttachmentTrait;
+    use AttachmentTrait, HistoryTrait;
 
     /**
      * Xero identifier

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -9,7 +9,8 @@ use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 
 class Contact extends Remote\Model
 {
-    use AttachmentTrait, HistoryTrait;
+    use AttachmentTrait;
+    use HistoryTrait;
 
     /**
      * Xero identifier

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -1,5 +1,4 @@
 <?php
-//This class is a pseudo-model to represent an attachment.  Can't be directly put ot fetched.
 
 
 namespace XeroPHP\Models\Accounting;

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -1,0 +1,138 @@
+<?php
+//This class is a pseudo-model to represent an attachment.  Can't be directly put ot fetched.
+
+
+namespace XeroPHP\Models\Accounting;
+
+use XeroPHP\Application;
+use XeroPHP\Remote\Model;
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\URL;
+
+class History extends Model
+{
+    /**
+     * The type of change recorded against the document.
+     *
+     * @property string Changes
+     */
+
+    /**
+     * UTC date that the history record was created
+     *
+     * @property \DateTimeInterface DateUTC
+     */
+
+    /**
+     * The user responsible for the change ("System Generated" when the change happens via API)
+     *
+     * @property string User
+     */
+
+    /**
+     * Description of the change event or transaction
+     *
+     * @property string Details
+     */
+
+    /**
+     * Get the GUID Property if it exists
+     *
+     * @return string
+     */
+    static function getGUIDProperty()
+    {
+        return '';
+    }
+
+    /**
+     * Get a list of properties
+     *
+     * @return array
+     */
+    static function getProperties()
+    {
+        return array(
+            'Changes' => array(false, self::PROPERTY_TYPE_STRING, null, false, false),
+            'DateUTC' => [false, self::PROPERTY_TYPE_TIMESTAMP, '\\DateTimeInterface', false, false],
+            'User' => array(false, self::PROPERTY_TYPE_STRING, null, false, false),
+            'Details' => array(true, self::PROPERTY_TYPE_STRING, null, false, false)
+        );
+    }
+
+    /**
+     * Get a list of the supported HTTP Methods
+     *
+     * @return array
+     */
+    static function getSupportedMethods()
+    {
+        return array(
+            Request::METHOD_GET,
+            Request::METHOD_PUT
+        );
+    }
+
+    /**
+     * return the URI of the resource (if any)
+     *
+     * @return string
+     */
+    static function getResourceURI()
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getChanges()
+    {
+        return $this->_data['Changes'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getUser()
+    {
+        return $this->_data['User'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDetails()
+    {
+        return $this->_data['Details'];
+    }
+
+    /**
+     * @param string $value
+     * @return History
+     */
+    public function setDetails($value)
+    {
+        $this->propertyUpdated('Details', $value);
+        $this->_data['Details'] = $value;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function isPageable()
+    {
+        return false;
+    }
+
+    static function getAPIStem()
+    {
+        return '';
+    }
+
+    static function getRootNodeName()
+    {
+        // TODO: Implement getRootNodeName() method.
+    }
+}

--- a/src/XeroPHP/Traits/HistoryTrait.php
+++ b/src/XeroPHP/Traits/HistoryTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace XeroPHP\Traits;
+
+use XeroPHP\Models\Accounting\History;
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\URL;
+use XeroPHP\Exception;
+use XeroPHP\Helpers;
+
+trait HistoryTrait
+{
+    public function addHistory(History $history)
+    {
+        /**
+         * @var Object $this
+         */
+        $uri = sprintf('%s/%s/History', $this::getResourceURI(), $this->getGUID());
+
+        $url = new URL($this->_application, $uri);
+        $request = new Request($this->_application, $url, Request::METHOD_POST);
+
+        $request->setBody(Helpers::arrayToXML(['HistoryRecords' => [($history->toStringArray())]]));
+        $request->send();
+
+        $response = $request->getResponse();
+
+        return $this;
+    }
+
+    public function getHistory()
+    {
+        /**
+         * @var Object $this
+         */
+        if ($this->hasGUID() === false) {
+            throw new Exception(
+                'History/Notes are only available to objects that exist remotely.'
+            );
+        }
+
+        $uri = sprintf(
+            '%s/%s/History',
+            $this::getResourceURI(),
+            $this->getGUID()
+        );
+
+        $url = new URL($this->_application, $uri);
+        $request = new Request($this->_application, $url, Request::METHOD_GET);
+        $request->send();
+
+        $historyEntries = [];
+        foreach ($request->getResponse()->getElements() as $element) {
+            $history = new History($this->_application);
+            $history->fromStringArray($element);
+            $historyEntries[] = $history;
+        }
+
+        return $historyEntries;
+    }
+}


### PR DESCRIPTION
This PR adds support for HistoryRecords (a.k.a Notes) on Contacts in Xero. 

Xero API docs: https://developer.xero.com/documentation/api/history-and-notes

It should be fairly easy to extend this to the other objects which support HistoryRecords by adding the HistoryTrait to those models.