### PR TITLE
Code style: php_unit_set_up_tear_down_visibility

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -12,7 +12,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
      */
     private $application;
 
-    public function setUp()
+    protected function setUp()
     {
         $config = [
             'oauth' => [

--- a/tests/Webhook/EventTest.php
+++ b/tests/Webhook/EventTest.php
@@ -13,7 +13,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     private $application;
 
-    public function setUp()
+    protected function setUp()
     {
         $config = [
             'oauth' => [

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -14,7 +14,7 @@ class WebhookTest extends \PHPUnit_Framework_TestCase
      */
     private $application;
 
-    public function setUp()
+    protected function setUp()
     {
         $config = [
             'oauth' => [


### PR DESCRIPTION
Changes the visibility of the setUp() and tearDown() functions of PHPUnit to protected, to match the PHPUnit TestCase.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer