### PR TITLE
Code style: modernize_types_casting

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -60,7 +60,7 @@ if ($oauth_session === null) {
     $request->send();
     $oauth_response = $request->getResponse()->getOAuthResponse();
 
-    $expires = time() + intval($oauth_response['oauth_expires_in']);
+    $expires = time() + (int) $oauth_response['oauth_expires_in'];
 
     setOAuthSession(
         $oauth_response['oauth_token'],
@@ -86,7 +86,7 @@ if ($oauth_session === null) {
         $request->send();
         $oauth_response = $request->getResponse()->getOAuthResponse();
 
-        $expires = time() + intval($oauth_response['oauth_expires_in']);
+        $expires = time() + (int) $oauth_response['oauth_expires_in'];
 
         setOAuthSession(
             $oauth_response['oauth_token'],

--- a/examples/public.php
+++ b/examples/public.php
@@ -94,7 +94,7 @@ function setOAuthSession($token, $secret, $expires = null)
 {
     // expires sends back an int
     if ($expires !== null) {
-        $expires = time() + intval($expires);
+        $expires = time() + (int) $expires;
     }
 
     $_SESSION['oauth'] = [

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -309,10 +309,10 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         switch ($type) {
 
             case self::PROPERTY_TYPE_INT:
-                return intval($value);
+                return (int) $value;
 
             case self::PROPERTY_TYPE_FLOAT:
-                return floatval($value);
+                return (float) $value;
 
             case self::PROPERTY_TYPE_BOOLEAN:
                 return in_array(strtolower($value), ['true', '1', 'yes']);

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -196,7 +196,7 @@ class Query
         if (!$from_class::isPageable()) {
             throw new Exception(sprintf('%s does not support paging.', $from_class));
         }
-        $this->page = intval($page);
+        $this->page = (int) $page;
 
         return $this;
     }
@@ -207,7 +207,7 @@ class Query
      */
     public function offset($offset = 0)
     {
-        $this->offset = intval($offset);
+        $this->offset = (int) $offset;
         return $this;
     }
 


### PR DESCRIPTION
Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer