### PR TITLE
Code style: strict_param

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -314,7 +314,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 return (float) $value;
 
             case self::PROPERTY_TYPE_BOOLEAN:
-                return in_array(strtolower($value), ['true', '1', 'yes']);
+                return in_array(strtolower($value), ['true', '1', 'yes'], true);
 
             /** @noinspection PhpMissingBreakStatementInspection */
             case self::PROPERTY_TYPE_TIMESTAMP:
@@ -503,7 +503,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      */
     public static function supportsMethod($method)
     {
-        return in_array($method, static::getSupportedMethods());
+        return in_array($method, static::getSupportedMethods(), true);
     }
 
     /**


### PR DESCRIPTION
Functions should be used with `$strict` param set to `true`.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer

I just made this (https://3v4l.org/YFIk8) to make sure any values, like booleans, are actually converted correctly with this change, as it is risky, but it looks like it is sweet to me.