### PR TITLE
Code style: not_operator_with_successor_space

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -49,7 +49,7 @@ if ($oauth_session === null) {
 
     printf('<a href="%s">Click here to Authorize</a>', $xero->getAuthorizeURL($oauth_response['oauth_token']));
     exit;
-} elseif (isset($oauth_session['session_handle']) && !isset($oauth_session['expires'])) {
+} elseif (isset($oauth_session['session_handle']) && ! isset($oauth_session['expires'])) {
     // If session is expired refresh the token
     $url = new URL($xero, URL::OAUTH_ACCESS_TOKEN);
     $request = new Request($xero, $url);
@@ -122,7 +122,7 @@ function setOAuthSession($token, $secret, $expires = null, $session_handle = nul
 function getOAuthSession()
 {
     //If it doesn't exist, return null
-    if (!isset($_SESSION['oauth'])) {
+    if (! isset($_SESSION['oauth'])) {
         return null;
     }
 

--- a/examples/public.php
+++ b/examples/public.php
@@ -107,7 +107,7 @@ function setOAuthSession($token, $secret, $expires = null)
 function getOAuthSession()
 {
     //If it doesn't exist or is expired, return null
-    if (!isset($_SESSION['oauth'])
+    if (! isset($_SESSION['oauth'])
         || ($_SESSION['oauth']['expires'] !== null
         && $_SESSION['oauth']['expires'] <= time())
     ) {

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -91,7 +91,7 @@ abstract class Application
      */
     public function getConfig($key)
     {
-        if (!isset($this->config[$key])) {
+        if (! isset($this->config[$key])) {
             throw new Exception("Invalid configuration key [{$key}]");
         }
         return $this->config[$key];
@@ -106,7 +106,7 @@ abstract class Application
      */
     public function getConfigOption($config, $option)
     {
-        if (!isset($this->getConfig($config)[$option])) {
+        if (! isset($this->getConfig($config)[$option])) {
             throw new Exception("Invalid configuration option [{$option}]");
         }
         return $this->getConfig($config)[$option];
@@ -136,7 +136,7 @@ abstract class Application
      */
     public function setConfigOption($config, $option, $value)
     {
-        if (!isset($this->config[$config])) {
+        if (! isset($this->config[$config])) {
             throw new Exception("Invalid configuration key [{$config}]");
         }
         $this->config[$config][$option] = $value;
@@ -158,7 +158,7 @@ abstract class Application
 
         $class = $this->prependConfigNamespace($class);
 
-        if (!class_exists($class)) {
+        if (! class_exists($class)) {
             throw new Exception("Class does not exist [{$class}]");
         }
 
@@ -272,7 +272,7 @@ abstract class Application
         //(special saving endpoints)
         $this->savePropertiesDirectly($object);
 
-        if (!$object->isDirty()) {
+        if (! $object->isDirty()) {
             return null;
         }
         $object->validate();
@@ -288,7 +288,7 @@ abstract class Application
             $object->setApplication($this);
         }
 
-        if (!$object::supportsMethod($method)) {
+        if (! $object::supportsMethod($method)) {
             throw new Exception(sprintf('%s doesn\'t support [%s] via the API', get_class($object), $method));
         }
 
@@ -418,7 +418,7 @@ abstract class Application
      */
     public function delete(Remote\Model $object)
     {
-        if (!$object::supportsMethod(Request::METHOD_DELETE)) {
+        if (! $object::supportsMethod(Request::METHOD_DELETE)) {
             throw new Exception(
                 sprintf(
                     '%s doesn\'t support [DELETE] via the API',

--- a/src/XeroPHP/Models/Accounting/Attachment.php
+++ b/src/XeroPHP/Models/Accounting/Attachment.php
@@ -144,11 +144,11 @@ class Attachment extends Model
      */
     public function getContent()
     {
-        if (!isset($this->content)) {
+        if (! isset($this->content)) {
             //If it's been created locally, you can just read it back.
             if (isset($this->local_handle)) {
                 rewind($this->local_handle);
-                while (!feof($this->local_handle)) {
+                while (! feof($this->local_handle)) {
                     $this->content .= fread($this->local_handle, 8192);
                 }
                 //Otherwise, if it can be fetched

--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -306,7 +306,7 @@ class BankTransaction extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;

--- a/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
@@ -322,7 +322,7 @@ class LineItem extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -539,7 +539,7 @@ class Contact extends Remote\Model
     public function addContactPerson(ContactPerson $value)
     {
         $this->propertyUpdated('ContactPersons', $value);
-        if (!isset($this->_data['ContactPersons'])) {
+        if (! isset($this->_data['ContactPersons'])) {
             $this->_data['ContactPersons'] = new Remote\Collection();
         }
         $this->_data['ContactPersons'][] = $value;
@@ -638,7 +638,7 @@ class Contact extends Remote\Model
     public function addAddress(Address $value)
     {
         $this->propertyUpdated('Addresses', $value);
-        if (!isset($this->_data['Addresses'])) {
+        if (! isset($this->_data['Addresses'])) {
             $this->_data['Addresses'] = new Remote\Collection();
         }
         $this->_data['Addresses'][] = $value;
@@ -661,7 +661,7 @@ class Contact extends Remote\Model
     public function addPhone(Phone $value)
     {
         $this->propertyUpdated('Phones', $value);
-        if (!isset($this->_data['Phones'])) {
+        if (! isset($this->_data['Phones'])) {
             $this->_data['Phones'] = new Remote\Collection();
         }
         $this->_data['Phones'][] = $value;
@@ -792,7 +792,7 @@ class Contact extends Remote\Model
     public function addSalesTrackingCategory(TrackingCategory $value)
     {
         $this->propertyUpdated('SalesTrackingCategories', $value);
-        if (!isset($this->_data['SalesTrackingCategories'])) {
+        if (! isset($this->_data['SalesTrackingCategories'])) {
             $this->_data['SalesTrackingCategories'] = new Remote\Collection();
         }
         $this->_data['SalesTrackingCategories'][] = $value;
@@ -815,7 +815,7 @@ class Contact extends Remote\Model
     public function addPurchasesTrackingCategory(TrackingCategory $value)
     {
         $this->propertyUpdated('PurchasesTrackingCategories', $value);
-        if (!isset($this->_data['PurchasesTrackingCategories'])) {
+        if (! isset($this->_data['PurchasesTrackingCategories'])) {
             $this->_data['PurchasesTrackingCategories'] = new Remote\Collection();
         }
         $this->_data['PurchasesTrackingCategories'][] = $value;
@@ -876,7 +876,7 @@ class Contact extends Remote\Model
     public function addPaymentTerm(PaymentTerm $value)
     {
         $this->propertyUpdated('PaymentTerms', $value);
-        if (!isset($this->_data['PaymentTerms'])) {
+        if (! isset($this->_data['PaymentTerms'])) {
             $this->_data['PaymentTerms'] = new Remote\Collection();
         }
         $this->_data['PaymentTerms'][] = $value;
@@ -918,7 +918,7 @@ class Contact extends Remote\Model
     public function addContactGroup(ContactGroup $value)
     {
         $this->propertyUpdated('ContactGroups', $value);
-        if (!isset($this->_data['ContactGroups'])) {
+        if (! isset($this->_data['ContactGroups'])) {
             $this->_data['ContactGroups'] = new Remote\Collection();
         }
         $this->_data['ContactGroups'][] = $value;

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -192,7 +192,7 @@ class ContactGroup extends Remote\Model
     public function addContact(Contact $value)
     {
         $this->propertyUpdated('Contacts', $value);
-        if (!isset($this->_data['Contacts'])) {
+        if (! isset($this->_data['Contacts'])) {
             $this->_data['Contacts'] = new Remote\Collection();
         }
         $this->_data['Contacts'][] = $value;

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -359,7 +359,7 @@ class CreditNote extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;
@@ -619,7 +619,7 @@ class CreditNote extends Remote\Model
     public function addAllocation(Allocation $value)
     {
         $this->propertyUpdated('Allocations', $value);
-        if (!isset($this->_data['Allocations'])) {
+        if (! isset($this->_data['Allocations'])) {
             $this->_data['Allocations'] = new Remote\Collection();
         }
         $this->_data['Allocations'][] = $value;

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim.php
@@ -180,7 +180,7 @@ class ExpenseClaim extends Remote\Model
     public function addReceipt(Receipt $value)
     {
         $this->propertyUpdated('Receipts', $value);
-        if (!isset($this->_data['Receipts'])) {
+        if (! isset($this->_data['Receipts'])) {
             $this->_data['Receipts'] = new Remote\Collection();
         }
         $this->_data['Receipts'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -377,7 +377,7 @@ class Invoice extends Remote\Model
      */
     public function getLineItems()
     {
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
 
@@ -391,7 +391,7 @@ class Invoice extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;
@@ -802,7 +802,7 @@ class Invoice extends Remote\Model
      */
     public function getOnlineInvoiceUrl()
     {
-        if (!$this->hasGUID()) {
+        if (! $this->hasGUID()) {
             throw new Exception('Unable to retrieve the online invoice URL as the invoice has no GUID');
         }
 

--- a/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
@@ -356,7 +356,7 @@ class LineItem extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -316,7 +316,7 @@ class Journal extends Remote\Model
     public function addJournalLine(JournalLine $value)
     {
         $this->propertyUpdated('JournalLines', $value);
-        if (!isset($this->_data['JournalLines'])) {
+        if (! isset($this->_data['JournalLines'])) {
             $this->_data['JournalLines'] = new Remote\Collection();
         }
         $this->_data['JournalLines'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
@@ -394,7 +394,7 @@ class JournalLine extends Remote\Model
     public function addTrackingCategory(TrackingCategory $value)
     {
         $this->propertyUpdated('TrackingCategories', $value);
-        if (!isset($this->_data['TrackingCategories'])) {
+        if (! isset($this->_data['TrackingCategories'])) {
             $this->_data['TrackingCategories'] = new Remote\Collection();
         }
         $this->_data['TrackingCategories'][] = $value;

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -219,7 +219,7 @@ class ManualJournal extends Remote\Model
     public function addJournalLine(JournalLine $value)
     {
         $this->propertyUpdated('JournalLines', $value);
-        if (!isset($this->_data['JournalLines'])) {
+        if (! isset($this->_data['JournalLines'])) {
             $this->_data['JournalLines'] = new Remote\Collection();
         }
         $this->_data['JournalLines'][] = $value;

--- a/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
@@ -220,7 +220,7 @@ class JournalLine extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Organisation.php
+++ b/src/XeroPHP/Models/Accounting/Organisation.php
@@ -804,7 +804,7 @@ class Organisation extends Remote\Model
     public function addAddress(Address $value)
     {
         $this->propertyUpdated('Addresses', $value);
-        if (!isset($this->_data['Addresses'])) {
+        if (! isset($this->_data['Addresses'])) {
             $this->_data['Addresses'] = new Remote\Collection();
         }
         $this->_data['Addresses'][] = $value;
@@ -827,7 +827,7 @@ class Organisation extends Remote\Model
     public function addPhone(Phone $value)
     {
         $this->propertyUpdated('Phones', $value);
-        if (!isset($this->_data['Phones'])) {
+        if (! isset($this->_data['Phones'])) {
             $this->_data['Phones'] = new Remote\Collection();
         }
         $this->_data['Phones'][] = $value;
@@ -850,7 +850,7 @@ class Organisation extends Remote\Model
     public function addExternalLink(ExternalLink $value)
     {
         $this->propertyUpdated('ExternalLinks', $value);
-        if (!isset($this->_data['ExternalLinks'])) {
+        if (! isset($this->_data['ExternalLinks'])) {
             $this->_data['ExternalLinks'] = new Remote\Collection();
         }
         $this->_data['ExternalLinks'][] = $value;
@@ -873,7 +873,7 @@ class Organisation extends Remote\Model
     public function addPaymentTerm(PaymentTerm $value)
     {
         $this->propertyUpdated('PaymentTerms', $value);
-        if (!isset($this->_data['PaymentTerms'])) {
+        if (! isset($this->_data['PaymentTerms'])) {
             $this->_data['PaymentTerms'] = new Remote\Collection();
         }
         $this->_data['PaymentTerms'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -113,7 +113,7 @@ class PaymentTerm extends Remote\Model
     public function addBill(Bill $value)
     {
         $this->propertyUpdated('Bills', $value);
-        if (!isset($this->_data['Bills'])) {
+        if (! isset($this->_data['Bills'])) {
             $this->_data['Bills'] = new Remote\Collection();
         }
         $this->_data['Bills'][] = $value;
@@ -136,7 +136,7 @@ class PaymentTerm extends Remote\Model
     public function addSale(Sale $value)
     {
         $this->propertyUpdated('Sales', $value);
-        if (!isset($this->_data['Sales'])) {
+        if (! isset($this->_data['Sales'])) {
             $this->_data['Sales'] = new Remote\Collection();
         }
         $this->_data['Sales'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -367,7 +367,7 @@ class Overpayment extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;
@@ -563,7 +563,7 @@ class Overpayment extends Remote\Model
     public function addAllocation(Allocation $value)
     {
         $this->propertyUpdated('Allocations', $value);
-        if (!isset($this->_data['Allocations'])) {
+        if (! isset($this->_data['Allocations'])) {
             $this->_data['Allocations'] = new Remote\Collection();
         }
         $this->_data['Allocations'][] = $value;
@@ -586,7 +586,7 @@ class Overpayment extends Remote\Model
     public function addPayment(Payment $value)
     {
         $this->propertyUpdated('Payments', $value);
-        if (!isset($this->_data['Payments'])) {
+        if (! isset($this->_data['Payments'])) {
             $this->_data['Payments'] = new Remote\Collection();
         }
         $this->_data['Payments'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Prepayment.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment.php
@@ -360,7 +360,7 @@ class Prepayment extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;
@@ -556,7 +556,7 @@ class Prepayment extends Remote\Model
     public function addAllocation(Allocation $value)
     {
         $this->propertyUpdated('Allocations', $value);
-        if (!isset($this->_data['Allocations'])) {
+        if (! isset($this->_data['Allocations'])) {
             $this->_data['Allocations'] = new Remote\Collection();
         }
         $this->_data['Allocations'][] = $value;

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder.php
@@ -308,7 +308,7 @@ class PurchaseOrder extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
@@ -315,7 +315,7 @@ class LineItem extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Receipt.php
+++ b/src/XeroPHP/Models/Accounting/Receipt.php
@@ -256,7 +256,7 @@ class Receipt extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;

--- a/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
@@ -300,7 +300,7 @@ class LineItem extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
@@ -263,7 +263,7 @@ class RepeatingInvoice extends Remote\Model
     public function addLineItem(LineItem $value)
     {
         $this->propertyUpdated('LineItems', $value);
-        if (!isset($this->_data['LineItems'])) {
+        if (! isset($this->_data['LineItems'])) {
             $this->_data['LineItems'] = new Remote\Collection();
         }
         $this->_data['LineItems'][] = $value;

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
@@ -331,7 +331,7 @@ class LineItem extends Remote\Model
     public function addTracking(TrackingCategory $value)
     {
         $this->propertyUpdated('Tracking', $value);
-        if (!isset($this->_data['Tracking'])) {
+        if (! isset($this->_data['Tracking'])) {
             $this->_data['Tracking'] = new Remote\Collection();
         }
         $this->_data['Tracking'][] = $value;

--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -229,7 +229,7 @@ class TaxRate extends Remote\Model
     public function addTaxComponent(TaxComponent $value)
     {
         $this->propertyUpdated('TaxComponents', $value);
-        if (!isset($this->_data['TaxComponents'])) {
+        if (! isset($this->_data['TaxComponents'])) {
             $this->_data['TaxComponents'] = new Remote\Collection();
         }
         $this->_data['TaxComponents'][] = $value;

--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -236,7 +236,7 @@ class TrackingCategory extends Remote\Model
     public function addOption(TrackingOption $value)
     {
         $this->propertyUpdated('Options', $value);
-        if (!isset($this->_data['Options'])) {
+        if (! isset($this->_data['Options'])) {
             $this->_data['Options'] = new Remote\Collection();
         }
         $this->_data['Options'][] = $value;

--- a/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
+++ b/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
@@ -191,7 +191,7 @@ class BookDepreciationSetting extends Remote\Model
     public function addeffectiveLifeYear($value)
     {
         $this->propertyUpdated('effectiveLifeYears', $value);
-        if (!isset($this->_data['effectiveLifeYears'])) {
+        if (! isset($this->_data['effectiveLifeYears'])) {
             $this->_data['effectiveLifeYears'] = new Remote\Collection();
         }
         $this->_data['effectiveLifeYears'][] = $value;

--- a/src/XeroPHP/Models/Files/Folder.php
+++ b/src/XeroPHP/Models/Files/Folder.php
@@ -249,7 +249,7 @@ class Folder extends Remote\Model
     public function addFile(File $value)
     {
         $this->propertyUpdated('Files', $value);
-        if (!isset($this->_data['Files'])) {
+        if (! isset($this->_data['Files'])) {
             $this->_data['Files'] = new Remote\Collection();
         }
         $this->_data['Files'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -686,7 +686,7 @@ class Employee extends Remote\Model
     public function addBankAccount(BankAccount $value)
     {
         $this->propertyUpdated('BankAccounts', $value);
-        if (!isset($this->_data['BankAccounts'])) {
+        if (! isset($this->_data['BankAccounts'])) {
             $this->_data['BankAccounts'] = new Remote\Collection();
         }
         $this->_data['BankAccounts'][] = $value;
@@ -728,7 +728,7 @@ class Employee extends Remote\Model
     public function addOpeningBalance(OpeningBalance $value)
     {
         $this->propertyUpdated('OpeningBalances', $value);
-        if (!isset($this->_data['OpeningBalances'])) {
+        if (! isset($this->_data['OpeningBalances'])) {
             $this->_data['OpeningBalances'] = new Remote\Collection();
         }
         $this->_data['OpeningBalances'][] = $value;
@@ -751,7 +751,7 @@ class Employee extends Remote\Model
     public function addLeaveBalance(LeaveBalance $value)
     {
         $this->propertyUpdated('LeaveBalances', $value);
-        if (!isset($this->_data['LeaveBalances'])) {
+        if (! isset($this->_data['LeaveBalances'])) {
             $this->_data['LeaveBalances'] = new Remote\Collection();
         }
         $this->_data['LeaveBalances'][] = $value;
@@ -774,7 +774,7 @@ class Employee extends Remote\Model
     public function addSuperMembership(SuperMembership $value)
     {
         $this->propertyUpdated('SuperMemberships', $value);
-        if (!isset($this->_data['SuperMemberships'])) {
+        if (! isset($this->_data['SuperMemberships'])) {
             $this->_data['SuperMemberships'] = new Remote\Collection();
         }
         $this->_data['SuperMemberships'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
@@ -185,7 +185,7 @@ class LeaveBalance extends Remote\Model
     public function addTypeOfUnit(PayItem $value)
     {
         $this->propertyUpdated('TypeOfUnits', $value);
-        if (!isset($this->_data['TypeOfUnits'])) {
+        if (! isset($this->_data['TypeOfUnits'])) {
             $this->_data['TypeOfUnits'] = new Remote\Collection();
         }
         $this->_data['TypeOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
@@ -245,7 +245,7 @@ class OpeningBalance extends Remote\Model
     public function addEarningsLine(EarningsLine $value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -268,7 +268,7 @@ class OpeningBalance extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -310,7 +310,7 @@ class OpeningBalance extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -137,7 +137,7 @@ class PayTemplate extends Remote\Model
     public function addEarningsLine(EarningsLine $value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -160,7 +160,7 @@ class PayTemplate extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -183,7 +183,7 @@ class PayTemplate extends Remote\Model
     public function addSuperLine(SuperLine $value)
     {
         $this->propertyUpdated('SuperLines', $value);
-        if (!isset($this->_data['SuperLines'])) {
+        if (! isset($this->_data['SuperLines'])) {
             $this->_data['SuperLines'] = new Remote\Collection();
         }
         $this->_data['SuperLines'][] = $value;
@@ -206,7 +206,7 @@ class PayTemplate extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;
@@ -229,7 +229,7 @@ class PayTemplate extends Remote\Model
     public function addLeaveLine(LeaveLine $value)
     {
         $this->propertyUpdated('LeaveLines', $value);
-        if (!isset($this->_data['LeaveLines'])) {
+        if (! isset($this->_data['LeaveLines'])) {
             $this->_data['LeaveLines'] = new Remote\Collection();
         }
         $this->_data['LeaveLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -294,7 +294,7 @@ class LeaveApplication extends Remote\Model
     public function addLeavePeriod(LeavePeriod $value)
     {
         $this->propertyUpdated('LeavePeriods', $value);
-        if (!isset($this->_data['LeavePeriods'])) {
+        if (! isset($this->_data['LeavePeriods'])) {
             $this->_data['LeavePeriods'] = new Remote\Collection();
         }
         $this->_data['LeavePeriods'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -133,7 +133,7 @@ class PayItem extends Remote\Model
     public function addEarningsRate(EarningsRate $value)
     {
         $this->propertyUpdated('EarningsRates', $value);
-        if (!isset($this->_data['EarningsRates'])) {
+        if (! isset($this->_data['EarningsRates'])) {
             $this->_data['EarningsRates'] = new Remote\Collection();
         }
         $this->_data['EarningsRates'][] = $value;
@@ -156,7 +156,7 @@ class PayItem extends Remote\Model
     public function addDeductionType(DeductionType $value)
     {
         $this->propertyUpdated('DeductionTypes', $value);
-        if (!isset($this->_data['DeductionTypes'])) {
+        if (! isset($this->_data['DeductionTypes'])) {
             $this->_data['DeductionTypes'] = new Remote\Collection();
         }
         $this->_data['DeductionTypes'][] = $value;
@@ -179,7 +179,7 @@ class PayItem extends Remote\Model
     public function addLeaveType(LeaveType $value)
     {
         $this->propertyUpdated('LeaveTypes', $value);
-        if (!isset($this->_data['LeaveTypes'])) {
+        if (! isset($this->_data['LeaveTypes'])) {
             $this->_data['LeaveTypes'] = new Remote\Collection();
         }
         $this->_data['LeaveTypes'][] = $value;
@@ -202,7 +202,7 @@ class PayItem extends Remote\Model
     public function addReimbursementType(ReimbursementType $value)
     {
         $this->propertyUpdated('ReimbursementTypes', $value);
-        if (!isset($this->_data['ReimbursementTypes'])) {
+        if (! isset($this->_data['ReimbursementTypes'])) {
             $this->_data['ReimbursementTypes'] = new Remote\Collection();
         }
         $this->_data['ReimbursementTypes'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Payslip.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip.php
@@ -307,7 +307,7 @@ class Payslip extends Remote\Model
     public function addEarningsLine(EarningsLine $value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -330,7 +330,7 @@ class Payslip extends Remote\Model
     public function addTimesheetEarningsLine(TimesheetEarningsLine $value)
     {
         $this->propertyUpdated('TimesheetEarningsLines', $value);
-        if (!isset($this->_data['TimesheetEarningsLines'])) {
+        if (! isset($this->_data['TimesheetEarningsLines'])) {
             $this->_data['TimesheetEarningsLines'] = new Remote\Collection();
         }
         $this->_data['TimesheetEarningsLines'][] = $value;
@@ -353,7 +353,7 @@ class Payslip extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -376,7 +376,7 @@ class Payslip extends Remote\Model
     public function addLeaveAccrualLine(LeaveAccrualLine $value)
     {
         $this->propertyUpdated('LeaveAccrualLines', $value);
-        if (!isset($this->_data['LeaveAccrualLines'])) {
+        if (! isset($this->_data['LeaveAccrualLines'])) {
             $this->_data['LeaveAccrualLines'] = new Remote\Collection();
         }
         $this->_data['LeaveAccrualLines'][] = $value;
@@ -399,7 +399,7 @@ class Payslip extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;
@@ -422,7 +422,7 @@ class Payslip extends Remote\Model
     public function addSuperannuationLine(SuperannuationLine $value)
     {
         $this->propertyUpdated('SuperannuationLines', $value);
-        if (!isset($this->_data['SuperannuationLines'])) {
+        if (! isset($this->_data['SuperannuationLines'])) {
             $this->_data['SuperannuationLines'] = new Remote\Collection();
         }
         $this->_data['SuperannuationLines'][] = $value;
@@ -445,7 +445,7 @@ class Payslip extends Remote\Model
     public function addTaxLine(TaxLine $value)
     {
         $this->propertyUpdated('TaxLines', $value);
-        if (!isset($this->_data['TaxLines'])) {
+        if (! isset($this->_data['TaxLines'])) {
             $this->_data['TaxLines'] = new Remote\Collection();
         }
         $this->_data['TaxLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
@@ -198,7 +198,7 @@ class DeductionLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
@@ -158,7 +158,7 @@ class LeaveEarningsLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Setting.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting.php
@@ -124,7 +124,7 @@ class Setting extends Remote\Model
     public function addAccount(Account $value)
     {
         $this->propertyUpdated('Accounts', $value);
-        if (!isset($this->_data['Accounts'])) {
+        if (! isset($this->_data['Accounts'])) {
             $this->_data['Accounts'] = new Remote\Collection();
         }
         $this->_data['Accounts'][] = $value;
@@ -147,7 +147,7 @@ class Setting extends Remote\Model
     public function addTrackingCategory(TrackingCategory $value)
     {
         $this->propertyUpdated('TrackingCategories', $value);
-        if (!isset($this->_data['TrackingCategories'])) {
+        if (! isset($this->_data['TrackingCategories'])) {
             $this->_data['TrackingCategories'] = new Remote\Collection();
         }
         $this->_data['TrackingCategories'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet.php
@@ -212,7 +212,7 @@ class Timesheet extends Remote\Model
     public function addTimesheetLine(TimesheetLine $value)
     {
         $this->propertyUpdated('TimesheetLines', $value);
-        if (!isset($this->_data['TimesheetLines'])) {
+        if (! isset($this->_data['TimesheetLines'])) {
             $this->_data['TimesheetLines'] = new Remote\Collection();
         }
         $this->_data['TimesheetLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -159,7 +159,7 @@ class TimesheetLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -693,7 +693,7 @@ class Employee extends Remote\Model
     public function addSalaryAndWage(SalaryAndWage $value)
     {
         $this->propertyUpdated('SalaryAndWages', $value);
-        if (!isset($this->_data['SalaryAndWages'])) {
+        if (! isset($this->_data['SalaryAndWages'])) {
             $this->_data['SalaryAndWages'] = new Remote\Collection();
         }
         $this->_data['SalaryAndWages'][] = $value;
@@ -716,7 +716,7 @@ class Employee extends Remote\Model
     public function addWorkLocation(WorkLocation $value)
     {
         $this->propertyUpdated('WorkLocations', $value);
-        if (!isset($this->_data['WorkLocations'])) {
+        if (! isset($this->_data['WorkLocations'])) {
             $this->_data['WorkLocations'] = new Remote\Collection();
         }
         $this->_data['WorkLocations'][] = $value;
@@ -777,7 +777,7 @@ class Employee extends Remote\Model
     public function addOpeningBalance(OpeningBalance $value)
     {
         $this->propertyUpdated('OpeningBalances', $value);
-        if (!isset($this->_data['OpeningBalances'])) {
+        if (! isset($this->_data['OpeningBalances'])) {
             $this->_data['OpeningBalances'] = new Remote\Collection();
         }
         $this->_data['OpeningBalances'][] = $value;
@@ -800,7 +800,7 @@ class Employee extends Remote\Model
     public function addTimeOffBalance(TimeOffBalance $value)
     {
         $this->propertyUpdated('TimeOffBalances', $value);
-        if (!isset($this->_data['TimeOffBalances'])) {
+        if (! isset($this->_data['TimeOffBalances'])) {
             $this->_data['TimeOffBalances'] = new Remote\Collection();
         }
         $this->_data['TimeOffBalances'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
@@ -174,7 +174,7 @@ class OpeningBalance extends Remote\Model
     public function addEarningsLine(EarningsLine $value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -197,7 +197,7 @@ class OpeningBalance extends Remote\Model
     public function addBenefitLine(BenefitLine $value)
     {
         $this->propertyUpdated('BenefitLines', $value);
-        if (!isset($this->_data['BenefitLines'])) {
+        if (! isset($this->_data['BenefitLines'])) {
             $this->_data['BenefitLines'] = new Remote\Collection();
         }
         $this->_data['BenefitLines'][] = $value;
@@ -220,7 +220,7 @@ class OpeningBalance extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -243,7 +243,7 @@ class OpeningBalance extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
@@ -214,7 +214,7 @@ class PayTemplate extends Remote\Model
     public function addEarningsLine($value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -237,7 +237,7 @@ class PayTemplate extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -260,7 +260,7 @@ class PayTemplate extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;
@@ -283,7 +283,7 @@ class PayTemplate extends Remote\Model
     public function addBenefitLine(BenefitLine $value)
     {
         $this->propertyUpdated('BenefitLines', $value);
-        if (!isset($this->_data['BenefitLines'])) {
+        if (! isset($this->_data['BenefitLines'])) {
             $this->_data['BenefitLines'] = new Remote\Collection();
         }
         $this->_data['BenefitLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
@@ -136,7 +136,7 @@ class PaymentMethod extends Remote\Model
     public function addBankAccount(BankAccount $value)
     {
         $this->propertyUpdated('BankAccounts', $value);
-        if (!isset($this->_data['BankAccounts'])) {
+        if (! isset($this->_data['BankAccounts'])) {
             $this->_data['BankAccounts'] = new Remote\Collection();
         }
         $this->_data['BankAccounts'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
@@ -192,7 +192,7 @@ class TimeOffBalance extends Remote\Model
     public function addTypeOfUnit(PayItem $value)
     {
         $this->propertyUpdated('TypeOfUnits', $value);
-        if (!isset($this->_data['TypeOfUnits'])) {
+        if (! isset($this->_data['TypeOfUnits'])) {
             $this->_data['TypeOfUnits'] = new Remote\Collection();
         }
         $this->_data['TypeOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/PayItem.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem.php
@@ -141,7 +141,7 @@ class PayItem extends Remote\Model
     public function addEarningsType(EarningsType $value)
     {
         $this->propertyUpdated('EarningsTypes', $value);
-        if (!isset($this->_data['EarningsTypes'])) {
+        if (! isset($this->_data['EarningsTypes'])) {
             $this->_data['EarningsTypes'] = new Remote\Collection();
         }
         $this->_data['EarningsTypes'][] = $value;
@@ -164,7 +164,7 @@ class PayItem extends Remote\Model
     public function addBenefitType(BenefitType $value)
     {
         $this->propertyUpdated('BenefitTypes', $value);
-        if (!isset($this->_data['BenefitTypes'])) {
+        if (! isset($this->_data['BenefitTypes'])) {
             $this->_data['BenefitTypes'] = new Remote\Collection();
         }
         $this->_data['BenefitTypes'][] = $value;
@@ -187,7 +187,7 @@ class PayItem extends Remote\Model
     public function addDeductionType(DeductionType $value)
     {
         $this->propertyUpdated('DeductionTypes', $value);
-        if (!isset($this->_data['DeductionTypes'])) {
+        if (! isset($this->_data['DeductionTypes'])) {
             $this->_data['DeductionTypes'] = new Remote\Collection();
         }
         $this->_data['DeductionTypes'][] = $value;
@@ -210,7 +210,7 @@ class PayItem extends Remote\Model
     public function addReimbursementType(ReimbursementType $value)
     {
         $this->propertyUpdated('ReimbursementTypes', $value);
-        if (!isset($this->_data['ReimbursementTypes'])) {
+        if (! isset($this->_data['ReimbursementTypes'])) {
             $this->_data['ReimbursementTypes'] = new Remote\Collection();
         }
         $this->_data['ReimbursementTypes'][] = $value;
@@ -233,7 +233,7 @@ class PayItem extends Remote\Model
     public function addTimeOffType(TimeOffType $value)
     {
         $this->propertyUpdated('TimeOffTypes', $value);
-        if (!isset($this->_data['TimeOffTypes'])) {
+        if (! isset($this->_data['TimeOffTypes'])) {
             $this->_data['TimeOffTypes'] = new Remote\Collection();
         }
         $this->_data['TimeOffTypes'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Paystub.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub.php
@@ -355,7 +355,7 @@ class Paystub extends Remote\Model
     public function addEarning($value)
     {
         $this->propertyUpdated('Earnings', $value);
-        if (!isset($this->_data['Earnings'])) {
+        if (! isset($this->_data['Earnings'])) {
             $this->_data['Earnings'] = new Remote\Collection();
         }
         $this->_data['Earnings'][] = $value;
@@ -378,7 +378,7 @@ class Paystub extends Remote\Model
     public function addDeduction($value)
     {
         $this->propertyUpdated('Deductions', $value);
-        if (!isset($this->_data['Deductions'])) {
+        if (! isset($this->_data['Deductions'])) {
             $this->_data['Deductions'] = new Remote\Collection();
         }
         $this->_data['Deductions'][] = $value;
@@ -420,7 +420,7 @@ class Paystub extends Remote\Model
     public function addReimbursement($value)
     {
         $this->propertyUpdated('Reimbursements', $value);
-        if (!isset($this->_data['Reimbursements'])) {
+        if (! isset($this->_data['Reimbursements'])) {
             $this->_data['Reimbursements'] = new Remote\Collection();
         }
         $this->_data['Reimbursements'][] = $value;
@@ -481,7 +481,7 @@ class Paystub extends Remote\Model
     public function addEarningsLine(EarningsLine $value)
     {
         $this->propertyUpdated('EarningsLines', $value);
-        if (!isset($this->_data['EarningsLines'])) {
+        if (! isset($this->_data['EarningsLines'])) {
             $this->_data['EarningsLines'] = new Remote\Collection();
         }
         $this->_data['EarningsLines'][] = $value;
@@ -504,7 +504,7 @@ class Paystub extends Remote\Model
     public function addLeaveEarningsLine(LeaveEarningsLine $value)
     {
         $this->propertyUpdated('LeaveEarningsLines', $value);
-        if (!isset($this->_data['LeaveEarningsLines'])) {
+        if (! isset($this->_data['LeaveEarningsLines'])) {
             $this->_data['LeaveEarningsLines'] = new Remote\Collection();
         }
         $this->_data['LeaveEarningsLines'][] = $value;
@@ -527,7 +527,7 @@ class Paystub extends Remote\Model
     public function addTimesheetEarningsLine(TimesheetEarningsLine $value)
     {
         $this->propertyUpdated('TimesheetEarningsLines', $value);
-        if (!isset($this->_data['TimesheetEarningsLines'])) {
+        if (! isset($this->_data['TimesheetEarningsLines'])) {
             $this->_data['TimesheetEarningsLines'] = new Remote\Collection();
         }
         $this->_data['TimesheetEarningsLines'][] = $value;
@@ -550,7 +550,7 @@ class Paystub extends Remote\Model
     public function addDeductionLine(DeductionLine $value)
     {
         $this->propertyUpdated('DeductionLines', $value);
-        if (!isset($this->_data['DeductionLines'])) {
+        if (! isset($this->_data['DeductionLines'])) {
             $this->_data['DeductionLines'] = new Remote\Collection();
         }
         $this->_data['DeductionLines'][] = $value;
@@ -573,7 +573,7 @@ class Paystub extends Remote\Model
     public function addReimbursementLine(ReimbursementLine $value)
     {
         $this->propertyUpdated('ReimbursementLines', $value);
-        if (!isset($this->_data['ReimbursementLines'])) {
+        if (! isset($this->_data['ReimbursementLines'])) {
             $this->_data['ReimbursementLines'] = new Remote\Collection();
         }
         $this->_data['ReimbursementLines'][] = $value;
@@ -596,7 +596,7 @@ class Paystub extends Remote\Model
     public function addBenefitLine(BenefitLine $value)
     {
         $this->propertyUpdated('BenefitLines', $value);
-        if (!isset($this->_data['BenefitLines'])) {
+        if (! isset($this->_data['BenefitLines'])) {
             $this->_data['BenefitLines'] = new Remote\Collection();
         }
         $this->_data['BenefitLines'][] = $value;
@@ -619,7 +619,7 @@ class Paystub extends Remote\Model
     public function addTimeOffLine(TimeOffLine $value)
     {
         $this->propertyUpdated('TimeOffLines', $value);
-        if (!isset($this->_data['TimeOffLines'])) {
+        if (! isset($this->_data['TimeOffLines'])) {
             $this->_data['TimeOffLines'] = new Remote\Collection();
         }
         $this->_data['TimeOffLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
@@ -158,7 +158,7 @@ class EarningsLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
@@ -158,7 +158,7 @@ class LeaveEarningsLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
@@ -158,7 +158,7 @@ class TimesheetEarningsLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Setting.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting.php
@@ -116,7 +116,7 @@ class Setting extends Remote\Model
     public function addAccount(Account $value)
     {
         $this->propertyUpdated('Accounts', $value);
-        if (!isset($this->_data['Accounts'])) {
+        if (! isset($this->_data['Accounts'])) {
             $this->_data['Accounts'] = new Remote\Collection();
         }
         $this->_data['Accounts'][] = $value;
@@ -139,7 +139,7 @@ class Setting extends Remote\Model
     public function addTrackingCategory(TrackingCategory $value)
     {
         $this->propertyUpdated('TrackingCategories', $value);
-        if (!isset($this->_data['TrackingCategories'])) {
+        if (! isset($this->_data['TrackingCategories'])) {
             $this->_data['TrackingCategories'] = new Remote\Collection();
         }
         $this->_data['TrackingCategories'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet.php
@@ -212,7 +212,7 @@ class Timesheet extends Remote\Model
     public function addTimesheetLine(TimesheetLine $value)
     {
         $this->propertyUpdated('TimesheetLines', $value);
-        if (!isset($this->_data['TimesheetLines'])) {
+        if (! isset($this->_data['TimesheetLines'])) {
             $this->_data['TimesheetLines'] = new Remote\Collection();
         }
         $this->_data['TimesheetLines'][] = $value;

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -167,7 +167,7 @@ class TimesheetLine extends Remote\Model
     public function addNumberOfUnit($value)
     {
         $this->propertyUpdated('NumberOfUnits', $value);
-        if (!isset($this->_data['NumberOfUnits'])) {
+        if (! isset($this->_data['NumberOfUnits'])) {
             $this->_data['NumberOfUnits'] = new Remote\Collection();
         }
         $this->_data['NumberOfUnits'][] = $value;

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -181,11 +181,11 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             $php_type = $meta[self::KEY_PHP_TYPE];
 
             //If set and NOT replace data, continue
-            if (!$replace_data && isset($this->_data[$property])) {
+            if (! $replace_data && isset($this->_data[$property])) {
                 continue;
             }
 
-            if (!isset($input_array[$property])) {
+            if (! isset($input_array[$property])) {
                 $this->_data[$property] = null;
                 continue;
             }
@@ -225,12 +225,12 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     {
         $out = [];
         foreach (static::getProperties() as $property => $meta) {
-            if (!isset($this->_data[$property])) {
+            if (! isset($this->_data[$property])) {
                 continue;
             }
 
             //if we only want the dirty props, stop here
-            if ($dirty_only && !isset($this->_dirty[$property])) {
+            if ($dirty_only && ! isset($this->_dirty[$property])) {
                 continue;
             }
 
@@ -355,8 +355,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             $mandatory = $meta[self::KEY_MANDATORY];
 
             //If it's got a GUID, it's already going to be valid almost all cases
-            if (!$this->hasGUID() && $mandatory) {
-                if (!isset($this->_data[$property]) || empty($this->_data[$property])) {
+            if (! $this->hasGUID() && $mandatory) {
+                if (! isset($this->_data[$property]) || empty($this->_data[$property])) {
                     throw new Exception(
                         sprintf(
                             '%s::$%s is mandatory and is either missing or empty.',
@@ -480,7 +480,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     protected function propertyUpdated($property, $value)
     {
-        if (!isset($this->_data[$property]) || $this->_data[$property] !== $value) {
+        if (! isset($this->_data[$property]) || $this->_data[$property] !== $value) {
             //If this object can update itself, set its own dirty flag, otherwise, set its parent's.
             if (count(array_intersect($this::getSupportedMethods(), [Request::METHOD_PUT, Request::METHOD_POST])) > 0) {
                 //Object can update itself

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -104,7 +104,7 @@ class Client
     private function getOAuthParams()
     {
         //this needs to be stateful until the request is signed, then it gets unset
-        if (!isset($this->oauth_params)) {
+        if (! isset($this->oauth_params)) {
             $this->oauth_params = [
                 'oauth_consumer_key' => $this->getConsumerKey(),
                 'oauth_signature_method' => $this->getSignatureMethod(),
@@ -223,7 +223,7 @@ class Client
     private function getNonce($length = 20)
     {
         $parts = explode('.', number_format(microtime(true), 22, '.', ''));
-        if (!isset($parts[1])) {
+        if (! isset($parts[1])) {
             $parts[1] = 0;
         }
         $nonce = base_convert($parts[1], 10, 36);

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -193,7 +193,7 @@ class Query
          * @var ObjectInterface $from_class
          */
         $from_class = $this->from_class;
-        if (!$from_class::isPageable()) {
+        if (! $from_class::isPageable()) {
             throw new Exception(sprintf('%s does not support paging.', $from_class));
         }
         $this->page = (int) $page;
@@ -248,7 +248,7 @@ class Query
         // Concatenate where statements
         $where = $this->getWhere();
 
-        if (!empty($where)) {
+        if (! empty($where)) {
             $request->setParameter('where', $where);
         }
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -108,7 +108,7 @@ class Request
             list($name, $value) = explode(':', $header, 2);
             $name = strtolower(trim($name));
             $value = trim($value);
-            if (!array_key_exists($name, $headers)) {
+            if (! array_key_exists($name, $headers)) {
                 $headers[$name] = [];
             }
             $headers[$name][] = $value;
@@ -146,7 +146,7 @@ class Request
      */
     public function getHeader($key)
     {
-        if (!isset($this->headers[$key])) {
+        if (! isset($this->headers[$key])) {
             return null;
         }
         return $this->headers[$key];

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -71,7 +71,7 @@ class Response
         switch ($this->status) {
             case Response::STATUS_BAD_REQUEST:
                 //This catches actual app errors
-                if (isset($this->root_error) && !empty($this->root_error)) {
+                if (isset($this->root_error) && ! empty($this->root_error)) {
                     $message = sprintf('%s (%s)', $this->root_error['message'], implode(', ', $this->element_errors));
                     $message .= $this->parseBadRequest();
                     throw new BadRequestException($message, $this->root_error['code']);
@@ -122,7 +122,7 @@ class Response
      */
     private function parseBadRequest()
     {
-        if (!empty($this->elements)) {
+        if (! empty($this->elements)) {
             $field_errors = [];
             foreach ($this->elements as $n => $element) {
                 if (isset($element['ValidationErrors'])) {

--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -80,7 +80,7 @@ class URL
         $this->endpoint = $endpoint;
 
         //Check here that the URI hasn't been set by one of the OAuth methods and handle as normal
-        if (!isset($this->path)) {
+        if (! isset($this->path)) {
             switch ($api) {
                 case self::API_CORE:
                     $version = $xero_config['core_version'];

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -16,7 +16,7 @@ trait PDFTrait
      */
     public function getPDF()
     {
-        if (!$this->hasGUID()) {
+        if (! $this->hasGUID()) {
             throw new Exception('PDF files are only available to objects that exist remotely.');
         }
 

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -51,9 +51,9 @@ class Webhook
         }
 
         // bail if we don't have all the fields we are expecting
-        if (!isset($this->payload['events']) ||
-            !isset($this->payload['firstEventSequence']) ||
-            !isset($this->payload['lastEventSequence'])) {
+        if (! isset($this->payload['events']) ||
+            ! isset($this->payload['firstEventSequence']) ||
+            ! isset($this->payload['lastEventSequence'])) {
             throw new Application\Exception("The webhook payload was malformed");
         }
     }

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -64,7 +64,7 @@ class Event
         ];
 
         foreach ($fields as $required) {
-            if (!isset($event[$required])) {
+            if (! isset($event[$required])) {
                 throw new \XeroPHP\Application\Exception("The event payload was malformed; missing required field {$required}");
             }
 


### PR DESCRIPTION
Logical NOT operators (!) should have one trailing whitespace.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer