### PR TITLE
Code style: fopen_flags

### DIFF
--- a/src/XeroPHP/Models/Accounting/Attachment.php
+++ b/src/XeroPHP/Models/Accounting/Attachment.php
@@ -116,7 +116,7 @@ class Attachment extends Model
             'ContentLength' => $content_length,
             'FileName' => $path_info['basename'],
         ]);
-        $instance->setLocalHandle(fopen($file_name, 'r'));
+        $instance->setLocalHandle(fopen($file_name, 'rb'));
 
         return $instance;
     }


### PR DESCRIPTION
The flags in fopen calls must omit t, and b must be omitted or included consistently.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer

**Note:** I'm not actually sure if this is considered a breaking change, or potentially a bug fix.

On windows, in some situations it will translate `\n` with `\r\n`. This is done so that plain text files can be opened in Windows applications, such as NotePad. Introducing the `b` flag is explicitly stating: Do not translate these.

Because this is a PDF and should be the same file on both platforms, I believe this could actually be considered a bug fix. Thoughts?

Have a scan over the doc notes here: https://www.php.net/manual/en/function.fopen.php