### PR TITLE
Use hash_equals() or polyfill for signature validation

### DIFF
--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -208,4 +208,47 @@ class Helpers
     {
         return rawurlencode($string);
     }
+
+    /**
+     * @param $knownString string
+     * @param $userInput string
+     * @return bool
+     * @see https://github.com/symfony/polyfill-php56
+     */
+    public static function hashEquals($knownString, $userInput)
+    {
+        if (PHP_VERSION_ID >= 50600) {
+            return hash_equals($knownString, $userInput);
+        }
+
+        if (! is_string($knownString)) {
+            trigger_error('Expected known_string to be a string, '.gettype($knownString).' given', E_USER_WARNING);
+            return false;
+        }
+
+        if (! is_string($userInput)) {
+            trigger_error('Expected user_input to be a string, '.gettype($userInput).' given', E_USER_WARNING);
+            return false;
+        }
+
+        if (extension_loaded('mbstring')) {
+            $knownLen = mb_strlen($knownString, '8bit');
+            $userLen = mb_strlen($userInput, '8bit');
+        } else {
+            $knownLen = strlen($knownString);
+            $userLen = strlen($userInput);
+        }
+
+        if ($knownLen !== $userLen) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $knownLen; ++$i) {
+            $result |= ord($knownString[$i]) ^ ord($userInput[$i]);
+        }
+
+        return $result === 0;
+    }
 }

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -2,6 +2,8 @@
 
 namespace XeroPHP;
 
+use XeroPHP\Helpers;
+
 class Webhook
 {
     /**
@@ -78,7 +80,7 @@ class Webhook
      */
     public function validate($signature)
     {
-        return $this->getSignature() === $signature;
+        return Helpers::hashEquals($this->getSignature(), $signature);
     }
 
     /**


### PR DESCRIPTION
Fixes the timing attack vector for webhook validation.

If the version is greater than 5.6, use the hash_equals() method, if not it falls through to the Symfony polyfill.

Huge thanks to @timacdonald for picking this up.