### PR TITLE
Code style: phpdoc_var_without_name

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -190,7 +190,7 @@ abstract class Application
     public function loadByGUID($model, $guid)
     {
         /**
-         * @var Remote\Model $class
+         * @var Remote\Model
          */
         $class = $this->validateModelClass($model);
 
@@ -204,7 +204,7 @@ abstract class Application
         //Return the first (if any) element from the response.
         foreach ($request->getResponse()->getElements() as $element) {
             /**
-             * @var Remote\Model $object
+             * @var Remote\Model
              */
             $object = new $class($this);
             $object->fromStringArray($element);
@@ -225,7 +225,7 @@ abstract class Application
     public function loadByGUIDs($model, $guids)
     {
         /**
-         * @var Remote\Model $class
+         * @var Remote\Model
          */
         $class = $this->validateModelClass($model);
 
@@ -239,7 +239,7 @@ abstract class Application
         $elements = new Collection();
         foreach ($request->getResponse()->getElements() as $element) {
             /**
-             * @var Remote\Model $object
+             * @var Remote\Model
              */
             $object = new $class($this);
             $object->fromStringArray($element);
@@ -323,7 +323,7 @@ abstract class Application
         //Just get one type to compare with, doesn't matter which.
         $current_object = $objects[0];
         /**
-         * @var Remote\Model $type
+         * @var Remote\Model
          */
         $type = get_class($current_object);
         $has_guid = $checkGuid ? $current_object->hasGUID() : true;

--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -70,7 +70,7 @@ class Helpers
 
         foreach ($sxml->children() as $child_name => $child) {
             /**
-             * @var \SimpleXMLElement $child
+             * @var \SimpleXMLElement
              */
             if ($child->count() > 0) {
                 $node = self::XMLToArray($child);

--- a/src/XeroPHP/Models/Accounting/Attachment.php
+++ b/src/XeroPHP/Models/Accounting/Attachment.php
@@ -37,7 +37,7 @@ class Attachment extends Model
     /**
      * Actual file content (binary)
      *
-     * @var string $content
+     * @var string
      */
     private $content;
 

--- a/src/XeroPHP/Remote/Collection.php
+++ b/src/XeroPHP/Remote/Collection.php
@@ -28,7 +28,7 @@ class Collection extends \ArrayObject
         if (isset($this[$index])) {
             foreach ($this->_associated_objects as $parent_property => $object) {
                 /**
-                 * @var Model $object
+                 * @var Model
                  */
                 $object->setDirty($parent_property);
             }
@@ -57,7 +57,7 @@ class Collection extends \ArrayObject
     {
         foreach ($this->_associated_objects as $parent_property => $object) {
             /**
-             * @var Model $object
+             * @var Model
              */
             $object->setDirty($parent_property);
         }

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -59,7 +59,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Holds a ref to the application that was used to load the object,
      * enables shorthand $object->save();
      *
-     * @var Application $_application
+     * @var Application
      */
     protected $_application;
 
@@ -269,13 +269,13 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
             case self::PROPERTY_TYPE_DATE:
                 /**
-                 * @var \DateTimeInterface $value
+                 * @var \DateTimeInterface
                  */
                 return $value->format('Y-m-d');
 
             case self::PROPERTY_TYPE_TIMESTAMP:
                 /**
-                 * @var \DateTimeInterface $value
+                 * @var \DateTimeInterface
                  */
                 return $value->format('c');
 

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -190,7 +190,7 @@ class Query
     public function page($page = 1)
     {
         /**
-         * @var ObjectInterface $from_class
+         * @var ObjectInterface
          */
         $from_class = $this->from_class;
         if (! $from_class::isPageable()) {
@@ -230,7 +230,7 @@ class Query
     public function execute()
     {
         /**
-         * @var ObjectInterface $from_class
+         * @var ObjectInterface
          */
         $from_class = $this->from_class;
         $url = new URL(
@@ -289,7 +289,7 @@ class Query
         $elements = new Collection();
         foreach ($request->getResponse()->getElements() as $element) {
             /**
-             * @var Model $built_element
+             * @var Model
              */
             $built_element = new $from_class($this->app);
             $built_element->fromStringArray($element);

--- a/src/XeroPHP/Traits/AttachmentTrait.php
+++ b/src/XeroPHP/Traits/AttachmentTrait.php
@@ -12,7 +12,7 @@ trait AttachmentTrait
     public function addAttachment(Attachment $attachment, $include_online = false)
     {
         /**
-         * @var \XeroPHP\Remote\Model $this
+         * @var \XeroPHP\Remote\Model
          */
         $uri = sprintf('%s/%s/Attachments/%s', $this::getResourceURI(), $this->getGUID(), rawurlencode($attachment->getFileName()));
 
@@ -40,7 +40,7 @@ trait AttachmentTrait
     public function getAttachments()
     {
         /**
-         * @var \XeroPHP\Remote\Model $this
+         * @var \XeroPHP\Remote\Model
          */
         if ($this->hasGUID() === false) {
             throw new Exception(

--- a/src/XeroPHP/Traits/HistoryTrait.php
+++ b/src/XeroPHP/Traits/HistoryTrait.php
@@ -13,7 +13,7 @@ trait HistoryTrait
     public function addHistory(History $history)
     {
         /**
-         * @var \XeroPHP\Remote\Model $this
+         * @var \XeroPHP\Remote\Model
          */
         $uri = sprintf('%s/%s/History', $this::getResourceURI(), $this->getGUID());
 
@@ -31,7 +31,7 @@ trait HistoryTrait
     public function getHistory()
     {
         /**
-         * @var \XeroPHP\Remote\Model $this
+         * @var \XeroPHP\Remote\Model
          */
         if ($this->hasGUID() === false) {
             throw new Exception(

--- a/src/XeroPHP/Traits/SendEmailTrait.php
+++ b/src/XeroPHP/Traits/SendEmailTrait.php
@@ -19,7 +19,7 @@ trait SendEmailTrait
          * Documentation here:
          * https://developer.xero.com/documentation/api/invoices#email
          *
-         * @var \XeroPHP\Remote\Model $this
+         * @var \XeroPHP\Remote\Model
          */
         $uri = sprintf('%s/%s/Email', $this::getResourceURI(), $this->getGUID());
 


### PR DESCRIPTION
`@var` and `@type` annotations should not contain the variable name.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer