### PR TITLE
Code style: phpdoc_order

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -86,8 +86,8 @@ abstract class Application
 
     /**
      * @param mixed $key
-     * @return mixed
      * @throws Exception
+     * @return mixed
      */
     public function getConfig($key)
     {
@@ -101,8 +101,8 @@ abstract class Application
      * @param string $config
      * @param mixed $option
      * @param mixed $value
-     * @return mixed
      * @throws Exception
+     * @return mixed
      */
     public function getConfigOption($config, $option)
     {
@@ -131,8 +131,8 @@ abstract class Application
      * @param string $config
      * @param mixed $option
      * @param mixed $value
-     * @return array
      * @throws Exception
+     * @return array
      */
     public function setConfigOption($config, $option, $value)
     {
@@ -147,8 +147,8 @@ abstract class Application
      * Validates and expands the provided model class to a full PHP class
      *
      * @param string $class
-     * @return string
      * @throws Exception
+     * @return string
      */
     public function validateModelClass($class)
     {
@@ -183,9 +183,9 @@ abstract class Application
      *
      * @param $model
      * @param $guid
-     * @return Remote\Model|null
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
+     * @return Remote\Model|null
      */
     public function loadByGUID($model, $guid)
     {
@@ -218,9 +218,9 @@ abstract class Application
      *
      * @param $model
      * @param string $guids
-     * @return Collection
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
+     * @return Collection
      */
     public function loadByGUIDs($model, $guids)
     {
@@ -251,8 +251,8 @@ abstract class Application
 
     /**
      * @param string $model
-     * @return Query
      * @throws Remote\Exception
+     * @return Query
      */
     public function load($model)
     {
@@ -263,8 +263,8 @@ abstract class Application
     /**
      * @param Remote\Model $object
      * @param bool $replace_data
-     * @return Remote\Response|null
      * @throws Exception
+     * @return Remote\Response|null
      */
     public function save(Remote\Model $object, $replace_data = false)
     {
@@ -313,8 +313,8 @@ abstract class Application
      * @param Collection|array $objects
      * @param mixed $checkGuid
      * @param mixed $replace_data
-     * @return Remote\Response
      * @throws Exception
+     * @return Remote\Response
      */
     public function saveAll($objects, $checkGuid = true, $replace_data = false)
     {
@@ -415,8 +415,8 @@ abstract class Application
 
     /**
      * @param Remote\Model $object
-     * @return Remote\Response
      * @throws Exception
+     * @return Remote\Response
      */
     public function delete(Remote\Model $object)
     {

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -797,8 +797,8 @@ class Invoice extends Remote\Model
     /**
      * Retrieve the online invoice URL.
      *
-     * @return string
      * @throws \XeroPHP\Exception
+     * @return string
      */
     public function getOnlineInvoiceUrl()
     {

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -219,8 +219,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Convert the object into an array, and any non-primitives to string.
      *
-     * @return array
      * @param mixed $dirty_only
+     * @return array
      */
     public function toStringArray($dirty_only = false)
     {
@@ -346,8 +346,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Validate the object and (optionally) the child objects recursively.
      *
      * @param bool $check_children
-     * @return bool
      * @throws Exception
+     * @return bool
      */
     public function validate($check_children = true)
     {
@@ -391,8 +391,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Shorthand save an object if it is instantiated with app context.
      *
-     * @return Response|null
      * @throws Exception
+     * @return Response|null
      */
     public function save()
     {
@@ -408,8 +408,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * Shorthand delete an object if it is instantiated with app context.
      *
-     * @return Response|null
      * @throws Exception
+     * @return Response|null
      */
     public function delete()
     {

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -131,8 +131,8 @@ class Client
      * consistency, pass the same constructor to each one.
      *
      * @param Request $request
-     * @return string
      * @throws Exception
+     * @return string
      */
     private function getSignature(Request $request)
     {

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -184,8 +184,8 @@ class Query
 
     /**
      * @param int $page
-     * @return $this
      * @throws Exception
+     * @return $this
      */
     public function page($page = 1)
     {

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -11,8 +11,8 @@ trait PDFTrait
     /**
      * Get the raw content of the resource's PDF file.
      *
-     * @return string
      * @throws \XeroPHP\Exception
+     * @return string
      */
     public function getPDF()
     {

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -31,8 +31,8 @@ class Webhook
      * @param \XeroPHP\Application $application
      * @param string $payload
      * @param string|null $event
-     * @return void
      * @throws \XeroPHP\Application\Exception
+     * @return void
      */
     public function __construct($application, $payload, $event = null)
     {


### PR DESCRIPTION
Annotations in PHPDoc should be ordered so that @param annotations come first, then @throws annotations, then @return annotations.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer