### PR TITLE
update model.php to define default format for the body of POST or PUT…

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -558,4 +558,10 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     {
         unset($this->_data[$offset]);
     }
+
+    public static function getBodyFormat()
+    {
+        return 'xml';
+    }
+
 }


### PR DESCRIPTION
… calls

Newer API endpoints only accept the body to be in JSON format. By adding this function, the existing models will default to XML, and allow new models to be defined with json instead. 

This would allow Application.php to be modified in the future to submit json when necessary.

I appreciate this might not be the tidiest solution and am open to more elegant solutions.