### PR TITLE
Coding style: explicit_string_variable

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -92,7 +92,7 @@ abstract class Application
     public function getConfig($key)
     {
         if (!isset($this->config[$key])) {
-            throw new Exception("Invalid configuration key [$key]");
+            throw new Exception("Invalid configuration key [{$key}]");
         }
         return $this->config[$key];
     }
@@ -107,7 +107,7 @@ abstract class Application
     public function getConfigOption($config, $option)
     {
         if (!isset($this->getConfig($config)[$option])) {
-            throw new Exception("Invalid configuration option [$option]");
+            throw new Exception("Invalid configuration option [{$option}]");
         }
         return $this->getConfig($config)[$option];
     }
@@ -137,7 +137,7 @@ abstract class Application
     public function setConfigOption($config, $option, $value)
     {
         if (!isset($this->config[$config])) {
-            throw new Exception("Invalid configuration key [$config]");
+            throw new Exception("Invalid configuration key [{$config}]");
         }
         $this->config[$config][$option] = $value;
         return $this->config;
@@ -159,7 +159,7 @@ abstract class Application
         $class = $this->prependConfigNamespace($class);
 
         if (!class_exists($class)) {
-            throw new Exception("Class does not exist [$class]");
+            throw new Exception("Class does not exist [{$class}]");
         }
 
         return $class;

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -50,7 +50,7 @@ class Request
                 $this->method = $method;
                 break;
             default:
-                throw new Exception("Invalid request method [$method]");
+                throw new Exception("Invalid request method [{$method}]");
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
@@ -90,7 +90,7 @@ class Request
         $query_string = Helpers::flattenAssocArray($this->getParameters(), '%s=%s', '&', true);
 
         if (strlen($query_string) > 0) {
-            $full_uri .= "?$query_string";
+            $full_uri .= "?{$query_string}";
         }
         curl_setopt($ch, CURLOPT_URL, $full_uri);
 

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -65,7 +65,7 @@ class Event
 
         foreach ($fields as $required) {
             if (!isset($event[$required])) {
-                throw new \XeroPHP\Application\Exception("The event payload was malformed; missing required field $required");
+                throw new \XeroPHP\Application\Exception("The event payload was malformed; missing required field {$required}");
             }
 
             $this->{$required} = $event[$required];


### PR DESCRIPTION
Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.

See: https://github.com/FriendsOfPHP/PHP-CS-Fixer