### PR TITLE
Code style: non_printable_character

### DIFF
--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -32,7 +32,7 @@ class Journal extends Remote\Model
      */
 
     /**
-     *  
+     *  
      *
      * @property string Reference
      */

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -14,13 +14,13 @@ use XeroPHP\Models\PayrollAU\Employee\SuperMembership;
 class Employee extends Remote\Model
 {
     /**
-     * First name of employee (max length = 35)
+     * First name of employee (max length = 35)
      *
      * @property string FirstName
      */
 
     /**
-     * Last name of employee (max length = 35)
+     * Last name of employee (max length = 35)
      *
      * @property string LastName
      */
@@ -45,19 +45,19 @@ class Employee extends Remote\Model
      */
 
     /**
-     * Title of the employee (max length = 10)
+     * Title of the employee (max length = 10)
      *
      * @property string Title
      */
 
     /**
-     * Middle name(s) of the employee (max length = 35)
+     * Middle name(s) of the employee (max length = 35)
      *
      * @property string MiddleNames
      */
 
     /**
-     * The email address for the employee (max length = 100)
+     * The email address for the employee (max length = 100)
      *
      * @property string Email
      */
@@ -69,13 +69,13 @@ class Employee extends Remote\Model
      */
 
     /**
-     * Employee mobile number (max length = 50)
+     * Employee mobile number (max length = 50)
      *
      * @property string Mobile
      */
 
     /**
-     * Employee’s twitter name, entered as @twittername (max length = 50)
+     * Employee’s twitter name, entered as @twittername (max length = 50)
      *
      * @property string TwitterUserName
      */
@@ -101,14 +101,14 @@ class Employee extends Remote\Model
      */
 
     /**
-     * JobTitle of the employee (max length = 50)
+     * JobTitle of the employee (max length = 50)
      *
      * @property string JobTitle
      */
 
     /**
      * Employees under an award scheme will be covered by a modern award classification. If you record a
-     * classification, it will be included on your payslips (max length = 100)
+     * classification, it will be included on your payslips (max length = 100)
      *
      * @property string Classification
      */

--- a/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
@@ -7,26 +7,26 @@ use XeroPHP\Remote;
 class BankAccount extends Remote\Model
 {
     /**
-     * The text that will appear on your employee’s bank statement when they receive payment (max length
+     * The text that will appear on your employee’s bank statement when they receive payment (max length
      * = 18)
      *
      * @property string StatementText
      */
 
     /**
-     * The name of the account (max length = 32)
+     * The name of the account (max length = 32)
      *
      * @property string AccountName
      */
 
     /**
-     * The BSB number of the account (length = 6)
+     * The BSB number of the account (length = 6)
      *
      * @property string BSB
      */
 
     /**
-     * The account number (max length = 9)
+     * The account number (max length = 9)
      *
      * @property string AccountNumber
      */

--- a/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
@@ -7,19 +7,19 @@ use XeroPHP\Remote;
 class HomeAddress extends Remote\Model
 {
     /**
-     * Address line 1 for employee home address (max length = 50)
+     * Address line 1 for employee home address (max length = 50)
      *
      * @property string AddressLine1
      */
 
     /**
-     * Address line 2 for employee home address (max length = 50)
+     * Address line 2 for employee home address (max length = 50)
      *
      * @property string AddressLine2
      */
 
     /**
-     * Suburb for employee home address (max length = 50)
+     * Suburb for employee home address (max length = 50)
      *
      * @property string City
      */
@@ -31,7 +31,7 @@ class HomeAddress extends Remote\Model
      */
 
     /**
-     * PostCode for employee home address (max length = 4)
+     * PostCode for employee home address (max length = 4)
      *
      * @property string PostalCode
      */

--- a/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
@@ -26,7 +26,7 @@ class LeaveBalance extends Remote\Model
      */
 
     /**
-     * The type of units as specified by the LeaveType (see PayItems)
+     * The type of units as specified by the LeaveType (see PayItems)
      *
      * @property PayItem[] TypeOfUnits
      */

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
@@ -25,13 +25,13 @@ class SuperLine extends Remote\Model
      */
 
     /**
-     *  Account code for the Expense Account. i.e 478
+     *  Account code for the Expense Account. i.e 478
      *
      * @property string ExpenseAccountCode
      */
 
     /**
-     *  Account code for the Liability Account. i.e 826
+     *  Account code for the Liability Account. i.e 826
      *
      * @property string LiabilityAccountCode
      */

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -26,7 +26,7 @@ class LeaveApplication extends Remote\Model
      */
 
     /**
-     * The title of the leave (max length = 50)
+     * The title of the leave (max length = 50)
      *
      * @property string Title
      */
@@ -44,7 +44,7 @@ class LeaveApplication extends Remote\Model
      */
 
     /**
-     * The Description of the Leave (max length = 200)
+     * The Description of the Leave (max length = 200)
      *
      * @property string Description
      */

--- a/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
@@ -7,7 +7,7 @@ use XeroPHP\Remote;
 class SuperFundProduct extends Remote\Model
 {
     /**
-     * The ABN of the Regulated SuperFund (e.g 40022701955)
+     * The ABN of the Regulated SuperFund (e.g 40022701955)
      *
      * @property string ABN
      */

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -15,13 +15,13 @@ use XeroPHP\Models\PayrollUS\Employee\TimeOffBalance;
 class Employee extends Remote\Model
 {
     /**
-     * First name of employee (max length = 35)
+     * First name of employee (max length = 35)
      *
      * @property string FirstName
      */
 
     /**
-     * Last name of employee (max length = 35)
+     * Last name of employee (max length = 35)
      *
      * @property string LastName
      */
@@ -39,7 +39,7 @@ class Employee extends Remote\Model
      */
 
     /**
-     * Middle name(s) of the employee (max length = 35)
+     * Middle name(s) of the employee (max length = 35)
      *
      * @property string MiddleNames
      */

--- a/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
@@ -37,13 +37,13 @@ class HomeAddress extends Remote\Model
      */
 
     /**
-     * The Latitude of employee home address
+     * The Latitude of employee home address
      *
      * @property string Lattitude
      */
 
     /**
-     * The Longitude of employee home address
+     * The Longitude of employee home address
      *
      * @property string Longitude
      */

--- a/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
@@ -37,13 +37,13 @@ class MailingAddress extends Remote\Model
      */
 
     /**
-     * The Latitude of employee home address
+     * The Latitude of employee home address
      *
      * @property string Lattitude
      */
 
     /**
-     * The Longitude of employee home address
+     * The Longitude of employee home address
      *
      * @property string Longitude
      */

--- a/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
@@ -26,7 +26,7 @@ class TimeOffBalance extends Remote\Model
      */
 
     /**
-     * The type of units as specified by the LeaveType (see PayItems)
+     * The type of units as specified by the LeaveType (see PayItems)
      *
      * @property PayItem[] TypeOfUnits
      */


### PR DESCRIPTION
Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer