### PR TITLE
Code style: self_accessor

### DIFF
--- a/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
@@ -177,7 +177,7 @@ class BenefitType extends Remote\Model
      * @param BenefitType $value
      * @return BenefitType
      */
-    public function setBenefitType(BenefitType $value)
+    public function setBenefitType(self $value)
     {
         $this->propertyUpdated('BenefitType', $value);
         $this->_data['BenefitType'] = $value;

--- a/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
@@ -175,7 +175,7 @@ class DeductionType extends Remote\Model
      * @param DeductionType $value
      * @return DeductionType
      */
-    public function setDeductionType(DeductionType $value)
+    public function setDeductionType(self $value)
     {
         $this->propertyUpdated('DeductionType', $value);
         $this->_data['DeductionType'] = $value;

--- a/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
@@ -203,7 +203,7 @@ class EarningsType extends Remote\Model
      * @param EarningsType $value
      * @return EarningsType
      */
-    public function setEarningsType(EarningsType $value)
+    public function setEarningsType(self $value)
     {
         $this->propertyUpdated('EarningsType', $value);
         $this->_data['EarningsType'] = $value;

--- a/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
@@ -116,7 +116,7 @@ class ReimbursementType extends Remote\Model
      * @param ReimbursementType $value
      * @return ReimbursementType
      */
-    public function setReimbursementType(ReimbursementType $value)
+    public function setReimbursementType(self $value)
     {
         $this->propertyUpdated('ReimbursementType', $value);
         $this->_data['ReimbursementType'] = $value;

--- a/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
@@ -142,7 +142,7 @@ class TimeOffType extends Remote\Model
      * @param TimeOffType $value
      * @return TimeOffType
      */
-    public function setTimeOffType(TimeOffType $value)
+    public function setTimeOffType(self $value)
     {
         $this->propertyUpdated('TimeOffType', $value);
         $this->_data['TimeOffType'] = $value;

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -199,7 +199,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 foreach ($input_array[$property] as $assoc_element) {
                     $cast = self::castFromString($type, $assoc_element, $php_type);
                     //Do this here so that you know it's not a static method call to ::castFromString
-                    if ($cast instanceof Model) {
+                    if ($cast instanceof self) {
                         $cast->addAssociatedObject($property, $this);
                     }
                     $collection->append($cast);
@@ -208,7 +208,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             } else {
                 $cast = self::castFromString($type, $input_array[$property], $php_type);
                 //Do this here so that you know it's not a static method call to ::castFromString
-                if ($cast instanceof Model) {
+                if ($cast instanceof self) {
                     $cast->addAssociatedObject($property, $this);
                 }
                 $this->_data[$property] = $cast;
@@ -280,7 +280,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 return $value->format('c');
 
             case self::PROPERTY_TYPE_OBJECT:
-                if ($value instanceof Model) {
+                if ($value instanceof self) {
                     return $value->toStringArray();
                 }
                 return '';
@@ -368,14 +368,14 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 }
 
                 if ($check_children) {
-                    if ($this->_data[$property] instanceof Model) {
+                    if ($this->_data[$property] instanceof self) {
                         //Keep IDEs happy
                         /** @var self $obj */
                         $obj = $this->_data[$property];
                         $obj->validate();
                     } elseif ($this->_data[$property] instanceof Collection) {
                         foreach ($this->_data[$property] as $element) {
-                            if ($element instanceof Model) {
+                            if ($element instanceof self) {
                                 $element->validate();
                             }
                         }
@@ -426,7 +426,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * @param string $property
      * @param Model $object
      */
-    public function addAssociatedObject($property, Model $object)
+    public function addAssociatedObject($property, self $object)
     {
         $this->_associated_objects[$property] = $object;
     }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -69,7 +69,7 @@ class Response
         $this->parseBody();
 
         switch ($this->status) {
-            case Response::STATUS_BAD_REQUEST:
+            case self::STATUS_BAD_REQUEST:
                 //This catches actual app errors
                 if (isset($this->root_error) && ! empty($this->root_error)) {
                     $message = sprintf('%s (%s)', $this->root_error['message'], implode(', ', $this->element_errors));
@@ -81,27 +81,27 @@ class Response
 
             /** @noinspection PhpMissingBreakStatementInspection */
             // no break
-            case Response::STATUS_UNAUTHORISED:
+            case self::STATUS_UNAUTHORISED:
                 //This is where OAuth errors end up, this could maybe change to an OAuth exception
                 if (isset($this->oauth_response['oauth_problem_advice'])) {
                     throw new UnauthorizedException($this->oauth_response['oauth_problem_advice']);
                 }
                 // no break
-            case Response::STATUS_FORBIDDEN:
+            case self::STATUS_FORBIDDEN:
                 throw new UnauthorizedException();
 
-            case Response::STATUS_NOT_FOUND:
+            case self::STATUS_NOT_FOUND:
                 throw new NotFoundException();
 
-            case Response::STATUS_INTERNAL_ERROR:
+            case self::STATUS_INTERNAL_ERROR:
                 throw new InternalErrorException();
 
-            case Response::STATUS_NOT_IMPLEMENTED:
+            case self::STATUS_NOT_IMPLEMENTED:
                 throw new NotImplementedException();
 
-            case Response::STATUS_NOT_AVAILABLE:
-            case Response::STATUS_RATE_LIMIT_EXCEEDED:
-            case Response::STATUS_ORGANISATION_OFFLINE:
+            case self::STATUS_NOT_AVAILABLE:
+            case self::STATUS_RATE_LIMIT_EXCEEDED:
+            case self::STATUS_ORGANISATION_OFFLINE:
                 //There must be a better way than this?
                 $response = urldecode($this->response_body);
                 if (false !== stripos($response, 'Organisation is offline')) {


### PR DESCRIPTION
Inside class or interface element `self` should be preferred to the class name itself.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer