### PR TITLE
Fix repeating invoice -> schedule -> due date type

### DIFF
--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -20,6 +20,11 @@ class PaymentTerm extends Remote\Model
      */
 
 
+     const DAYSAFTERBILLDATE = 'DAYSAFTERBILLDATE';
+     const DAYSAFTERBILLMONTH = 'DAYSAFTERBILLMONTH';
+     const OFCURRENTMONTH = 'OFCURRENTMONTH';
+     const OFFOLLOWINGMONTH = 'OFFOLLOWINGMONTH';
+
 
     /**
      * Get the resource uri of the class (Contacts) etc

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
@@ -122,7 +122,7 @@ class Schedule extends Remote\Model
             'Period' => [false, self::PROPERTY_TYPE_INT, null, false, false],
             'Unit' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'DueDate' => [false, self::PROPERTY_TYPE_INT, null, false, false],
-            'DueDateType' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'DueDateType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'StartDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
             'NextScheduledDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
             'EndDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false]

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
@@ -3,7 +3,6 @@
 namespace XeroPHP\Models\Accounting\RepeatingInvoice;
 
 use XeroPHP\Remote;
-use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 
 class Schedule extends Remote\Model
 {
@@ -27,9 +26,9 @@ class Schedule extends Remote\Model
      */
 
     /**
-     * See Payment Terms
+     * Get the due date type
      *
-     * @property PaymentTerm DueDateType
+     * @property string DueDateType
      */
 
     /**
@@ -123,7 +122,7 @@ class Schedule extends Remote\Model
             'Period' => [false, self::PROPERTY_TYPE_INT, null, false, false],
             'Unit' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'DueDate' => [false, self::PROPERTY_TYPE_INT, null, false, false],
-            'DueDateType' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\Organisation\\PaymentTerm', false, false],
+            'DueDateType' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'StartDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
             'NextScheduledDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
             'EndDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false]
@@ -193,7 +192,7 @@ class Schedule extends Remote\Model
     }
 
     /**
-     * @return PaymentTerm
+     * @return string
      */
     public function getDueDateType()
     {
@@ -201,10 +200,10 @@ class Schedule extends Remote\Model
     }
 
     /**
-     * @param PaymentTerm $value
+     * @param string $value
      * @return Schedule
      */
-    public function setDueDateType(PaymentTerm $value)
+    public function setDueDateType(string $value)
     {
         $this->propertyUpdated('DueDateType', $value);
         $this->_data['DueDateType'] = $value;

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
@@ -203,7 +203,7 @@ class Schedule extends Remote\Model
      * @param string $value
      * @return Schedule
      */
-    public function setDueDateType(string $value)
+    public function setDueDateType($value)
     {
         $this->propertyUpdated('DueDateType', $value);
         $this->_data['DueDateType'] = $value;


### PR DESCRIPTION
This PR fixes #257. 

The `DueDateType` specified in a repeating invoice schedule is provided as a string value from Xero.

In PHP the schedule looks like:

```php
"Schedule" => array:6 [
    "Period" => "12"
    "Unit" => "MONTHLY"
    "DueDate" => "5"
    "DueDateType" => "OFFOLLOWINGMONTH"
    "StartDate" => "2016-04-01T00:00:00"
    "NextScheduledDate" => "2019-03-01T00:00:00"
]
```

The problem is that the Schedule model uses `Organization\PaymentTerm` for the `DueDateType` property, resulting in a `PaymentTerm` instance with empty `Bills` and `Sales`. The string value "OFFOLLOWINGMONTH" is entirely lost.

It appears that `Organization\PaymentTerm` is the wrong model for a repeating invoice due date type. The nested `Bills` and `Sales` structure is used for Organizations and Contacts, but with a RepeatingInvoice Schedule it is a simple string.

I've already tested this PR and can successfully access the `DueDateType` property of my repeating invoices now.

Let me know if you'd prefer this to be an enum property with class constants. I wasn't sure how you'd want those constants named given the [lengthy payment term names](https://developer.xero.com/documentation/api/types#PaymentTerms). I also wasn't sure if you'd want the constants defined in the `Schedule` class that contains that `DueDateType` property, or if you'd rather put them in `Organization\PaymentTerm` even though we aren't using that model. And I figured since `Unit` was a string and not an enum I might get away with it. =)