### PR TITLE
Code style: simplified_null_return

### DIFF
--- a/examples/partner.php
+++ b/examples/partner.php
@@ -123,7 +123,7 @@ function getOAuthSession()
 {
     //If it doesn't exist, return null
     if (! isset($_SESSION['oauth'])) {
-        return null;
+        return;
     }
 
     // If the session is expired or expiring, unset the expires key

--- a/examples/public.php
+++ b/examples/public.php
@@ -111,7 +111,7 @@ function getOAuthSession()
         || ($_SESSION['oauth']['expires'] !== null
         && $_SESSION['oauth']['expires'] <= time())
     ) {
-        return null;
+        return;
     }
     return $_SESSION['oauth'];
 }

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -210,7 +210,7 @@ abstract class Application
             $object->fromStringArray($element);
             return $object;
         }
-        return null;
+        return;
     }
 
     /**
@@ -273,7 +273,7 @@ abstract class Application
         $this->savePropertiesDirectly($object);
 
         if (! $object->isDirty()) {
-            return null;
+            return;
         }
         $object->validate();
 

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -457,7 +457,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         }
 
         trigger_error(sprintf("Undefined property %s::$%s.\n", __CLASS__, $property));
-        return null;
+        return;
     }
 
     /**
@@ -476,7 +476,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         }
 
         trigger_error(sprintf("Undefined property %s::$%s.\n", __CLASS__, $property));
-        return null;
+        return;
     }
 
     protected function propertyUpdated($property, $value)

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -254,7 +254,7 @@ class Client
         if (isset($this->config['token'])) {
             return $this->config['token'];
         }
-        return null;
+        return;
     }
 
     /**
@@ -342,7 +342,7 @@ class Client
         if (isset($this->token_secret)) {
             return $this->token_secret;
         }
-        return null;
+        return;
     }
 
     public function setVerifier($verifier)
@@ -357,6 +357,6 @@ class Client
         if (isset($this->verifier)) {
             return $this->verifier;
         }
-        return null;
+        return;
     }
 }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -147,7 +147,7 @@ class Request
     public function getHeader($key)
     {
         if (! isset($this->headers[$key])) {
-            return null;
+            return;
         }
         return $this->headers[$key];
     }
@@ -165,7 +165,7 @@ class Request
         if (isset($this->response)) {
             return $this->response;
         }
-        return null;
+        return;
     }
 
     /**

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -159,7 +159,7 @@ class Response
         if (isset($this->element_errors[$element_id])) {
             return $this->element_errors[$element_id];
         }
-        return null;
+        return;
     }
 
     public function getElementErrors()

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -142,7 +142,7 @@ class Event
             return \XeroPHP\Models\Accounting\Contact::class;
         }
 
-        return null;
+        return;
     }
 
     /**


### PR DESCRIPTION
A return statement wishing to return `void` should not return `null`.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer