### PR TITLE
Coding style: method_chaining_indentation

### DIFF
--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -807,8 +807,8 @@ class Invoice extends Remote\Model
         }
 
         return $this->onlineInvoiceRequest()
-                    ->send()
-                    ->getElements()[0]['OnlineInvoiceUrl'];
+            ->send()
+            ->getElements()[0]['OnlineInvoiceUrl'];
     }
 
     /**


### PR DESCRIPTION
Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.

See: https://github.com/calcinai/xero-php/compare/master...timacdonald:style_method_chaining_indentation?expand=1

**Note**: This one is my favourite fix...because it was my code before haha: https://github.com/timacdonald/xero-php/commit/f26af746e718fd04de92f22aa33bc81b0fb02838