### PR TITLE
Add php-cs-fixer as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.7",
         "fabpot/goutte": "~2.0",
-        "twig/twig": "1.16.2"
+        "twig/twig": "1.16.2",
+        "friendsofphp/php-cs-fixer": "^2.14"
     },
 
     "repositories": [


### PR DESCRIPTION
This PR adds the PHP Code Style fixer to the dev dependencies. As this is only a dev dependency it has no impact on the production composer requirements and is not a breaking change.

Having it as a dependency means you will be able to run it in C.I. once that is setup to utilise it and also run it locally with:

```
$ ./vendor/bin/php-cs-fixer fix
```