### PR TITLE
Update webhook doc blocks and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,40 @@ To set the `IncludeOnline` flag on the attachment, pass `true` as the second par
 PDF - Models that support PDF export will inherit a ```->getPDF()``` method, which returns the raw content of the PDF.  Currently this is limited to Invoices and CreditNotes.
 
 Refer to the [examples](examples) for more complex usage and nested/related objects.  There's also [a sample PHP app](https://github.com/XeroAPI/xero-php-sample-app) using this library.
+
+## Webhooks
+
+If you are receiving webhooks from Xero there is `Webhook` class that can help with handling the request and parsing the associated event list.
+
+```php
+$webhook = new Webhook($application, $request->getContent());
+
+/**
+ * @return int
+ */
+$webhook->getFirstEventSequence();
+
+/**
+ * @return int
+ */
+$webhook->getLastEventSequence();
+
+/**
+ * @return \XeroPHP\Webhook\Event[]
+ */
+$webhook->getEvents();
+```
+
+See: [Webhooks documentation](https://developer.xero.com/documentation/webhooks/overview)
+
+### Validating Webhooks
+
+To ensure the webhooks are coming from Xero you should validate the incoming request header that Xero provides.
+
+```php
+if (! $webhook->validate($request->headers->get('x-xero-signature'))) {
+    throw new Exception('This request did not come from Xero');
+}
+```
+
+See: [Signature documentation](https://developer.xero.com/documentation/webhooks/configuring-your-server#intent)

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -2,9 +2,6 @@
 
 namespace XeroPHP;
 
-/**
- * Represents a webhook and it's associated event list
- */
 class Webhook
 {
     /**
@@ -29,11 +26,10 @@ class Webhook
     private $webhookEvent;
 
     /**
-     * Parse a webhook payload from Xero
-     *
-     * @param \XeroPHP\Application $application the application the webhook was delivered to
-     * @param string $payload raw json payload
-     * @param mixed $event class name used for dependency injection
+     * @param \XeroPHP\Application $application
+     * @param string $payload
+     * @param string|null $event
+     * @return void
      * @throws \XeroPHP\Application\Exception
      */
     public function __construct($application, $payload, $event = null)
@@ -69,9 +65,7 @@ class Webhook
     }
 
     /**
-     * Returns the calculated signature of the payload and your signing key
-     *
-     * @return string hashed payload
+     * @return string
      */
     public function getSignature()
     {
@@ -79,10 +73,8 @@ class Webhook
     }
 
     /**
-     * Validates the calculated signature against the given x-xero-signature header
-     *
-     * @param  string $signature value from
-     * @return [type]            [description]
+     * @param string $signature
+     * @return bool
      */
     public function validate($signature)
     {
@@ -90,7 +82,7 @@ class Webhook
     }
 
     /**
-     * @return int first event sequence ID
+     * @return int
      */
     public function getFirstEventSequence()
     {
@@ -98,7 +90,7 @@ class Webhook
     }
 
     /**
-     * @return int last event sequence ID
+     * @return int
      */
     public function getLastEventSequence()
     {
@@ -106,9 +98,7 @@ class Webhook
     }
 
     /**
-     * Parses and returns a list of events for this webhook
-     *
-     * @return \XeroPHP\Webhook\Event[] list of events
+     * @return \XeroPHP\Webhook\Event[]
      */
     public function getEvents()
     {


### PR DESCRIPTION
This is the start of a round of PRs I'd like to do to improve:

1. The doc blocks.
2. The readme documentation.

In this PR I have:

- Added / fixed the doc blocks to each method.
- Removed parameter descriptions as these seemed like they didn't add anything.
- Put some docs in the readme to help with the usage of the class instead of the parameter comments.