### PR TITLE
Code style: no_null_property_initialization

### DIFF
--- a/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
+++ b/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
@@ -11,7 +11,7 @@ class RateLimitExceededException extends Exception
 
     protected $code = Response::STATUS_RATE_LIMIT_EXCEEDED;
 
-    protected $rateLimitProblem = null;
+    protected $rateLimitProblem;
 
     public function setRateLimitProblem($rateLimitProblem)
     {


### PR DESCRIPTION
Properties MUST not be explicitly initialized with `null`.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer