### PR TITLE
Remove remaining references to deprecated Object class

### DIFF
--- a/generator/templates/model.twig
+++ b/generator/templates/model.twig
@@ -12,7 +12,7 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\{{ class }};
 {% endfor %}
 
-class {{ model.ClassName }} extends Remote\Object
+class {{ model.ClassName }} extends Remote\Model
 {
 
 {% if model.SupportsPDF %}

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -318,7 +318,7 @@ abstract class Application
         //Just get one type to compare with, doesn't matter which.
         $current_object = $objects[0];
         /**
-         * @var Object $type
+         * @var Remote\Model $type
          */
         $type = get_class($current_object);
         $has_guid = $checkGuid ? $current_object->hasGUID() : true;
@@ -377,14 +377,14 @@ abstract class Application
             if ($meta[Remote\Model::KEY_SAVE_DIRECTLY] && $object->isDirty($property_name)) {
                 //Then actually save
                 $property_objects = $object->$property_name;
-                /** @var Object $property_type */
+                /** @var Remote\Model $property_type */
                 $property_type = get_class(current($property_objects));
 
                 $url = new URL($this, sprintf('%s/%s/%s', $object::getResourceURI(), $object->getGUID(), $property_type::getResourceURI()));
                 $request = new Request($this, $url, Request::METHOD_PUT);
 
                 $property_array = [];
-                /** @var Object[] $property_objects */
+                /** @var Remote\Model[] $property_objects */
                 foreach ($property_objects as $property_object) {
                     $property_array[] = $property_object->toStringArray(false);
                 }

--- a/src/XeroPHP/Models/Accounting/InvoiceReminder.php
+++ b/src/XeroPHP/Models/Accounting/InvoiceReminder.php
@@ -3,7 +3,7 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
-class InvoiceReminder extends Remote\Object
+class InvoiceReminder extends Remote\Model
 {
 
 

--- a/src/XeroPHP/Remote/Collection.php
+++ b/src/XeroPHP/Remote/Collection.php
@@ -8,7 +8,7 @@ class Collection extends \ArrayObject
      * Holds a list of objects that hold child references to the collection.
      * todo - 2.x make this more elegant.
      *
-     * @var Object[]
+     * @var Model[]
      */
     protected $_associated_objects;
 
@@ -28,7 +28,7 @@ class Collection extends \ArrayObject
         if (isset($this[$index])) {
             foreach ($this->_associated_objects as $parent_property => $object) {
                 /**
-                 * @var Object $object
+                 * @var Model $object
                  */
                 $object->setDirty($parent_property);
             }
@@ -39,7 +39,7 @@ class Collection extends \ArrayObject
     /**
      * Remove a specific object from the collection
      *
-     * @param Object $object
+     * @param Model $object
      */
     public function remove(Model $object)
     {
@@ -57,7 +57,7 @@ class Collection extends \ArrayObject
     {
         foreach ($this->_associated_objects as $parent_property => $object) {
             /**
-             * @var Object $object
+             * @var Model $object
              */
             $object->setDirty($parent_property);
         }

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -6,7 +6,7 @@ use XeroPHP\Application;
 use XeroPHP\Helpers;
 
 /**
- * Class Object
+ * Class Model
  * @package XeroPHP\Remote
  *
  * todo - at 2.x, move this into the root of the project and refer to it as a model.
@@ -425,7 +425,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     /**
      * @param string $property
-     * @param Object $object
+     * @param Model $object
      */
     public function addAssociatedObject($property, Model $object)
     {

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -289,7 +289,7 @@ class Query
         $elements = new Collection();
         foreach ($request->getResponse()->getElements() as $element) {
             /**
-             * @var Object $built_element
+             * @var Model $built_element
              */
             $built_element = new $from_class($this->app);
             $built_element->fromStringArray($element);

--- a/src/XeroPHP/Traits/AttachmentTrait.php
+++ b/src/XeroPHP/Traits/AttachmentTrait.php
@@ -12,7 +12,7 @@ trait AttachmentTrait
     public function addAttachment(Attachment $attachment, $include_online = false)
     {
         /**
-         * @var Object $this
+         * @var \XeroPHP\Remote\Model $this
          */
         $uri = sprintf('%s/%s/Attachments/%s', $this::getResourceURI(), $this->getGUID(), rawurlencode($attachment->getFileName()));
 
@@ -40,7 +40,7 @@ trait AttachmentTrait
     public function getAttachments()
     {
         /**
-         * @var Object $this
+         * @var \XeroPHP\Remote\Model $this
          */
         if ($this->hasGUID() === false) {
             throw new Exception(

--- a/src/XeroPHP/Traits/HistoryTrait.php
+++ b/src/XeroPHP/Traits/HistoryTrait.php
@@ -13,7 +13,7 @@ trait HistoryTrait
     public function addHistory(History $history)
     {
         /**
-         * @var Object $this
+         * @var \XeroPHP\Remote\Model $this
          */
         $uri = sprintf('%s/%s/History', $this::getResourceURI(), $this->getGUID());
 
@@ -31,7 +31,7 @@ trait HistoryTrait
     public function getHistory()
     {
         /**
-         * @var Object $this
+         * @var \XeroPHP\Remote\Model $this
          */
         if ($this->hasGUID() === false) {
             throw new Exception(

--- a/src/XeroPHP/Traits/SendEmailTrait.php
+++ b/src/XeroPHP/Traits/SendEmailTrait.php
@@ -19,7 +19,7 @@ trait SendEmailTrait
          * Documentation here: 
          * https://developer.xero.com/documentation/api/invoices#email
          *
-         * @var Object $this
+         * @var \XeroPHP\Remote\Model $this
          */
         $uri = sprintf('%s/%s/Email', $this::getResourceURI(), $this->getGUID());
         


### PR DESCRIPTION
Removing all remaining references to the deprecated `Object` class. See https://github.com/calcinai/xero-php/pull/331

Although someplace it is being used when the variable is actually a string, I just wanted to swap out the class and will look at that in another PR. e.g. `$type = get_class($current_object);` is marked as a Model class, but is just a string of the class.