### PR TITLE
Code style: phpdoc_no_package

### DIFF
--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -9,7 +9,6 @@ use XeroPHP\Models\Accounting\TrackingCategory;
  * This is to avoid external dependencies.
  *
  * Class Helpers
- * @package XeroPHP
  */
 class Helpers
 {

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -7,10 +7,6 @@ use XeroPHP\Application;
 
 /**
  * Class Model
- * @package XeroPHP\Remote
- *
- * todo - at 2.x, move this into the root of the project and refer to it as a model.
- * Also make this an ArrayObject to simplify storage
  */
 abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 {

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -14,7 +14,6 @@ use XeroPHP\Remote\OAuth\SignatureMethod\PLAINTEXT;
  * which comes in the recommended php developer kit.
  *
  * @author Michael Calcinai
- * @package XeroPHP\Remote\OAuth
  */
 class Client
 {

--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -10,7 +10,6 @@ use XeroPHP\Application;
  *
  * Class URL
  * @author Michael Calcinai
- * @package XeroPHP\Remote
  */
 class URL
 {


### PR DESCRIPTION
`@package` and `@subpackage` annotations should be omitted from PHPDoc.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer