### PR TITLE
Coding style: concat_space

### DIFF
--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -66,7 +66,7 @@ class Client
                 //Needs escaping in the header, not in the QS
                 $oauth_params['oauth_signature'] = Helpers::escape($oauth_params['oauth_signature']);
 
-                $header = 'OAuth ' . Helpers::flattenAssocArray($oauth_params, '%s="%s"', ', ');
+                $header = 'OAuth '.Helpers::flattenAssocArray($oauth_params, '%s="%s"', ', ');
                 $request->setHeader(Request::HEADER_AUTHORIZATION, $header);
                 break;
 
@@ -203,7 +203,7 @@ class Client
      */
     private function getSigningSecret()
     {
-        $secret = $this->getConsumerSecret() . '&';
+        $secret = $this->getConsumerSecret().'&';
 
         if (null !== $token_secret = $this->getTokenSecret()) {
             $secret .= $token_secret;

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -120,7 +120,7 @@ class Request
         $info = curl_getinfo($ch);
 
         if ($response === false) {
-            throw new Exception('Curl error: ' . curl_error($ch));
+            throw new Exception('Curl error: '.curl_error($ch));
         }
 
         $this->response = new Response($this, $response, $info, $headers);

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -32,7 +32,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $expectedUrl = $this->application->getOAuthClient()->getAuthorizeURL();
         $this->assertSame($expectedUrl, $this->application->getAuthorizeURL());
         $this->assertSame(
-            $expectedUrl . '?oauth_token=test',
+            $expectedUrl.'?oauth_token=test',
             $this->application->getAuthorizeURL('test')
         );
     }


### PR DESCRIPTION
Use no space when concatenating strings.

See: https://github.com/FriendsOfPHP/PHP-CS-Fixer