### PR TITLE
Code style: no_empty_phpdoc

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -23,9 +23,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     const KEY_IS_ARRAY = 3;
     const KEY_SAVE_DIRECTLY = 4;
 
-    /**
-     *
-     */
+    
     const PROPERTY_TYPE_STRING = 'string';
     const PROPERTY_TYPE_INT = 'int';
     const PROPERTY_TYPE_FLOAT = 'float';


### PR DESCRIPTION
There should not be empty PHPDoc blocks.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer