### PR TITLE
Code style: phpdoc_align

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -171,7 +171,7 @@ abstract class Application
     /**
      * Prepend the configuration namespace to the class.
      *
-     * @param  string  $class
+     * @param string $class
      * @return string
      */
     protected function prependConfigNamespace($class)

--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -294,7 +294,6 @@ class BankTransaction extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {

--- a/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
@@ -316,7 +316,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -534,7 +534,6 @@ class Contact extends Remote\Model
 
     /**
      * @return ContactPerson[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getContactPersons()
     {
@@ -638,7 +637,6 @@ class Contact extends Remote\Model
 
     /**
      * @return Address[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAddresses()
     {
@@ -662,7 +660,6 @@ class Contact extends Remote\Model
 
     /**
      * @return Phone[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPhones()
     {
@@ -798,7 +795,6 @@ class Contact extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSalesTrackingCategories()
     {
@@ -822,7 +818,6 @@ class Contact extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPurchasesTrackingCategories()
     {
@@ -886,7 +881,6 @@ class Contact extends Remote\Model
 
     /**
      * @return PaymentTerm[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPaymentTerms()
     {
@@ -930,7 +924,6 @@ class Contact extends Remote\Model
 
     /**
      * @return ContactGroup[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getContactGroups()
     {

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -181,7 +181,6 @@ class ContactGroup extends Remote\Model
 
     /**
      * @return Contact[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getContacts()
     {

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -350,7 +350,6 @@ class CreditNote extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {
@@ -374,7 +373,6 @@ class CreditNote extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPayments()
     {
@@ -623,7 +621,6 @@ class CreditNote extends Remote\Model
 
     /**
      * @return Allocation[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations()
     {

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim.php
@@ -168,7 +168,6 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @return Receipt[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReceipts()
     {

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
@@ -176,7 +176,6 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @return Payment[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPayments()
     {

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -375,7 +375,6 @@ class Invoice extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {
@@ -728,7 +727,6 @@ class Invoice extends Remote\Model
 
     /**
      * @return Payment[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPayments()
     {
@@ -738,7 +736,6 @@ class Invoice extends Remote\Model
 
     /**
      * @return Prepayment[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPrepayments()
     {
@@ -748,7 +745,6 @@ class Invoice extends Remote\Model
 
     /**
      * @return Overpayment[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getOverpayments()
     {
@@ -803,7 +799,6 @@ class Invoice extends Remote\Model
 
     /**
      * @return CreditNote[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getCreditNotes()
     {

--- a/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
@@ -351,7 +351,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -358,7 +358,6 @@ class Item extends Remote\Model
 
     /**
      * @return Purchase[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPurchaseDetails()
     {
@@ -388,7 +387,6 @@ class Item extends Remote\Model
 
     /**
      * @return Sale[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSalesDetails()
     {

--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -32,7 +32,7 @@ class Journal extends Remote\Model
      */
 
     /**
-     *  
+     *
      *
      * @property string Reference
      */
@@ -309,7 +309,6 @@ class Journal extends Remote\Model
 
     /**
      * @return JournalLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getJournalLines()
     {

--- a/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
@@ -391,7 +391,6 @@ class JournalLine extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories()
     {

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -207,7 +207,6 @@ class ManualJournal extends Remote\Model
 
     /**
      * @return JournalLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getJournalLines()
     {

--- a/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
@@ -210,7 +210,6 @@ class JournalLine extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/Organisation.php
+++ b/src/XeroPHP/Models/Accounting/Organisation.php
@@ -815,7 +815,6 @@ class Organisation extends Remote\Model
 
     /**
      * @return Address[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAddresses()
     {
@@ -839,7 +838,6 @@ class Organisation extends Remote\Model
 
     /**
      * @return Phone[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPhones()
     {
@@ -863,7 +861,6 @@ class Organisation extends Remote\Model
 
     /**
      * @return ExternalLink[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getExternalLinks()
     {
@@ -887,7 +884,6 @@ class Organisation extends Remote\Model
 
     /**
      * @return PaymentTerm[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPaymentTerms()
     {

--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -104,7 +104,6 @@ class PaymentTerm extends Remote\Model
 
     /**
      * @return Bill[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBills()
     {
@@ -128,7 +127,6 @@ class PaymentTerm extends Remote\Model
 
     /**
      * @return Sale[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSales()
     {

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -359,7 +359,6 @@ class Overpayment extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {
@@ -565,7 +564,6 @@ class Overpayment extends Remote\Model
 
     /**
      * @return Allocation[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations()
     {
@@ -589,7 +587,6 @@ class Overpayment extends Remote\Model
 
     /**
      * @return Payment[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPayments()
     {

--- a/src/XeroPHP/Models/Accounting/Overpayment/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment/LineItem.php
@@ -213,7 +213,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/Prepayment.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment.php
@@ -352,7 +352,6 @@ class Prepayment extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {
@@ -558,7 +557,6 @@ class Prepayment extends Remote\Model
 
     /**
      * @return Allocation[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAllocations()
     {

--- a/src/XeroPHP/Models/Accounting/Prepayment/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment/LineItem.php
@@ -213,7 +213,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder.php
@@ -295,7 +295,6 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
@@ -308,7 +308,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/Receipt.php
+++ b/src/XeroPHP/Models/Accounting/Receipt.php
@@ -244,7 +244,6 @@ class Receipt extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {

--- a/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
@@ -293,7 +293,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
@@ -252,7 +252,6 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @return LineItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLineItems()
     {

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
@@ -325,7 +325,6 @@ class LineItem extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTracking()
     {

--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -217,7 +217,6 @@ class TaxRate extends Remote\Model
 
     /**
      * @return TaxComponent[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTaxComponents()
     {

--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -227,7 +227,6 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @return TrackingOption[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getOptions()
     {
@@ -250,8 +249,9 @@ class TrackingCategory extends Remote\Model
     }
 
     /**
-     * @return string $value
      * Returns selected option name
+     *
+     * @return string $value
      */
     public function getOption()
     {

--- a/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
+++ b/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
@@ -180,7 +180,6 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function geteffectiveLifeYears()
     {

--- a/src/XeroPHP/Models/Files/Folder.php
+++ b/src/XeroPHP/Models/Files/Folder.php
@@ -240,7 +240,6 @@ class Folder extends Remote\Model
 
     /**
      * @return File[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getFiles()
     {

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -691,7 +691,6 @@ class Employee extends Remote\Model
 
     /**
      * @return BankAccount[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBankAccounts()
     {
@@ -735,7 +734,6 @@ class Employee extends Remote\Model
 
     /**
      * @return OpeningBalance[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getOpeningBalances()
     {
@@ -759,7 +757,6 @@ class Employee extends Remote\Model
 
     /**
      * @return LeaveBalance[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveBalances()
     {
@@ -783,7 +780,6 @@ class Employee extends Remote\Model
 
     /**
      * @return SuperMembership[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSuperMemberships()
     {

--- a/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
@@ -174,7 +174,6 @@ class LeaveBalance extends Remote\Model
 
     /**
      * @return PayItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTypeOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
@@ -233,7 +233,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return EarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -257,7 +256,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -301,7 +299,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -123,7 +123,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return EarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -147,7 +146,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -171,7 +169,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return SuperLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSuperLines()
     {
@@ -195,7 +192,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {
@@ -219,7 +215,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return LeaveLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveLines()
     {

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -287,7 +287,6 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @return LeavePeriod[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeavePeriods()
     {

--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -119,7 +119,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return EarningsRate[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsRates()
     {
@@ -143,7 +142,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return DeductionType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionTypes()
     {
@@ -167,7 +165,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return LeaveType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveTypes()
     {
@@ -191,7 +188,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return ReimbursementType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementTypes()
     {

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -156,7 +156,6 @@ class LeaveType extends Remote\Model
 
     /**
      * @return string
-     * Always returns a collection, switch is for type hinting
      */
     public function getTypeOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollAU/PayRun.php
+++ b/src/XeroPHP/Models/PayrollAU/PayRun.php
@@ -314,7 +314,6 @@ class PayRun extends Remote\Model
 
     /**
      * @return Payslip[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getPayslips()
     {

--- a/src/XeroPHP/Models/PayrollAU/Payslip.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip.php
@@ -296,7 +296,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return EarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -320,7 +319,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return TimesheetEarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetEarningsLines()
     {
@@ -344,7 +342,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -368,7 +365,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return LeaveAccrualLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveAccrualLines()
     {
@@ -392,7 +388,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {
@@ -416,7 +411,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return SuperannuationLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSuperannuationLines()
     {
@@ -440,7 +434,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return TaxLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTaxLines()
     {
@@ -496,7 +489,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getWages()
     {
@@ -505,7 +497,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions()
     {
@@ -538,7 +529,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursements()
     {
@@ -547,7 +537,6 @@ class Payslip extends Remote\Model
 
     /**
      * @return LeaveEarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveEarningsLines()
     {

--- a/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
@@ -188,7 +188,6 @@ class DeductionLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
@@ -147,7 +147,6 @@ class EarningsLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
@@ -146,7 +146,6 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollAU/Setting.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting.php
@@ -110,7 +110,6 @@ class Setting extends Remote\Model
 
     /**
      * @return Account[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAccounts()
     {
@@ -134,7 +133,6 @@ class Setting extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories()
     {

--- a/src/XeroPHP/Models/PayrollAU/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet.php
@@ -201,7 +201,6 @@ class Timesheet extends Remote\Model
 
     /**
      * @return TimesheetLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetLines()
     {

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -147,7 +147,6 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -699,7 +699,6 @@ class Employee extends Remote\Model
 
     /**
      * @return SalaryAndWage[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getSalaryAndWages()
     {
@@ -723,7 +722,6 @@ class Employee extends Remote\Model
 
     /**
      * @return WorkLocation[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getWorkLocations()
     {
@@ -787,7 +785,6 @@ class Employee extends Remote\Model
 
     /**
      * @return OpeningBalance[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getOpeningBalances()
     {
@@ -811,7 +808,6 @@ class Employee extends Remote\Model
 
     /**
      * @return TimeOffBalance[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimeOffBalances()
     {

--- a/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
@@ -160,7 +160,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return EarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -184,7 +183,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return BenefitLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines()
     {
@@ -208,7 +206,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -232,7 +229,6 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {

--- a/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
@@ -200,7 +200,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -224,7 +223,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -248,7 +246,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {
@@ -272,7 +269,6 @@ class PayTemplate extends Remote\Model
 
     /**
      * @return BenefitLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines()
     {

--- a/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
@@ -123,7 +123,6 @@ class PaymentMethod extends Remote\Model
 
     /**
      * @return BankAccount[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBankAccounts()
     {

--- a/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
@@ -181,7 +181,6 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @return PayItem[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTypeOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollUS/PayItem.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem.php
@@ -127,7 +127,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return EarningsType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsTypes()
     {
@@ -151,7 +150,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return BenefitType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitTypes()
     {
@@ -175,7 +173,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return DeductionType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionTypes()
     {
@@ -199,7 +196,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return ReimbursementType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementTypes()
     {
@@ -223,7 +219,6 @@ class PayItem extends Remote\Model
 
     /**
      * @return TimeOffType[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimeOffTypes()
     {

--- a/src/XeroPHP/Models/PayrollUS/Paystub.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub.php
@@ -347,7 +347,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarnings()
     {
@@ -371,7 +370,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductions()
     {
@@ -415,7 +413,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursements()
     {
@@ -479,7 +476,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return EarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getEarningsLines()
     {
@@ -503,7 +499,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return LeaveEarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getLeaveEarningsLines()
     {
@@ -527,7 +522,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return TimesheetEarningsLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetEarningsLines()
     {
@@ -551,7 +545,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return DeductionLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getDeductionLines()
     {
@@ -575,7 +568,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return ReimbursementLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getReimbursementLines()
     {
@@ -599,7 +591,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return BenefitLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getBenefitLines()
     {
@@ -623,7 +614,6 @@ class Paystub extends Remote\Model
 
     /**
      * @return TimeOffLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimeOffLines()
     {

--- a/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
@@ -146,7 +146,6 @@ class EarningsLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
@@ -146,7 +146,6 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
@@ -146,7 +146,6 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Models/PayrollUS/Setting.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting.php
@@ -102,7 +102,6 @@ class Setting extends Remote\Model
 
     /**
      * @return Account[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getAccounts()
     {
@@ -126,7 +125,6 @@ class Setting extends Remote\Model
 
     /**
      * @return TrackingCategory[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTrackingCategories()
     {

--- a/src/XeroPHP/Models/PayrollUS/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet.php
@@ -201,7 +201,6 @@ class Timesheet extends Remote\Model
 
     /**
      * @return TimesheetLine[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getTimesheetLines()
     {

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -155,7 +155,6 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @return float[]|Remote\Collection
-     * Always returns a collection, switch is for type hinting
      */
     public function getNumberOfUnits()
     {

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -313,8 +313,8 @@ class Client
     /**
      * Prepend URL with query string.
      *
-     * @param  string  $url
-     * @param  array  $query
+     * @param string $url
+     * @param array $query
      * @return string
      */
     protected function appendUrlQuery($url, $query)
@@ -327,7 +327,7 @@ class Client
     /**
      * Determine if the URL has a query string.
      *
-     * @param  string  $url
+     * @param string $url
      * @return bool
      */
     protected function urlHasQuery($url)

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -164,8 +164,8 @@ class Event
     /**
      * Fetches the resource and, if possible, loads it into it's respective model class
      *
-     * @param  \XeroPHP\Application $application an optional application instance to use to retrieve the remote resource.
-     *                              Useful if you have separate instances with different oauth tokens based on the tenant
+     * @param \XeroPHP\Application $application an optional application instance to use to retrieve the remote resource.
+     *                                          Useful if you have separate instances with different oauth tokens based on the tenant
      * @return \XeroPHP\Remote\Model|array If the event category is known, returns the model, otherwise, returns the resource as an array
      */
     public function getResource($application = null)


### PR DESCRIPTION
All items of the given phpdoc tags must be left-aligned.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer

To appease this rule I also removed a repeating comment that I (personally) thought didn't bring much including. I also think it is probably supposed to be "array" and not "switch".

Pretty sure we could just typehint the collection as `Remote\Collection[LineItem]` as well. Not sure that is exactly it, but I believe there is a way to typehint collections like that.