### PR TITLE
Code style: no_leading_namespace_whitespace

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund.php
@@ -1,5 +1,5 @@
 <?php
-    namespace XeroPHP\Models\PayrollAU;
+namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;
 


### PR DESCRIPTION
The namespace declaration line shouldn't contain leading whitespace.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer