### PR TITLE
Code style: phpdoc_add_missing_param_annotation

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -311,6 +311,8 @@ abstract class Application
 
     /**
      * @param Collection|array $objects
+     * @param mixed $checkGuid
+     * @param mixed $replace_data
      * @return Remote\Response
      * @throws Exception
      */

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -220,6 +220,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Convert the object into an array, and any non-primitives to string.
      *
      * @return array
+     * @param mixed $dirty_only
      */
     public function toStringArray($dirty_only = false)
     {


### PR DESCRIPTION
PHPDoc should contain @param for all params.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer