### PR TITLE
Support for a callback on successful API call

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -451,9 +451,9 @@ abstract class Application
         return $object;
     }
 
-    public function requestCompleted($response) {
+    public function requestCompleted($request) {
         foreach($this->requestCompletedCallbacks as $callback) {
-            call_user_func($callback, $response);
+            call_user_func($callback, $request);
         }
     }
 

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -56,6 +56,11 @@ abstract class Application
     protected static $_type_config_defaults = [];
 
     /**
+     * @var Closure
+     */
+    protected $requestCompletedCallback;
+
+    /**
      * @param array $config
      */
     public function __construct(array $config)
@@ -446,16 +451,14 @@ abstract class Application
         return $object;
     }
 
-	protected $requestCompletedCallback;
+    public function requestCompleted($response, $info, $headers) {
+        if($this->requestCompletedCallback instanceof \Closure) {
+            call_user_func($this->requestCompletedCallback, $response, $info, $headers);
+        }
+    }
 
-	public function requestCompleted($response, $info, $headers) {
-		if($this->requestCompletedCallback instanceof \Closure) {
-			call_user_func($this->requestCompletedCallback, $response, $info, $headers);
-		}
-	}
-
-	public function onRequestCompleted($callback) {
-		$this->requestCompletedCallback = $callback;
-	}
+    public function onRequestCompleted($callback) {
+        $this->requestCompletedCallback = $callback;
+    }
 
 }

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -56,9 +56,9 @@ abstract class Application
     protected static $_type_config_defaults = [];
 
     /**
-     * @var Closure
+     * @var array
      */
-    protected $requestCompletedCallback;
+    protected $requestCompletedCallbacks = [];
 
     /**
      * @param array $config
@@ -452,13 +452,15 @@ abstract class Application
     }
 
     public function requestCompleted($response, $info, $headers) {
-        if($this->requestCompletedCallback instanceof \Closure) {
-            call_user_func($this->requestCompletedCallback, $response, $info, $headers);
+        foreach($this->requestCompletedCallbacks as $callback) {
+            if($callback instanceof \Closure) {
+                call_user_func($callback, $response, $info, $headers);
+            }
         }
     }
 
     public function onRequestCompleted($callback) {
-        $this->requestCompletedCallback = $callback;
+        $this->requestCompletedCallbacks[] = $callback;
     }
 
 }

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -453,9 +453,7 @@ abstract class Application
 
     public function requestCompleted($response, $info, $headers) {
         foreach($this->requestCompletedCallbacks as $callback) {
-            if($callback instanceof \Closure) {
-                call_user_func($callback, $response, $info, $headers);
-            }
+            call_user_func($callback, $response, $info, $headers);
         }
     }
 

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -445,4 +445,17 @@ abstract class Application
 
         return $object;
     }
+
+	protected $requestCompletedCallback;
+
+	public function requestCompleted($response, $info, $headers) {
+		if($this->requestCompletedCallback instanceof \Closure) {
+			call_user_func($this->requestCompletedCallback, $response, $info, $headers);
+		}
+	}
+
+	public function onRequestCompleted($callback) {
+		$this->requestCompletedCallback = $callback;
+	}
+
 }

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -451,9 +451,9 @@ abstract class Application
         return $object;
     }
 
-    public function requestCompleted($response, $info, $headers) {
+    public function requestCompleted($response) {
         foreach($this->requestCompletedCallbacks as $callback) {
-            call_user_func($callback, $response, $info, $headers);
+            call_user_func($callback, $response);
         }
     }
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -125,9 +125,9 @@ class Request
         }
 
         $this->response = new Response($this, $response, $info, $headers);
-        $this->app->requestCompleted($this);
 
         $this->response->parse();
+        $this->app->requestCompleted($this);
 
         return $this->response;
     }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -124,7 +124,7 @@ class Request
             throw new Exception('Curl error: '.curl_error($ch));
         }
 
-		$this->app->requestCompleted($response, $info, $headers);
+        $this->app->requestCompleted($response, $info, $headers);
 
         $this->response = new Response($this, $response, $info, $headers);
         $this->response->parse();

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -124,6 +124,8 @@ class Request
             throw new Exception('Curl error: '.curl_error($ch));
         }
 
+		$this->app->requestCompleted($response, $info, $headers);
+
         $this->response = new Response($this, $response, $info, $headers);
         $this->response->parse();
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -125,7 +125,7 @@ class Request
         }
 
         $this->response = new Response($this, $response, $info, $headers);
-        $this->app->requestCompleted($this->response);
+        $this->app->requestCompleted($this);
 
         $this->response->parse();
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -125,7 +125,6 @@ class Request
         }
 
         $this->response = new Response($this, $response, $info, $headers);
-
         $this->response->parse();
         $this->app->requestCompleted($this);
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -124,9 +124,9 @@ class Request
             throw new Exception('Curl error: '.curl_error($ch));
         }
 
-        $this->app->requestCompleted($response, $info, $headers);
-
         $this->response = new Response($this, $response, $info, $headers);
+        $this->app->requestCompleted($this->response);
+
         $this->response->parse();
 
         return $this->response;

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -190,6 +190,10 @@ class Response
         return $this->request;
     }
 
+    public function getHeaders() {
+        return $this->headers;
+    }
+
     public function parseBody()
     {
         if ($this->request->getUrl()->isOAuth()) {

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -186,6 +186,10 @@ class Response
         return $this->oauth_response;
     }
 
+    public function getRequest() {
+        return $this->request;
+    }
+
     public function parseBody()
     {
         if ($this->request->getUrl()->isOAuth()) {

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -186,10 +186,6 @@ class Response
         return $this->oauth_response;
     }
 
-    public function getRequest() {
-        return $this->request;
-    }
-
     public function getHeaders() {
         return $this->headers;
     }


### PR DESCRIPTION
We use this to track usage of the Xero API in our application so we can manage to stay under the 5,000 calls per day. Usage (for us):

```
    $xero->onRequestCompleted(function($response, $info, $headers){
        $log = new Apilog;
        $log->System = 'Xero';
        $log->URL = $info['url'];
        $log->HttpCode = $info['http_code'];
        $log->ResponseSize = strlen($response);
        $log->save();
    });
```