### PR TITLE
Code style: no_useless_return

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -214,7 +214,7 @@ abstract class Application
             return $object;
         }
 
-        return;
+        
     }
 
     /**

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -463,7 +463,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
         trigger_error(sprintf("Undefined property %s::$%s.\n", __CLASS__, $property));
 
-        return;
+        
     }
 
     /**
@@ -483,7 +483,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
         trigger_error(sprintf("Undefined property %s::$%s.\n", __CLASS__, $property));
 
-        return;
+        
     }
 
     protected function propertyUpdated($property, $value)

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -259,7 +259,7 @@ class Client
             return $this->config['token'];
         }
 
-        return;
+        
     }
 
     /**
@@ -349,7 +349,7 @@ class Client
             return $this->token_secret;
         }
 
-        return;
+        
     }
 
     public function setVerifier($verifier)
@@ -365,6 +365,6 @@ class Client
             return $this->verifier;
         }
 
-        return;
+        
     }
 }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -169,7 +169,7 @@ class Request
             return $this->response;
         }
 
-        return;
+        
     }
 
     /**

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -163,7 +163,7 @@ class Response
             return $this->element_errors[$element_id];
         }
 
-        return;
+        
     }
 
     public function getElementErrors()

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -142,7 +142,7 @@ class Event
             return \XeroPHP\Models\Accounting\Contact::class;
         }
 
-        return;
+        
     }
 
     /**


### PR DESCRIPTION
There should not be an empty `return` statement at the end of a function.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer