### PR TITLE
Code style: no_unused_imports

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -2,7 +2,6 @@
 
 namespace XeroPHP;
 
-use XeroPHP\Remote;
 use XeroPHP\Remote\URL;
 use XeroPHP\Remote\Query;
 use XeroPHP\Remote\Request;

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -3,8 +3,6 @@
 
 namespace XeroPHP\Models\Accounting;
 
-use XeroPHP\Remote\URL;
-use XeroPHP\Application;
 use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 

--- a/src/XeroPHP/Traits/SendEmailTrait.php
+++ b/src/XeroPHP/Traits/SendEmailTrait.php
@@ -2,7 +2,6 @@
 
 namespace XeroPHP\Traits;
 
-use XeroPHP\Exception;
 use XeroPHP\Remote\URL;
 use XeroPHP\Remote\Request;
 

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -2,8 +2,6 @@
 
 namespace XeroPHP;
 
-use XeroPHP\Helpers;
-
 class Webhook
 {
     /**

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -2,7 +2,6 @@
 
 namespace XeroPHP\tests\Application;
 
-use XeroPHP\Application\PartnerApplication;
 use XeroPHP\Application\PrivateApplication;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
Unused `use` statements are removed.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer