### PR TITLE
Code style: single_line_comment_style

### DIFF
--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -30,9 +30,7 @@ class Client
 
     private $config;
 
-    /*
-     * "Cached" parameters - will change between signings.
-     */
+    // "Cached" parameters - will change between signings.
     private $oauth_params;
 
     private $token_secret;


### PR DESCRIPTION
Single-line comments and multi-line comments with only one line of actual content should use the `//` syntax.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer