### PR TITLE
Code style: single_blank_line_before_namespace

### DIFF
--- a/src/XeroPHP/Models/Accounting/Attachment.php
+++ b/src/XeroPHP/Models/Accounting/Attachment.php
@@ -2,7 +2,6 @@
 
 //This class is a pseudo-model to represent an attachment.  Can't be directly put ot fetched.
 
-
 namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote\URL;

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote\URL;

--- a/src/XeroPHP/Models/PayrollAU/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;


### PR DESCRIPTION
There should be exactly one blank line before a namespace declaration.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer