### PR TITLE
Code style: no_unset_on_property

### DIFF
--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -91,7 +91,7 @@ class Client
      */
     private function resetOAuthParams()
     {
-        unset($this->oauth_params);
+        $this->oauth_params = null;
     }
 
     /**


### PR DESCRIPTION
Variables must be set `null` instead of using `(unset)` casting.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer