### PR TITLE
Add missing doc types

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -100,7 +100,6 @@ abstract class Application
     /**
     * @param string $config
     * @param mixed $option
-    * @param mixed $value
     * @return mixed
     * @throws Exception
     */
@@ -178,8 +177,8 @@ abstract class Application
     /**
      * As you should never have a GUID for a non-existent object, will throw a NotFoundExceptioon
      *
-     * @param $model
-     * @param $guid
+     * @param string $model
+     * @param string $guid
      * @return Remote\Model|null
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
@@ -213,7 +212,7 @@ abstract class Application
     /**
      * Filter by comma separated string of guid's
      *
-     * @param $model
+     * @param string $model
      * @param string $guids
      * @return Collection
      * @throws Exception

--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -96,7 +96,7 @@ class Helpers
      * It only contains a fraction of the rules from its predecessor,
      * so only good for a quick basic singularisation.
      *
-     * @param $string
+     * @param string $string
      * @return mixed
      */
     public static function singularize($string)
@@ -201,7 +201,7 @@ class Helpers
      * There were a lot more seemingly redundant transformations in
      * the SimpleOAuth class.
      *
-     * @param $string
+     * @param string $string
      * @return string
      */
     public static function escape($string)

--- a/src/XeroPHP/Remote/Collection.php
+++ b/src/XeroPHP/Remote/Collection.php
@@ -21,7 +21,7 @@ class Collection extends \ArrayObject
     /**
      * Remove an item at a specific index
      *
-     * @param $index
+     * @param mixed $index
      */
     public function removeAt($index)
     {

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -115,7 +115,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Manually set a property as dirty
      *
-     * @param $property
+     * @param string $property
      * @return self
      */
     public function setDirty($property)
@@ -173,8 +173,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Load an assoc array into the instance of the object $property => $value
      * $replace_data - replace existing data
      *
-     * @param $input_array
-     * @param $replace_data
+     * @param array $input_array
+     * @param bool $replace_data
      */
     public function fromStringArray($input_array, $replace_data = false)
     {
@@ -255,8 +255,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Convert properties to strings, based on the types parsed.
      *
-     * @param $type
-     * @param $value
+     * @param string $type
+     * @param mixed $value
      * @return string
      */
     public static function castToString($type, $value)
@@ -297,9 +297,9 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Cast the values to PHP types.
      *
-     * @param $type
-     * @param $value
-     * @param $php_type
+     * @param string $type
+     * @param mixed $value
+     * @param string $php_type
      * @return bool|\DateTimeInterface|float|int|string
      */
     public static function castFromString($type, $value, $php_type)
@@ -435,7 +435,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Magic method for testing if properties exist
      *
-     * @param $property
+     * @param string $property
      * @return bool
      */
     public function __isset($property)
@@ -446,7 +446,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Magic getter for accessing properties directly
      *
-     * @param $property
+     * @param string $property
      * @return mixed
      */
     public function __get($property)
@@ -464,8 +464,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Magic setter for setting properties directly
      *
-     * @param $property
-     * @param $value
+     * @param string $property
+     * @param mixed $value
      * @return mixed
      */
     public function __set($property, $value)
@@ -499,7 +499,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * If the object supports a specific HTTP method
      *
-     * @param $method
+     * @param string $method
      * @return bool
      */
     public static function supportsMethod($method)

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -141,7 +141,7 @@ class Request
     }
 
     /**
-     * @param $key string Name of the header
+     * @param string $key Name of the header
      * @return null|string Header or null if not defined
      */
     public function getHeader($key)
@@ -169,8 +169,8 @@ class Request
     }
 
     /**
-     * @param $key string Name of the header
-     * @param $val string Value of the header
+     * @param string $key Name of the header
+     * @param string $val Value of the header
      *
      * @return $this
      */

--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -37,7 +37,7 @@ class URL
 
     /**
      * @param Application $app
-     * @param $endpoint
+     * @param string $endpoint
      * @param null $api
      * @throws Exception
      */

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -81,8 +81,8 @@ class Webhook
     /**
      * Validates the calculated signature against the given x-xero-signature header
      *
-     * @param  string $signature value from
-     * @return [type]            [description]
+     * @param  string $signature
+     * @return boolean
      */
     public function validate($signature)
     {


### PR DESCRIPTION
So were a bunch of doc blocks with missing parameter type information. I've added the type information.

I know that there are also a bunch of methods without doc blocks, but I wanted to fix up what was currently existing first.

I hope you don't mind me sending through some of these incremental changes. Trying to keep them small and focused for you so it isn't to much work to review them.

~There are some missing types in the `src/XeroPHP/Models/*` classes, but as they are generated I figured I see if I can fix that in the generator, rather than on the classes themselves.~

I just saw that you no longer use the generator. I'll leave this PR as it is and deal with the Models folder at a later date.