### PR TITLE
Coding style: escape_implicit_backslashes

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -323,7 +323,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
                 // no break
             case self::PROPERTY_TYPE_DATE:
-                if (preg_match('/Date\((?<timestamp>[0-9\+\.]+)\)/', $value, $matches)) { //to catch stupid .net date serialisation
+                if (preg_match('/Date\\((?<timestamp>[0-9\\+\\.]+)\\)/', $value, $matches)) { //to catch stupid .net date serialisation
                     $value = $matches['timestamp'];
                 }
                 return new \DateTime($value, $timezone);

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -99,7 +99,7 @@ class Query
                 $this->where[] = sprintf('%s==%s', $args[0], $args[1]);
             } elseif (preg_match('/^(\'|")?(true|false)("|\')?$/i', $args[1])) {
                 $this->where[] = sprintf('%s=%s', $args[0], $args[1]);
-            } elseif (preg_match('/^([a-z]+)\.\1ID$/i', $args[0])
+            } elseif (preg_match('/^([a-z]+)\\.\\1ID$/i', $args[0])
                 && preg_match(
                     '/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i',
                     $args[1]

--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -92,7 +92,7 @@ class URL
                     $version = $xero_config['file_version'];
                     break;
                 default:
-                    throw new Exception('Invalid API passed to XeroPHP\URL::__construct(). Must be XeroPHP\URL::API_*');
+                    throw new Exception('Invalid API passed to XeroPHP\\URL::__construct(). Must be XeroPHP\\URL::API_*');
             }
 
             $this->path = sprintf('%s/%s/%s', $api, $version, $this->endpoint);

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -30,7 +30,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function test_allows_FQN_beginning_with_backslash_when_validating_model_class()
     {
-        $class = '\XeroPHP\Models\Accounting\Invoice';
+        $class = '\\XeroPHP\\Models\\Accounting\\Invoice';
 
         $this->assertSame(
             $this->instance()->validateModelClass($class),


### PR DESCRIPTION
Escape implicit backslashes in strings and heredocs to ease the understanding of which are special chars interpreted by PHP and which not.

See: https://github.com/FriendsOfPHP/PHP-CS-Fixer

**Note**: Some regex in this PR is changed, which naturally feels scary. But these are still equivalent. See / play here: https://3v4l.org/5COW1