### PR TITLE
When adding an allocation replace allocations with a single allocation.

### DIFF
--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -582,7 +582,7 @@ class Overpayment extends Remote\Model
         if (! isset($this->_data['Allocations'])) {
             $this->_data['Allocations'] = new Remote\Collection();
         }
-        $this->_data['Allocations'][] = $value;
+        $this->_data['Allocations'] = [$value];
 
         return $this;
     }

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -582,7 +582,11 @@ class Overpayment extends Remote\Model
         if (! isset($this->_data['Allocations'])) {
             $this->_data['Allocations'] = new Remote\Collection();
         }
-        $this->_data['Allocations'] = [$value];
+
+        // The allocations endpoint is additive. You can only add new allocations, not append to an existing collection.
+        $this->getAllocations()->removeAll();
+
+        $this->_data['Allocations'][] = $value;
 
         return $this;
     }


### PR DESCRIPTION
The Xero API is additive. You can only add new allocations, not append to an existing collection. Fix for https://github.com/calcinai/xero-php/issues/335 but needs more work before merging.