### PR TITLE
Add error handling to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,47 @@ if (! $webhook->validate($request->headers->get('x-xero-signature'))) {
 ```
 
 See: [Signature documentation](https://developer.xero.com/documentation/webhooks/configuring-your-server#intent)
+
+## Handling Errors
+
+Your request to Xero may cause an error which you will want to handle. You might run into errors such as:
+
+- `HTTP 400 Bad Request` by sending invalid data, like a malformed email address.
+- `HTTP 503 Rate Limit Exceeded` by hitting the API to quickly in a short period of time.
+- `HTTP 400 Bad Request` by requesting a resource that does not exist.
+
+These are just a couple of examples and you should read the official documentation to find out more about the possible errors.
+
+### Thrown exceptions
+
+This library will parse the response Xero returns and throw an exception when it hits one of these errors. Below is a table showing the response code and corresponding exception that is thrown:
+
+| HTTP Code | Exception |
+| --------- | ------------- |
+| 400 Bad Request | `\XeroPHP\Remote\Exception\BadRequestException` |
+| 401 Unauthorized | `\XeroPHP\Remote\Exception\UnauthorizedException` |
+| 403 Forbidden | `\XeroPHP\Remote\Exception\UnauthorizedException` |
+| 404 Not Found | `\XeroPHP\Remote\Exception\NotFoundException` |
+| 500 Internal Error | `\XeroPHP\Remote\Exception\InternalErrorException` |
+| 501 Not Implemented | `\XeroPHP\Remote\Exception\NotImplementedException` |
+| 503 Rate Limit Exceeded | `\XeroPHP\Remote\Exception\RateLimitExceededException` |
+| 503 Not Available | `\XeroPHP\Remote\Exception\NotAvailableException` |
+| 503 Organisation offline | `\XeroPHP\Remote\Exception\OrganisationOfflineException` |
+
+See: [Response codes and errors documentation](https://developer.xero.com/documentation/api/http-response-codes)
+
+### Handling exceptions
+
+To catch and handle these exceptions you can wrap the request in a try / catch block and deal with each exception as needed.
+
+```php
+try {
+    $xero->save($invoice);
+} catch (NotFoundException $exception) {
+    // handle not found error
+} catch (RateLimitExceededException $exception) {
+    // handle rate limit error
+}
+```
+
+See: [Working with exceptions](https://secure.php.net/manual/en/language.exceptions.php)


### PR DESCRIPTION
Adds some documentation around handling exceptions including a response code to exception map and also a brief example of how to handle an exception in PHP. Both provide links to more comprehensive and official resources.