### PR TITLE
Code style: phpdoc_single_line_var_spacing

### DIFF
--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -10,7 +10,7 @@ class Query
     const ORDER_ASC = 'ASC';
     const ORDER_DESC = 'DESC';
 
-    /** @var  \XeroPHP\Application */
+    /** @var \XeroPHP\Application */
     private $app;
 
     private $from_class;


### PR DESCRIPTION
Single line @var PHPDoc should have proper spacing.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer

Also, just wanted to let ya know I've nearly completed a first pass at PRing all the styling rules. I've left some more complicated rules out intentionally because they change a lot more things and might require more revision from yourself, and just focused on the easier ones to make to process easier.

No doubt it will pay off once you can make this a completely automated process.