### PR TITLE
Coding style: align_multiline_comment

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -98,12 +98,12 @@ abstract class Application
     }
 
     /**
-    * @param string $config
-    * @param mixed $option
-    * @param mixed $value
-    * @return mixed
-    * @throws Exception
-    */
+     * @param string $config
+     * @param mixed $option
+     * @param mixed $value
+     * @return mixed
+     * @throws Exception
+     */
     public function getConfigOption($config, $option)
     {
         if (!isset($this->getConfig($config)[$option])) {

--- a/src/XeroPHP/Models/Accounting/Account.php
+++ b/src/XeroPHP/Models/Accounting/Account.php
@@ -76,7 +76,7 @@ class Account extends Remote\Model
 
     /**
      * The Xero identifier for an account – specified as a string following the endpoint name
-e.g.
+     * e.g.
      * /297c2dc5-cc47-4afd-8ec8-74990b8761e9
      *
      * @property string AccountID

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -21,7 +21,7 @@ class ContactGroup extends Remote\Model
 
     /**
      * The Xero identifier for an contact group – specified as a string following the endpoint name.
-e.g.
+     * e.g.
      * /297c2dc5-cc47-4afd-8ec8-74990b8761e9
      *
      * @property string ContactGroupID

--- a/src/XeroPHP/Models/Accounting/Employee.php
+++ b/src/XeroPHP/Models/Accounting/Employee.php
@@ -34,7 +34,7 @@ class Employee extends Remote\Model
     /**
      * Link to an external resource, for example, an employee record in an external system. You can specify
      * the URL element.
-The description of the link is auto-generated in the form “Go to <App name>”.
+     * The description of the link is auto-generated in the form “Go to <App name>”.
      * <App name> refers to the Xero application name that is making the API call.
      *
      * @property ExternalLink ExternalLink

--- a/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
@@ -45,7 +45,7 @@ class DeductionType extends Remote\Model
      * you time when setting up the employee deductions. If you choose not to set an amount here, you can
      * enter the amounts to be deducted on a per employee basis. Only applicable when DeductionCategory is
      * AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT,
-SECTION125PLAN
+     * SECTION125PLAN
      *
      * @property float StandardAmount
      */
@@ -56,9 +56,9 @@ SECTION125PLAN
      * publishes limits for certain deduction types each year. You can set a company maximum that is lower
      * than the IRS limit, depending on your plan requirements. If you don’t set a maximum, the deduction
      * will stop automatically when the IRS limit is reached.
-Only applicable when DeductionCategory is
+     * Only applicable when DeductionCategory is
      * AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT,
-SECTION125PLAN
+     * SECTION125PLAN
      *
      * @property float CompanyMax
      */

--- a/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
@@ -15,7 +15,7 @@ class TimeOffType extends Remote\Model
     /**
      * Select Unpaid Time Off to indicate that an employee will not get paid when taking this time off
      * type.
-If Paid Time Off is selected the employee will get paid when taking this time off type and you
+     * If Paid Time Off is selected the employee will get paid when taking this time off type and you
      * can accrue the liability on the Balance Sheet
      *
      * @property string TimeOffCategory

--- a/tests/Webhook/EventTest.php
+++ b/tests/Webhook/EventTest.php
@@ -32,8 +32,8 @@ class EventTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-    * @expectedException \XeroPHP\Application\Exception
-    */
+     * @expectedException \XeroPHP\Application\Exception
+     */
     public function testMalformedPayload()
     {
         $payload = '{"events":[{"resourceId":"44aa0707-f718-4f1c-8d53-f2da9ca59533","eventDateUtc":"2018-02-09T09:18:28.917Z","eventType":"UPDATE","eventCategory":"INVOICE","tenantId":"e629a03c-7ffe-4913-bd94-ff2fdb36a702","tenantType":"ORGANISATION"}],"firstEventSequence": 2,"lastEventSequence": 3, "entropy": "GATSEZXWIBPBRNQOTMOH"}';

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -33,8 +33,8 @@ class WebhookTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-    * @expectedException \XeroPHP\Application\Exception
-    */
+     * @expectedException \XeroPHP\Application\Exception
+     */
     public function testMalformedPayload()
     {
         $payload = 'not valid json';


### PR DESCRIPTION
Ensures that all multiline comments are aligned to the first asterisks 

See: https://github.com/FriendsOfPHP/PHP-CS-Fixer