### PR TITLE
Code style: phpdoc_separation

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -76,6 +76,7 @@ abstract class Application
 
     /**
      * @param string|null $oauth_token
+     *
      * @return string
      */
     public function getAuthorizeURL($oauth_token = null)
@@ -85,7 +86,9 @@ abstract class Application
 
     /**
      * @param mixed $key
+     *
      * @throws Exception
+     *
      * @return mixed
      */
     public function getConfig($key)
@@ -101,7 +104,9 @@ abstract class Application
      * @param string $config
      * @param mixed $option
      * @param mixed $value
+     *
      * @throws Exception
+     *
      * @return mixed
      */
     public function getConfigOption($config, $option)
@@ -115,6 +120,7 @@ abstract class Application
 
     /**
      * @param array $config
+     *
      * @return array
      */
     public function setConfig($config)
@@ -132,7 +138,9 @@ abstract class Application
      * @param string $config
      * @param mixed $option
      * @param mixed $value
+     *
      * @throws Exception
+     *
      * @return array
      */
     public function setConfigOption($config, $option, $value)
@@ -149,7 +157,9 @@ abstract class Application
      * Validates and expands the provided model class to a full PHP class.
      *
      * @param string $class
+     *
      * @throws Exception
+     *
      * @return string
      */
     public function validateModelClass($class)
@@ -171,6 +181,7 @@ abstract class Application
      * Prepend the configuration namespace to the class.
      *
      * @param string $class
+     *
      * @return string
      */
     protected function prependConfigNamespace($class)
@@ -183,8 +194,10 @@ abstract class Application
      *
      * @param $model
      * @param $guid
+     *
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
+     *
      * @return Remote\Model|null
      */
     public function loadByGUID($model, $guid)
@@ -220,8 +233,10 @@ abstract class Application
      *
      * @param $model
      * @param string $guids
+     *
      * @throws Exception
      * @throws Remote\Exception\NotFoundException
+     *
      * @return Collection
      */
     public function loadByGUIDs($model, $guids)
@@ -253,7 +268,9 @@ abstract class Application
 
     /**
      * @param string $model
+     *
      * @throws Remote\Exception
+     *
      * @return Query
      */
     public function load($model)
@@ -266,7 +283,9 @@ abstract class Application
     /**
      * @param Remote\Model $object
      * @param bool $replace_data
+     *
      * @throws Exception
+     *
      * @return Remote\Response|null
      */
     public function save(Remote\Model $object, $replace_data = false)
@@ -316,7 +335,9 @@ abstract class Application
      * @param Collection|array $objects
      * @param mixed $checkGuid
      * @param mixed $replace_data
+     *
      * @throws Exception
+     *
      * @return Remote\Response
      */
     public function saveAll($objects, $checkGuid = true, $replace_data = false)
@@ -377,6 +398,7 @@ abstract class Application
      * adding contacts to ContactGroups
      *
      * @param Remote\Model $object
+     *
      * @throws Exception
      */
     private function savePropertiesDirectly(Remote\Model $object)
@@ -418,7 +440,9 @@ abstract class Application
 
     /**
      * @param Remote\Model $object
+     *
      * @throws Exception
+     *
      * @return Remote\Response
      */
     public function delete(Remote\Model $object)

--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -19,6 +19,7 @@ class Helpers
      *
      * @param array $array
      * @param null $key_override
+     *
      * @return string
      */
     public static function arrayToXML(array $array, $key_override = null)
@@ -96,6 +97,7 @@ class Helpers
      * so only good for a quick basic singularisation.
      *
      * @param $string
+     *
      * @return mixed
      */
     public static function singularize($string)
@@ -169,6 +171,7 @@ class Helpers
      * @param string $format
      * @param string|null $glue
      * @param bool $escape
+     *
      * @return string|array if no glue provided, it won't be imploded
      */
     public static function flattenAssocArray(
@@ -201,6 +204,7 @@ class Helpers
      * the SimpleOAuth class.
      *
      * @param $string
+     *
      * @return string
      */
     public static function escape($string)
@@ -211,7 +215,9 @@ class Helpers
     /**
      * @param $knownString string
      * @param $userInput string
+     *
      * @return bool
+     *
      * @see https://github.com/symfony/polyfill-php56
      */
     public static function hashEquals($knownString, $userInput)

--- a/src/XeroPHP/Models/Accounting/Account.php
+++ b/src/XeroPHP/Models/Accounting/Account.php
@@ -312,6 +312,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setCode($value)
@@ -332,6 +333,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setName($value)
@@ -352,6 +354,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setType($value)
@@ -372,6 +375,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setBankAccountNumber($value)
@@ -392,6 +396,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setStatus($value)
@@ -412,6 +417,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setDescription($value)
@@ -432,6 +438,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setBankAccountType($value)
@@ -452,6 +459,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setCurrencyCode($value)
@@ -472,6 +480,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setTaxType($value)
@@ -492,6 +501,7 @@ class Account extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Account
      */
     public function setEnablePaymentsToAccount($value)
@@ -512,6 +522,7 @@ class Account extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Account
      */
     public function setShowInExpenseClaim($value)
@@ -532,6 +543,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setAccountID($value)

--- a/src/XeroPHP/Models/Accounting/Address.php
+++ b/src/XeroPHP/Models/Accounting/Address.php
@@ -162,6 +162,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAddressType($value)
@@ -182,6 +183,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAddressLine1($value)
@@ -202,6 +204,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAddressLine2($value)
@@ -222,6 +225,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAddressLine3($value)
@@ -242,6 +246,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAddressLine4($value)
@@ -262,6 +267,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setCity($value)
@@ -282,6 +288,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setRegion($value)
@@ -302,6 +309,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setPostalCode($value)
@@ -322,6 +330,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setCountry($value)
@@ -342,6 +351,7 @@ class Address extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Address
      */
     public function setAttentionTo($value)

--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -263,6 +263,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setType($value)
@@ -283,6 +284,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return BankTransaction
      */
     public function setContact(Contact $value)
@@ -303,6 +305,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return BankTransaction
      */
     public function addLineItem(LineItem $value)
@@ -326,6 +329,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param BankAccount $value
+     *
      * @return BankTransaction
      */
     public function setBankAccount(BankAccount $value)
@@ -346,6 +350,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return BankTransaction
      */
     public function setIsReconciled($value)
@@ -366,6 +371,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return BankTransaction
      */
     public function setDate(\DateTimeInterface $value)
@@ -386,6 +392,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setReference($value)
@@ -406,6 +413,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setCurrencyCode($value)
@@ -426,6 +434,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankTransaction
      */
     public function setCurrencyRate($value)
@@ -446,6 +455,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setUrl($value)
@@ -466,6 +476,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setStatus($value)
@@ -486,6 +497,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setLineAmountType($value)
@@ -506,6 +518,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankTransaction
      */
     public function setSubTotal($value)
@@ -526,6 +539,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankTransaction
      */
     public function setTotalTax($value)
@@ -546,6 +560,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankTransaction
      */
     public function setTotal($value)
@@ -566,6 +581,7 @@ class BankTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransaction
      */
     public function setBankTransactionID($value)

--- a/src/XeroPHP/Models/Accounting/BankTransaction/BankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/BankAccount.php
@@ -101,6 +101,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setCode($value)
@@ -121,6 +122,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountID($value)

--- a/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
@@ -158,6 +158,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDescription($value)
@@ -178,6 +179,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setQuantity($value)
@@ -198,6 +200,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setUnitAmount($value)
@@ -218,6 +221,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setAccountCode($value)
@@ -238,6 +242,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setItemCode($value)
@@ -258,6 +263,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setLineItemID($value)
@@ -278,6 +284,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setTaxType($value)
@@ -298,6 +305,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setLineAmount($value)
@@ -318,6 +326,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return LineItem
      */
     public function addTracking(TrackingCategory $value)

--- a/src/XeroPHP/Models/Accounting/BankTransfer.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer.php
@@ -166,6 +166,7 @@ class BankTransfer extends Remote\Model
 
     /**
      * @param FromBankAccount $value
+     *
      * @return BankTransfer
      */
     public function setFromBankAccount(FromBankAccount $value)
@@ -186,6 +187,7 @@ class BankTransfer extends Remote\Model
 
     /**
      * @param ToBankAccount $value
+     *
      * @return BankTransfer
      */
     public function setToBankAccount(ToBankAccount $value)
@@ -206,6 +208,7 @@ class BankTransfer extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransfer
      */
     public function setAmount($value)
@@ -226,6 +229,7 @@ class BankTransfer extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return BankTransfer
      */
     public function setDate(\DateTimeInterface $value)
@@ -246,6 +250,7 @@ class BankTransfer extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankTransfer
      */
     public function setBankTransferID($value)

--- a/src/XeroPHP/Models/Accounting/BankTransfer/FromBankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer/FromBankAccount.php
@@ -108,6 +108,7 @@ class FromBankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return FromBankAccount
      */
     public function setCode($value)
@@ -128,6 +129,7 @@ class FromBankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return FromBankAccount
      */
     public function setAccountID($value)

--- a/src/XeroPHP/Models/Accounting/BankTransfer/ToBankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer/ToBankAccount.php
@@ -108,6 +108,7 @@ class ToBankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ToBankAccount
      */
     public function setCode($value)
@@ -128,6 +129,7 @@ class ToBankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ToBankAccount
      */
     public function setAccountID($value)

--- a/src/XeroPHP/Models/Accounting/BrandingTheme.php
+++ b/src/XeroPHP/Models/Accounting/BrandingTheme.php
@@ -116,6 +116,7 @@ class BrandingTheme extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BrandingTheme
      */
     public function setBrandingThemeID($value)
@@ -136,6 +137,7 @@ class BrandingTheme extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BrandingTheme
      */
     public function setName($value)
@@ -156,6 +158,7 @@ class BrandingTheme extends Remote\Model
 
     /**
      * @param int $value
+     *
      * @return BrandingTheme
      */
     public function setSortOrder($value)
@@ -176,6 +179,7 @@ class BrandingTheme extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return BrandingTheme
      */
     public function setCreatedDateUTC(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -356,6 +356,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setContactID($value)
@@ -376,6 +377,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setContactNumber($value)
@@ -396,6 +398,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setAccountNumber($value)
@@ -416,6 +419,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setContactStatus($value)
@@ -436,6 +440,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setName($value)
@@ -456,6 +461,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setFirstName($value)
@@ -476,6 +482,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setLastName($value)
@@ -496,6 +503,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setEmailAddress($value)
@@ -516,6 +524,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setSkypeUserName($value)
@@ -536,6 +545,7 @@ class Contact extends Remote\Model
 
     /**
      * @param ContactPerson $value
+     *
      * @return Contact
      */
     public function addContactPerson(ContactPerson $value)
@@ -559,6 +569,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setBankAccountDetail($value)
@@ -579,6 +590,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setTaxNumber($value)
@@ -599,6 +611,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setAccountsReceivableTaxType($value)
@@ -619,6 +632,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setAccountsPayableTaxType($value)
@@ -639,6 +653,7 @@ class Contact extends Remote\Model
 
     /**
      * @param Address $value
+     *
      * @return Contact
      */
     public function addAddress(Address $value)
@@ -662,6 +677,7 @@ class Contact extends Remote\Model
 
     /**
      * @param Phone $value
+     *
      * @return Contact
      */
     public function addPhone(Phone $value)
@@ -685,6 +701,7 @@ class Contact extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setIsSupplier($value)
@@ -701,6 +718,7 @@ class Contact extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setIsCustomer($value)
@@ -717,6 +735,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setDefaultCurrency($value)
@@ -737,6 +756,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setXeroNetworkKey($value)
@@ -757,6 +777,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setSalesDefaultAccountCode($value)
@@ -777,6 +798,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setPurchasesDefaultAccountCode($value)
@@ -797,6 +819,7 @@ class Contact extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return Contact
      */
     public function addSalesTrackingCategory(TrackingCategory $value)
@@ -820,6 +843,7 @@ class Contact extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return Contact
      */
     public function addPurchasesTrackingCategory(TrackingCategory $value)
@@ -843,6 +867,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setTrackingCategoryName($value)
@@ -863,6 +888,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setTrackingCategoryOption($value)
@@ -883,6 +909,7 @@ class Contact extends Remote\Model
 
     /**
      * @param PaymentTerm $value
+     *
      * @return Contact
      */
     public function addPaymentTerm(PaymentTerm $value)
@@ -906,6 +933,7 @@ class Contact extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Contact
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -926,6 +954,7 @@ class Contact extends Remote\Model
 
     /**
      * @param ContactGroup $value
+     *
      * @return Contact
      */
     public function addContactGroup(ContactGroup $value)
@@ -949,6 +978,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setWebsite($value)
@@ -969,6 +999,7 @@ class Contact extends Remote\Model
 
     /**
      * @param BrandingTheme $value
+     *
      * @return Contact
      */
     public function setBrandingTheme(BrandingTheme $value)
@@ -989,6 +1020,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setBatchPayment($value)
@@ -1009,6 +1041,7 @@ class Contact extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Contact
      */
     public function setDiscount($value)
@@ -1029,6 +1062,7 @@ class Contact extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Contact
      */
     public function setBalance($value)
@@ -1049,6 +1083,7 @@ class Contact extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setHasAttachment($value)

--- a/src/XeroPHP/Models/Accounting/Contact/ContactPerson.php
+++ b/src/XeroPHP/Models/Accounting/Contact/ContactPerson.php
@@ -115,6 +115,7 @@ class ContactPerson extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactPerson
      */
     public function setFirstName($value)
@@ -135,6 +136,7 @@ class ContactPerson extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactPerson
      */
     public function setLastName($value)
@@ -155,6 +157,7 @@ class ContactPerson extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactPerson
      */
     public function setEmailAddress($value)
@@ -175,6 +178,7 @@ class ContactPerson extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return ContactPerson
      */
     public function setIncludeInEmail($value)

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -123,6 +123,7 @@ class ContactGroup extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactGroup
      */
     public function setName($value)
@@ -143,6 +144,7 @@ class ContactGroup extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactGroup
      */
     public function setStatus($value)
@@ -163,6 +165,7 @@ class ContactGroup extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ContactGroup
      */
     public function setContactGroupID($value)
@@ -183,6 +186,7 @@ class ContactGroup extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return ContactGroup
      */
     public function addContact(Contact $value)

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -252,6 +252,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setType($value)
@@ -272,6 +273,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return CreditNote
      */
     public function setContact(Contact $value)
@@ -292,6 +294,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return CreditNote
      */
     public function setDate(\DateTimeInterface $value)
@@ -312,6 +315,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setStatus($value)
@@ -332,6 +336,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setLineAmountType($value)
@@ -352,6 +357,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return CreditNote
      */
     public function addLineItem(LineItem $value)
@@ -383,6 +389,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return CreditNote
      */
     public function setSubTotal($value)
@@ -403,6 +410,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return CreditNote
      */
     public function setTotalTax($value)
@@ -423,6 +431,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return CreditNote
      */
     public function setTotal($value)
@@ -443,6 +452,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return CreditNote
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -463,6 +473,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setCurrencyCode($value)
@@ -483,6 +494,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return CreditNote
      */
     public function setFullyPaidOnDate(\DateTimeInterface $value)
@@ -503,6 +515,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setCreditNoteID($value)
@@ -523,6 +536,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setCreditNoteNumber($value)
@@ -543,6 +557,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setReference($value)
@@ -563,6 +578,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return CreditNote
      */
     public function setSentToContact($value)
@@ -583,6 +599,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return CreditNote
      */
     public function setCurrencyRate($value)
@@ -603,6 +620,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setRemainingCredit($value)
@@ -623,6 +641,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param Allocation $value
+     *
      * @return CreditNote
      */
     public function addAllocation(Allocation $value)
@@ -646,6 +665,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return CreditNote
      */
     public function setBrandingThemeID($value)
@@ -666,6 +686,7 @@ class CreditNote extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setHasAttachment($value)

--- a/src/XeroPHP/Models/Accounting/CreditNote/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote/Allocation.php
@@ -110,6 +110,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param Invoice $value
+     *
      * @return Allocation
      */
     public function setInvoice(Invoice $value)
@@ -130,6 +131,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Allocation
      */
     public function setAppliedAmount($value)
@@ -150,6 +152,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Allocation
      */
     public function setDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/Currency.php
+++ b/src/XeroPHP/Models/Accounting/Currency.php
@@ -10,6 +10,7 @@ class Currency extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string ModifiedAfter
+     *
      * @deprecated
      */
 
@@ -103,6 +104,7 @@ class Currency extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getModifiedAfter()
@@ -112,7 +114,9 @@ class Currency extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Currency
+     *
      * @deprecated
      */
     public function setModifiedAfter($value)
@@ -133,6 +137,7 @@ class Currency extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Currency
      */
     public function setCode($value)
@@ -153,6 +158,7 @@ class Currency extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Currency
      */
     public function setDescription($value)

--- a/src/XeroPHP/Models/Accounting/Employee.php
+++ b/src/XeroPHP/Models/Accounting/Employee.php
@@ -129,6 +129,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeID($value)
@@ -149,6 +150,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setStatus($value)
@@ -169,6 +171,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setFirstName($value)
@@ -189,6 +192,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setLastName($value)
@@ -209,6 +213,7 @@ class Employee extends Remote\Model
 
     /**
      * @param ExternalLink $value
+     *
      * @return Employee
      */
     public function setExternalLink(ExternalLink $value)

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim.php
@@ -130,6 +130,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExpenseClaim
      */
     public function setExpenseClaimID($value)
@@ -150,6 +151,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param User $value
+     *
      * @return ExpenseClaim
      */
     public function setUser(User $value)
@@ -170,6 +172,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param Receipt $value
+     *
      * @return ExpenseClaim
      */
     public function addReceipt(Receipt $value)
@@ -201,6 +204,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExpenseClaim
      */
     public function setStatus($value)

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
@@ -158,6 +158,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExpenseClaim
      */
     public function setExpenseClaimID($value)
@@ -242,6 +243,7 @@ class ExpenseClaim extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExpenseClaim
      */
     public function setReceiptID($value)

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -105,6 +105,7 @@ class History extends Model
 
     /**
      * @param string $value
+     *
      * @return History
      */
     public function setDetails($value)

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -344,6 +344,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setType($value)
@@ -364,6 +365,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return Invoice
      */
     public function setContact(Contact $value)
@@ -388,6 +390,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return Invoice
      */
     public function addLineItem(LineItem $value)
@@ -411,6 +414,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Invoice
      */
     public function setDate(\DateTimeInterface $value)
@@ -431,6 +435,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Invoice
      */
     public function setDueDate(\DateTimeInterface $value)
@@ -451,6 +456,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setLineAmountType($value)
@@ -471,6 +477,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setInvoiceNumber($value)
@@ -491,6 +498,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setReference($value)
@@ -511,6 +519,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setBrandingThemeID($value)
@@ -531,6 +540,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setUrl($value)
@@ -551,6 +561,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setCurrencyCode($value)
@@ -571,6 +582,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Invoice
      */
     public function setCurrencyRate($value)
@@ -591,6 +603,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setStatus($value)
@@ -611,6 +624,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Invoice
      */
     public function setSentToContact($value)
@@ -631,6 +645,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setExpectedPaymentDate($value)
@@ -651,6 +666,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setPlannedPaymentDate($value)
@@ -703,6 +719,7 @@ class Invoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Invoice
      */
     public function setInvoiceID($value)
@@ -797,6 +814,7 @@ class Invoice extends Remote\Model
      * Retrieve the online invoice URL.
      *
      * @throws \XeroPHP\Exception
+     *
      * @return string
      */
     public function getOnlineInvoiceUrl()

--- a/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Invoice/LineItem.php
@@ -173,6 +173,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDescription($value)
@@ -193,6 +194,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setQuantity($value)
@@ -213,6 +215,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setUnitAmount($value)
@@ -233,6 +236,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setItemCode($value)
@@ -253,6 +257,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setAccountCode($value)
@@ -273,6 +278,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setLineItemID($value)
@@ -293,6 +299,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setTaxType($value)
@@ -313,6 +320,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setTaxAmount($value)
@@ -333,6 +341,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setLineAmount($value)
@@ -353,6 +362,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return LineItem
      */
     public function addTracking(TrackingCategory $value)
@@ -376,6 +386,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDiscountRate($value)

--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -200,6 +200,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setItemID($value)
@@ -220,6 +221,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setCode($value)
@@ -240,6 +242,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setInventoryAssetAccountCode($value)
@@ -260,6 +263,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setName($value)
@@ -280,6 +284,7 @@ class Item extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Item
      */
     public function setIsSold($value)
@@ -300,6 +305,7 @@ class Item extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Item
      */
     public function setIsPurchased($value)
@@ -320,6 +326,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setDescription($value)
@@ -340,6 +347,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setPurchaseDescription($value)
@@ -360,7 +368,9 @@ class Item extends Remote\Model
 
     /**
      * @param Purchase $value
+     *
      * @return Item
+     *
      * @deprecated
      */
     public function addPurchaseDetail(Purchase $value)
@@ -369,6 +379,7 @@ class Item extends Remote\Model
 
     /**
      * @param Purchase $value
+     *
      * @return Item
      */
     public function setPurchaseDetails(Purchase $value)
@@ -389,7 +400,9 @@ class Item extends Remote\Model
 
     /**
      * @param Sale $value
+     *
      * @return Item
+     *
      * @deprecated
      */
     public function addSalesDetail(Sale $value)
@@ -398,6 +411,7 @@ class Item extends Remote\Model
 
     /**
      * @param Sale $value
+     *
      * @return Item
      */
     public function setSalesDetails(Sale $value)
@@ -418,6 +432,7 @@ class Item extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Item
      */
     public function setIsTrackedAsInventory($value)
@@ -438,6 +453,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setTotalCostPool($value)
@@ -458,6 +474,7 @@ class Item extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Item
      */
     public function setQuantityOnHand($value)
@@ -478,6 +495,7 @@ class Item extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Item
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/Item/Purchase.php
+++ b/src/XeroPHP/Models/Accounting/Item/Purchase.php
@@ -30,6 +30,7 @@ class Purchase extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property \DateTimeInterface UpdatedDateUTC
+     *
      * @deprecated
      */
 
@@ -126,6 +127,7 @@ class Purchase extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Purchase
      */
     public function setUnitPrice($value)
@@ -146,6 +148,7 @@ class Purchase extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Purchase
      */
     public function setAccountCode($value)
@@ -166,6 +169,7 @@ class Purchase extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Purchase
      */
     public function setCOGSAccountCode($value)
@@ -178,6 +182,7 @@ class Purchase extends Remote\Model
 
     /**
      * @return \DateTimeInterface
+     *
      * @deprecated
      */
     public function getUpdatedDateUTC()
@@ -187,7 +192,9 @@ class Purchase extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Purchase
+     *
      * @deprecated
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -208,6 +215,7 @@ class Purchase extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Purchase
      */
     public function setTaxType($value)

--- a/src/XeroPHP/Models/Accounting/Item/Sale.php
+++ b/src/XeroPHP/Models/Accounting/Item/Sale.php
@@ -30,6 +30,7 @@ class Sale extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property \DateTimeInterface UpdatedDateUTC
+     *
      * @deprecated
      */
 
@@ -126,6 +127,7 @@ class Sale extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Sale
      */
     public function setUnitPrice($value)
@@ -146,6 +148,7 @@ class Sale extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Sale
      */
     public function setAccountCode($value)
@@ -166,6 +169,7 @@ class Sale extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Sale
      */
     public function setCOGSAccountCode($value)
@@ -178,6 +182,7 @@ class Sale extends Remote\Model
 
     /**
      * @return \DateTimeInterface
+     *
      * @deprecated
      */
     public function getUpdatedDateUTC()
@@ -187,7 +192,9 @@ class Sale extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Sale
+     *
      * @deprecated
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -208,6 +215,7 @@ class Sale extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Sale
      */
     public function setTaxType($value)

--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -194,6 +194,7 @@ class Journal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Journal
      */
     public function setJournalID($value)
@@ -214,6 +215,7 @@ class Journal extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Journal
      */
     public function setJournalDate(\DateTimeInterface $value)
@@ -234,6 +236,7 @@ class Journal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Journal
      */
     public function setJournalNumber($value)
@@ -254,6 +257,7 @@ class Journal extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Journal
      */
     public function setCreatedDateUTC(\DateTimeInterface $value)
@@ -274,6 +278,7 @@ class Journal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Journal
      */
     public function setReference($value)
@@ -294,6 +299,7 @@ class Journal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Journal
      */
     public function setSourceID($value)
@@ -314,6 +320,7 @@ class Journal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Journal
      */
     public function setSourceType($value)
@@ -334,6 +341,7 @@ class Journal extends Remote\Model
 
     /**
      * @param JournalLine $value
+     *
      * @return Journal
      */
     public function addJournalLine(JournalLine $value)

--- a/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
@@ -173,6 +173,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setJournalLineID($value)
@@ -193,6 +194,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setAccountID($value)
@@ -213,6 +215,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setAccountCode($value)
@@ -233,6 +236,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setAccountType($value)
@@ -253,6 +257,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setAccountName($value)
@@ -273,6 +278,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setDescription($value)
@@ -293,6 +299,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return JournalLine
      */
     public function setNetAmount($value)
@@ -313,6 +320,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return JournalLine
      */
     public function setGrossAmount($value)
@@ -333,6 +341,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return JournalLine
      */
     public function setTaxAmount($value)
@@ -353,6 +362,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setTaxType($value)
@@ -373,6 +383,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param TaxRate $value
+     *
      * @return JournalLine
      */
     public function setTaxName(TaxRate $value)
@@ -393,6 +404,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return JournalLine
      */
     public function addTrackingCategory(TrackingCategory $value)

--- a/src/XeroPHP/Models/Accounting/LinkedTransaction.php
+++ b/src/XeroPHP/Models/Accounting/LinkedTransaction.php
@@ -179,6 +179,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setSourceTransactionID($value)
@@ -199,6 +200,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setSourceLineItemID($value)
@@ -219,6 +221,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setContactID($value)
@@ -239,6 +242,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setTargetTransactionID($value)
@@ -259,6 +263,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setTargetLineItemID($value)
@@ -279,6 +284,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setLinkedTransactionID($value)
@@ -299,6 +305,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setStatus($value)
@@ -319,6 +326,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setType($value)
@@ -339,6 +347,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return LinkedTransaction
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -359,6 +368,7 @@ class LinkedTransaction extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LinkedTransaction
      */
     public function setSourceTransactionTypeCode($value)

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -171,6 +171,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ManualJournal
      */
     public function setManualJournalID($value)
@@ -191,6 +192,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ManualJournal
      */
     public function setNarration($value)
@@ -211,6 +213,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param JournalLine $value
+     *
      * @return ManualJournal
      */
     public function addJournalLine(JournalLine $value)
@@ -234,6 +237,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return ManualJournal
      */
     public function setDate(\DateTimeInterface $value)
@@ -254,6 +258,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ManualJournal
      */
     public function setLineAmountType($value)
@@ -274,6 +279,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ManualJournal
      */
     public function setStatus($value)
@@ -294,6 +300,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ManualJournal
      */
     public function setUrl($value)
@@ -314,6 +321,7 @@ class ManualJournal extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return ManualJournal
      */
     public function setShowOnCashBasisReport($value)

--- a/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
@@ -132,6 +132,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setLineAmount($value)
@@ -152,6 +153,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setAccountCode($value)
@@ -172,6 +174,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setDescription($value)
@@ -192,6 +195,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return JournalLine
      */
     public function setTaxType($value)
@@ -212,6 +216,7 @@ class JournalLine extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return JournalLine
      */
     public function addTracking(TrackingCategory $value)

--- a/src/XeroPHP/Models/Accounting/Organisation.php
+++ b/src/XeroPHP/Models/Accounting/Organisation.php
@@ -332,6 +332,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setAPIKey($value)
@@ -352,6 +353,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setName($value)
@@ -372,6 +374,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setLegalName($value)
@@ -392,6 +395,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Organisation
      */
     public function setPaysTax($value)
@@ -412,6 +416,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setVersion($value)
@@ -432,6 +437,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setOrganisationType($value)
@@ -452,6 +458,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setBaseCurrency($value)
@@ -472,6 +479,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setCountryCode($value)
@@ -492,6 +500,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Organisation
      */
     public function setIsDemoCompany($value)
@@ -512,6 +521,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setOrganisationStatus($value)
@@ -532,6 +542,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setRegistrationNumber($value)
@@ -552,6 +563,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setTaxNumber($value)
@@ -572,6 +584,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setFinancialYearEndDay($value)
@@ -592,6 +605,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setFinancialYearEndMonth($value)
@@ -612,6 +626,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setSalesTaxBasis($value)
@@ -632,6 +647,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setSalesTaxPeriod($value)
@@ -652,6 +668,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setDefaultSalesTax($value)
@@ -672,6 +689,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setDefaultPurchasesTax($value)
@@ -692,6 +710,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setPeriodLockDate($value)
@@ -712,6 +731,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setEndOfYearLockDate($value)
@@ -732,6 +752,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Organisation
      */
     public function setCreatedDateUTC(\DateTimeInterface $value)
@@ -752,6 +773,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setTimezone($value)
@@ -772,6 +794,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setOrganisationEntityType($value)
@@ -792,6 +815,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setShortCode($value)
@@ -812,6 +836,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Organisation
      */
     public function setLineOfBusiness($value)
@@ -832,6 +857,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param Address $value
+     *
      * @return Organisation
      */
     public function addAddress(Address $value)
@@ -855,6 +881,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param Phone $value
+     *
      * @return Organisation
      */
     public function addPhone(Phone $value)
@@ -878,6 +905,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param ExternalLink $value
+     *
      * @return Organisation
      */
     public function addExternalLink(ExternalLink $value)
@@ -901,6 +929,7 @@ class Organisation extends Remote\Model
 
     /**
      * @param PaymentTerm $value
+     *
      * @return Organisation
      */
     public function addPaymentTerm(PaymentTerm $value)

--- a/src/XeroPHP/Models/Accounting/Organisation/Bill.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/Bill.php
@@ -101,6 +101,7 @@ class Bill extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Bill
      */
     public function setDay($value)
@@ -121,6 +122,7 @@ class Bill extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Bill
      */
     public function setType($value)

--- a/src/XeroPHP/Models/Accounting/Organisation/ExternalLink.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/ExternalLink.php
@@ -110,6 +110,7 @@ class ExternalLink extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExternalLink
      */
     public function setLinkType($value)
@@ -130,6 +131,7 @@ class ExternalLink extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ExternalLink
      */
     public function setUrl($value)

--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -108,6 +108,7 @@ class PaymentTerm extends Remote\Model
 
     /**
      * @param Bill $value
+     *
      * @return PaymentTerm
      */
     public function addBill(Bill $value)
@@ -131,6 +132,7 @@ class PaymentTerm extends Remote\Model
 
     /**
      * @param Sale $value
+     *
      * @return PaymentTerm
      */
     public function addSale(Sale $value)

--- a/src/XeroPHP/Models/Accounting/Organisation/Sale.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/Sale.php
@@ -101,6 +101,7 @@ class Sale extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Sale
      */
     public function setDay($value)
@@ -121,6 +122,7 @@ class Sale extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Sale
      */
     public function setType($value)

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -17,6 +17,7 @@ class Overpayment extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string Reference
+     *
      * @deprecated
      */
 
@@ -90,6 +91,7 @@ class Overpayment extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string FullyPaidOnDate
+     *
      * @deprecated
      */
 
@@ -233,6 +235,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getReference()
@@ -242,7 +245,9 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
+     *
      * @deprecated
      */
     public function setReference($value)
@@ -263,6 +268,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setType($value)
@@ -283,6 +289,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return Overpayment
      */
     public function setContact(Contact $value)
@@ -303,6 +310,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Overpayment
      */
     public function setDate(\DateTimeInterface $value)
@@ -323,6 +331,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setStatus($value)
@@ -343,6 +352,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setLineAmountType($value)
@@ -363,6 +373,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return Overpayment
      */
     public function addLineItem(LineItem $value)
@@ -386,6 +397,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Overpayment
      */
     public function setSubTotal($value)
@@ -406,6 +418,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Overpayment
      */
     public function setTotalTax($value)
@@ -426,6 +439,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Overpayment
      */
     public function setTotal($value)
@@ -446,6 +460,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Overpayment
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -466,6 +481,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setCurrencyCode($value)
@@ -478,6 +494,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getFullyPaidOnDate()
@@ -487,7 +504,9 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
+     *
      * @deprecated
      */
     public function setFullyPaidOnDate($value)
@@ -508,6 +527,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setOverpaymentID($value)
@@ -528,6 +548,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Overpayment
      */
     public function setCurrencyRate($value)
@@ -548,6 +569,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Overpayment
      */
     public function setRemainingCredit($value)
@@ -568,6 +590,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param Allocation $value
+     *
      * @return Overpayment
      */
     public function addAllocation(Allocation $value)
@@ -591,6 +614,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @param Payment $value
+     *
      * @return Overpayment
      */
     public function addPayment(Payment $value)
@@ -614,6 +638,7 @@ class Overpayment extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setHasAttachment($value)

--- a/src/XeroPHP/Models/Accounting/Overpayment/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment/Allocation.php
@@ -110,6 +110,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param Invoice $value
+     *
      * @return Allocation
      */
     public function setInvoice(Invoice $value)
@@ -130,6 +131,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Allocation
      */
     public function setAppliedAmount($value)
@@ -150,6 +152,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Allocation
      */
     public function setDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/Payment.php
+++ b/src/XeroPHP/Models/Accounting/Payment.php
@@ -221,6 +221,7 @@ class Payment extends Remote\Model
 
     /**
      * @param Invoice $value
+     *
      * @return Payment
      */
     public function setInvoice(Invoice $value)
@@ -241,6 +242,7 @@ class Payment extends Remote\Model
 
     /**
      * @param CreditNote $value
+     *
      * @return Payment
      */
     public function setCreditNote(CreditNote $value)
@@ -261,6 +263,7 @@ class Payment extends Remote\Model
 
     /**
      * @param Prepayment $value
+     *
      * @return Payment
      */
     public function setPrepayment(Prepayment $value)
@@ -281,6 +284,7 @@ class Payment extends Remote\Model
 
     /**
      * @param Overpayment $value
+     *
      * @return Payment
      */
     public function setOverpayment(Overpayment $value)
@@ -301,6 +305,7 @@ class Payment extends Remote\Model
 
     /**
      * @param Account $value
+     *
      * @return Payment
      */
     public function setAccount(Account $value)
@@ -321,6 +326,7 @@ class Payment extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Payment
      */
     public function setDate(\DateTimeInterface $value)
@@ -341,6 +347,7 @@ class Payment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Payment
      */
     public function setCurrencyRate($value)
@@ -361,6 +368,7 @@ class Payment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Payment
      */
     public function setAmount($value)
@@ -381,6 +389,7 @@ class Payment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payment
      */
     public function setReference($value)
@@ -401,6 +410,7 @@ class Payment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payment
      */
     public function setIsReconciled($value)
@@ -421,6 +431,7 @@ class Payment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payment
      */
     public function setStatus($value)
@@ -457,6 +468,7 @@ class Payment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payment
      */
     public function setPaymentID($value)

--- a/src/XeroPHP/Models/Accounting/Phone.php
+++ b/src/XeroPHP/Models/Accounting/Phone.php
@@ -122,6 +122,7 @@ class Phone extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Phone
      */
     public function setPhoneType($value)
@@ -142,6 +143,7 @@ class Phone extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Phone
      */
     public function setPhoneNumber($value)
@@ -162,6 +164,7 @@ class Phone extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Phone
      */
     public function setPhoneAreaCode($value)
@@ -182,6 +185,7 @@ class Phone extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Phone
      */
     public function setPhoneCountryCode($value)

--- a/src/XeroPHP/Models/Accounting/Prepayment.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment.php
@@ -17,6 +17,7 @@ class Prepayment extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string Reference
+     *
      * @deprecated
      */
 
@@ -90,6 +91,7 @@ class Prepayment extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string FullyPaidOnDate
+     *
      * @deprecated
      */
 
@@ -226,6 +228,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getReference()
@@ -235,7 +238,9 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
+     *
      * @deprecated
      */
     public function setReference($value)
@@ -256,6 +261,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setType($value)
@@ -276,6 +282,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return Prepayment
      */
     public function setContact(Contact $value)
@@ -296,6 +303,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Prepayment
      */
     public function setDate(\DateTimeInterface $value)
@@ -316,6 +324,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setStatus($value)
@@ -336,6 +345,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setLineAmountType($value)
@@ -356,6 +366,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return Prepayment
      */
     public function addLineItem(LineItem $value)
@@ -379,6 +390,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Prepayment
      */
     public function setSubTotal($value)
@@ -399,6 +411,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Prepayment
      */
     public function setTotalTax($value)
@@ -419,6 +432,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Prepayment
      */
     public function setTotal($value)
@@ -439,6 +453,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Prepayment
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -459,6 +474,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setCurrencyCode($value)
@@ -471,6 +487,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getFullyPaidOnDate()
@@ -480,7 +497,9 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
+     *
      * @deprecated
      */
     public function setFullyPaidOnDate($value)
@@ -501,6 +520,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setPrepaymentID($value)
@@ -521,6 +541,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Prepayment
      */
     public function setCurrencyRate($value)
@@ -541,6 +562,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Prepayment
      */
     public function setRemainingCredit($value)
@@ -561,6 +583,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @param Allocation $value
+     *
      * @return Prepayment
      */
     public function addAllocation(Allocation $value)
@@ -584,6 +607,7 @@ class Prepayment extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setHasAttachment($value)

--- a/src/XeroPHP/Models/Accounting/Prepayment/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment/Allocation.php
@@ -110,6 +110,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param Invoice $value
+     *
      * @return Allocation
      */
     public function setInvoice(Invoice $value)
@@ -130,6 +131,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Allocation
      */
     public function setAppliedAmount($value)
@@ -150,6 +152,7 @@ class Allocation extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Allocation
      */
     public function setDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder.php
@@ -280,6 +280,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return PurchaseOrder
      */
     public function setContact(Contact $value)
@@ -300,6 +301,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return PurchaseOrder
      */
     public function addLineItem(LineItem $value)
@@ -323,6 +325,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PurchaseOrder
      */
     public function setDate(\DateTimeInterface $value)
@@ -343,6 +346,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PurchaseOrder
      */
     public function setDeliveryDate(\DateTimeInterface $value)
@@ -363,6 +367,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setLineAmountType($value)
@@ -383,6 +388,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setPurchaseOrderNumber($value)
@@ -403,6 +409,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setReference($value)
@@ -423,6 +430,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setBrandingThemeID($value)
@@ -443,6 +451,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setCurrencyCode($value)
@@ -463,6 +472,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setStatus($value)
@@ -483,6 +493,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return PurchaseOrder
      */
     public function setSentToContact($value)
@@ -503,6 +514,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setDeliveryAddress($value)
@@ -523,6 +535,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setAttentionTo($value)
@@ -543,6 +556,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setTelephone($value)
@@ -563,6 +577,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setDeliveryInstruction($value)
@@ -583,6 +598,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PurchaseOrder
      */
     public function setExpectedArrivalDate(\DateTimeInterface $value)
@@ -603,6 +619,7 @@ class PurchaseOrder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PurchaseOrder
      */
     public function setPurchaseOrderID($value)

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder/LineItem.php
@@ -170,6 +170,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDescription($value)
@@ -190,6 +191,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setQuantity($value)
@@ -210,6 +212,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setUnitAmount($value)
@@ -230,6 +233,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setItemCode($value)
@@ -250,6 +254,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setAccountCode($value)
@@ -270,6 +275,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setTaxType($value)
@@ -290,6 +296,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDiscountRate($value)
@@ -310,6 +317,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return LineItem
      */
     public function addTracking(TrackingCategory $value)
@@ -333,6 +341,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setLineItemID($value)
@@ -353,6 +362,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setTaxAmount($value)
@@ -373,6 +383,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setLineAmount($value)

--- a/src/XeroPHP/Models/Accounting/Receipt.php
+++ b/src/XeroPHP/Models/Accounting/Receipt.php
@@ -208,6 +208,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Receipt
      */
     public function setDate(\DateTimeInterface $value)
@@ -228,6 +229,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return Receipt
      */
     public function setContact(Contact $value)
@@ -248,6 +250,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return Receipt
      */
     public function addLineItem(LineItem $value)
@@ -271,6 +274,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param User $value
+     *
      * @return Receipt
      */
     public function setUser(User $value)
@@ -291,6 +295,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Receipt
      */
     public function setReference($value)
@@ -311,6 +316,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Receipt
      */
     public function setLineAmountType($value)
@@ -331,6 +337,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Receipt
      */
     public function setSubTotal($value)
@@ -351,6 +358,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Receipt
      */
     public function setTotalTax($value)
@@ -371,6 +379,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Receipt
      */
     public function setTotal($value)
@@ -391,6 +400,7 @@ class Receipt extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Receipt
      */
     public function setReceiptID($value)

--- a/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/Receipt/LineItem.php
@@ -155,6 +155,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setLineItemID($value)
@@ -175,6 +176,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDescription($value)
@@ -195,6 +197,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setUnitAmount($value)
@@ -215,6 +218,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setAccountCode($value)
@@ -235,6 +239,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setQuantity($value)
@@ -255,6 +260,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setTaxType($value)
@@ -275,6 +281,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setLineAmount($value)
@@ -295,6 +302,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return LineItem
      */
     public function addTracking(TrackingCategory $value)

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
@@ -194,6 +194,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setType($value)
@@ -214,6 +215,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param Contact $value
+     *
      * @return RepeatingInvoice
      */
     public function setContact(Contact $value)
@@ -234,6 +236,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param Schedule $value
+     *
      * @return RepeatingInvoice
      */
     public function setSchedule(Schedule $value)
@@ -254,6 +257,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param LineItem $value
+     *
      * @return RepeatingInvoice
      */
     public function addLineItem(LineItem $value)
@@ -277,6 +281,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setLineAmountType($value)
@@ -297,6 +302,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setReference($value)
@@ -317,6 +323,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setBrandingThemeID($value)
@@ -337,6 +344,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setCurrencyCode($value)
@@ -357,6 +365,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setStatus($value)
@@ -377,6 +386,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return RepeatingInvoice
      */
     public function setSubTotal($value)
@@ -397,6 +407,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return RepeatingInvoice
      */
     public function setTotalTax($value)
@@ -417,6 +428,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return RepeatingInvoice
      */
     public function setTotal($value)
@@ -437,6 +449,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return RepeatingInvoice
      */
     public function setRepeatingInvoiceID($value)
@@ -457,6 +470,7 @@ class RepeatingInvoice extends Remote\Model
 
     /**
      * @deprecated - this is a read only property and this method will be removed in future versions
+     *
      * @param $value
      */
     public function setHasAttachment($value)

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/LineItem.php
@@ -167,6 +167,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDescription($value)
@@ -187,6 +188,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setQuantity($value)
@@ -207,6 +209,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setUnitAmount($value)
@@ -227,6 +230,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setItemCode($value)
@@ -247,6 +251,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setAccountCode($value)
@@ -267,6 +272,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setTaxType($value)
@@ -287,6 +293,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setTaxAmount($value)
@@ -307,6 +314,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LineItem
      */
     public function setLineAmount($value)
@@ -327,6 +335,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return LineItem
      */
     public function addTracking(TrackingCategory $value)
@@ -350,6 +359,7 @@ class LineItem extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LineItem
      */
     public function setDiscountRate($value)

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
@@ -137,6 +137,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param int $value
+     *
      * @return Schedule
      */
     public function setPeriod($value)
@@ -157,6 +158,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Schedule
      */
     public function setUnit($value)
@@ -177,6 +179,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param int $value
+     *
      * @return Schedule
      */
     public function setDueDate($value)
@@ -197,6 +200,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Schedule
      */
     public function setDueDateType($value)
@@ -217,6 +221,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Schedule
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -237,6 +242,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Schedule
      */
     public function setNextScheduledDate(\DateTimeInterface $value)
@@ -257,6 +263,7 @@ class Schedule extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Schedule
      */
     public function setEndDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/Accounting/Report/Report.php
+++ b/src/XeroPHP/Models/Accounting/Report/Report.php
@@ -121,6 +121,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setReportID($value)
@@ -141,6 +142,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setReportName($value)
@@ -161,6 +163,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setReportType($value)
@@ -181,6 +184,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setReportTitles($value)
@@ -201,6 +205,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setReportDate($value)
@@ -221,6 +226,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setUpdatedDateUTC($value)
@@ -241,6 +247,7 @@ abstract class Report extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Report
      */
     public function setRows($value)

--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -180,6 +180,7 @@ class TaxRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxRate
      */
     public function setName($value)
@@ -200,6 +201,7 @@ class TaxRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxRate
      */
     public function setTaxType($value)
@@ -220,6 +222,7 @@ class TaxRate extends Remote\Model
 
     /**
      * @param TaxComponent $value
+     *
      * @return TaxRate
      */
     public function addTaxComponent(TaxComponent $value)
@@ -243,6 +246,7 @@ class TaxRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxRate
      */
     public function setStatus($value)
@@ -263,6 +267,7 @@ class TaxRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxRate
      */
     public function setReportTaxType($value)

--- a/src/XeroPHP/Models/Accounting/TaxRate/TaxComponent.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate/TaxComponent.php
@@ -108,6 +108,7 @@ class TaxComponent extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxComponent
      */
     public function setName($value)
@@ -128,6 +129,7 @@ class TaxComponent extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TaxComponent
      */
     public function setRate($value)
@@ -148,6 +150,7 @@ class TaxComponent extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return TaxComponent
      */
     public function setIsCompound($value)

--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -129,6 +129,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryID($value)
@@ -149,6 +150,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setName($value)
@@ -169,6 +171,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryName($value)
@@ -189,6 +192,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingOptionName($value)
@@ -209,6 +213,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setStatus($value)
@@ -229,6 +234,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param TrackingOption $value
+     *
      * @return TrackingCategory
      */
     public function addOption(TrackingOption $value)
@@ -254,6 +260,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setOption($value)

--- a/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
@@ -108,6 +108,7 @@ class TrackingOption extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingOption
      */
     public function setTrackingOptionID($value)
@@ -128,6 +129,7 @@ class TrackingOption extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingOption
      */
     public function setName($value)
@@ -148,6 +150,7 @@ class TrackingOption extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingOption
      */
     public function setStatus($value)

--- a/src/XeroPHP/Models/Accounting/User.php
+++ b/src/XeroPHP/Models/Accounting/User.php
@@ -137,6 +137,7 @@ class User extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return User
      */
     public function setUserID($value)
@@ -157,6 +158,7 @@ class User extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return User
      */
     public function setEmailAddress($value)
@@ -177,6 +179,7 @@ class User extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return User
      */
     public function setFirstName($value)
@@ -197,6 +200,7 @@ class User extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return User
      */
     public function setLastName($value)
@@ -217,6 +221,7 @@ class User extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return User
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -237,6 +242,7 @@ class User extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return User
      */
     public function setIsSubscriber($value)
@@ -257,6 +263,7 @@ class User extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return User
      */
     public function setOrganisationRole($value)

--- a/src/XeroPHP/Models/Assets/AssetType.php
+++ b/src/XeroPHP/Models/Assets/AssetType.php
@@ -140,6 +140,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setassetTypeName($value)
@@ -160,6 +161,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setfixedAssetAccountId($value)
@@ -180,6 +182,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setdepreciationExpenseAccountId($value)
@@ -200,6 +203,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setaccumulatedDepreciationAccountId($value)
@@ -220,6 +224,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param BookDepreciationSetting $value
+     *
      * @return AssetType
      */
     public function setBookDepreciationSetting(BookDepreciationSetting $value)
@@ -240,6 +245,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setassetTypeId($value)
@@ -260,6 +266,7 @@ class AssetType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return AssetType
      */
     public function setLock($value)

--- a/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
+++ b/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
@@ -122,6 +122,7 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BookDepreciationSetting
      */
     public function setdepreciationMethod($value)
@@ -142,6 +143,7 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BookDepreciationSetting
      */
     public function setaveragingMethod($value)
@@ -162,6 +164,7 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BookDepreciationSetting
      */
     public function setdepreciationRate($value)
@@ -182,6 +185,7 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BookDepreciationSetting
      */
     public function addeffectiveLifeYear($value)
@@ -205,6 +209,7 @@ class BookDepreciationSetting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BookDepreciationSetting
      */
     public function setdepreciationCalculationMethod($value)

--- a/src/XeroPHP/Models/Assets/Setting.php
+++ b/src/XeroPHP/Models/Assets/Setting.php
@@ -144,6 +144,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setassetNumberPrefix($value)
@@ -164,6 +165,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setassetNumberSequence($value)
@@ -184,6 +186,7 @@ class Setting extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Setting
      */
     public function setassetStartDate(\DateTimeInterface $value)
@@ -204,6 +207,7 @@ class Setting extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Setting
      */
     public function setlastDepreciationDate(\DateTimeInterface $value)
@@ -224,6 +228,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setdefaultGainOnDisposalAccountId($value)
@@ -244,6 +249,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setdefaultLossOnDisposalAccountId($value)
@@ -264,6 +270,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setdefaultCapitalGainOnDisposalAccount($value)
@@ -284,6 +291,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setoptInForTax($value)

--- a/src/XeroPHP/Models/Files/Association.php
+++ b/src/XeroPHP/Models/Files/Association.php
@@ -113,6 +113,7 @@ class Association extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Association
      */
     public function setObjectId($value)
@@ -133,6 +134,7 @@ class Association extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Association
      */
     public function setObjectGroup($value)
@@ -153,6 +155,7 @@ class Association extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Association
      */
     public function setObjectType($value)

--- a/src/XeroPHP/Models/Files/File.php
+++ b/src/XeroPHP/Models/Files/File.php
@@ -148,6 +148,7 @@ class File extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return File
      */
     public function setName($value)
@@ -168,6 +169,7 @@ class File extends Remote\Model
 
     /**
      * @param Folder $value
+     *
      * @return File
      */
     public function setFolderId(Folder $value)
@@ -188,6 +190,7 @@ class File extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return File
      */
     public function setMimeType($value)
@@ -208,6 +211,7 @@ class File extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return File
      */
     public function setSize($value)
@@ -228,6 +232,7 @@ class File extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return File
      */
     public function setCreatedDateUTC(\DateTimeInterface $value)
@@ -248,6 +253,7 @@ class File extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return File
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -268,6 +274,7 @@ class File extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return File
      */
     public function setUser($value)
@@ -288,6 +295,7 @@ class File extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return File
      */
     public function setId($value)

--- a/src/XeroPHP/Models/Files/Folder.php
+++ b/src/XeroPHP/Models/Files/Folder.php
@@ -142,6 +142,7 @@ class Folder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Folder
      */
     public function setName($value)
@@ -162,6 +163,7 @@ class Folder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Folder
      */
     public function setFileCount($value)
@@ -182,6 +184,7 @@ class Folder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Folder
      */
     public function setEmail($value)
@@ -202,6 +205,7 @@ class Folder extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Folder
      */
     public function setIsInbox($value)
@@ -222,6 +226,7 @@ class Folder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Folder
      */
     public function setId($value)
@@ -242,6 +247,7 @@ class Folder extends Remote\Model
 
     /**
      * @param File $value
+     *
      * @return Folder
      */
     public function addFile(File $value)
@@ -265,6 +271,7 @@ class Folder extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Folder
      */
     public function setFolderId($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -97,6 +97,7 @@ class Employee extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string Occupation
+     *
      * @deprecated
      */
 
@@ -318,6 +319,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setFirstName($value)
@@ -338,6 +340,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setLastName($value)
@@ -358,6 +361,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setDateOfBirth(\DateTimeInterface $value)
@@ -378,6 +382,7 @@ class Employee extends Remote\Model
 
     /**
      * @param HomeAddress $value
+     *
      * @return Employee
      */
     public function setHomeAddress(HomeAddress $value)
@@ -398,6 +403,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -418,6 +424,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setTitle($value)
@@ -438,6 +445,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setMiddleName($value)
@@ -458,6 +466,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmail($value)
@@ -478,6 +487,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setGender($value)
@@ -498,6 +508,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setMobile($value)
@@ -518,6 +529,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setTwitterUserName($value)
@@ -538,6 +550,7 @@ class Employee extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Employee
      */
     public function setIsAuthorisedToApproveLeave($value)
@@ -558,6 +571,7 @@ class Employee extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Employee
      */
     public function setIsAuthorisedToApproveTimesheet($value)
@@ -570,6 +584,7 @@ class Employee extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getOccupation()
@@ -579,7 +594,9 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
+     *
      * @deprecated
      */
     public function setOccupation($value)
@@ -600,6 +617,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setJobTitle($value)
@@ -620,6 +638,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setClassification($value)
@@ -640,6 +659,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setOrdinaryEarningsRateID($value)
@@ -660,6 +680,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setPayrollCalendarID($value)
@@ -680,6 +701,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeGroupName($value)
@@ -700,6 +722,7 @@ class Employee extends Remote\Model
 
     /**
      * @param BankAccount $value
+     *
      * @return Employee
      */
     public function addBankAccount(BankAccount $value)
@@ -723,6 +746,7 @@ class Employee extends Remote\Model
 
     /**
      * @param PayTemplate $value
+     *
      * @return Employee
      */
     public function setPayTemplate(PayTemplate $value)
@@ -743,6 +767,7 @@ class Employee extends Remote\Model
 
     /**
      * @param OpeningBalance $value
+     *
      * @return Employee
      */
     public function addOpeningBalance(OpeningBalance $value)
@@ -766,6 +791,7 @@ class Employee extends Remote\Model
 
     /**
      * @param LeaveBalance $value
+     *
      * @return Employee
      */
     public function addLeaveBalance(LeaveBalance $value)
@@ -789,6 +815,7 @@ class Employee extends Remote\Model
 
     /**
      * @param SuperMembership $value
+     *
      * @return Employee
      */
     public function addSuperMembership(SuperMembership $value)
@@ -812,6 +839,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setTerminationDate(\DateTimeInterface $value)
@@ -832,6 +860,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeID($value)
@@ -852,6 +881,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setStatus($value)
@@ -872,6 +902,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -892,6 +923,7 @@ class Employee extends Remote\Model
 
     /**
      * @param TaxDeclaration $value
+     *
      * @return Employee
      */
     public function setTaxDeclaration(TaxDeclaration $value)
@@ -912,6 +944,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setPhone($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
@@ -131,6 +131,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setStatementText($value)
@@ -151,6 +152,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountName($value)
@@ -171,6 +173,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setBSB($value)
@@ -191,6 +194,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountNumber($value)
@@ -211,6 +215,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setRemainder($value)
@@ -231,6 +236,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankAccount
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
@@ -129,6 +129,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setAddressLine1($value)
@@ -149,6 +150,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setAddressLine2($value)
@@ -169,6 +171,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setCity($value)
@@ -189,6 +192,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setRegion($value)
@@ -209,6 +213,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setPostalCode($value)
@@ -229,6 +234,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setCountry($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
@@ -116,6 +116,7 @@ class LeaveBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveBalance
      */
     public function setLeaveName($value)
@@ -136,6 +137,7 @@ class LeaveBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveBalance
      */
     public function setLeaveTypeID($value)
@@ -156,6 +158,7 @@ class LeaveBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveBalance
      */
     public function setNumberOfUnit($value)
@@ -176,6 +179,7 @@ class LeaveBalance extends Remote\Model
 
     /**
      * @param PayItem $value
+     *
      * @return LeaveBalance
      */
     public function addTypeOfUnit(PayItem $value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
@@ -195,6 +195,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return OpeningBalance
      */
     public function setOpeningBalanceDate(\DateTimeInterface $value)
@@ -215,6 +216,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setTax($value)
@@ -235,6 +237,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param EarningsLine $value
+     *
      * @return OpeningBalance
      */
     public function addEarningsLine(EarningsLine $value)
@@ -258,6 +261,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return OpeningBalance
      */
     public function addDeductionLine(DeductionLine $value)
@@ -281,6 +285,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setSuperLine($value)
@@ -301,6 +306,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return OpeningBalance
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -324,6 +330,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setLeaveLine($value)
@@ -344,6 +351,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setEarningsRateID($value)
@@ -364,6 +372,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return OpeningBalance
      */
     public function setAmount($value)
@@ -384,6 +393,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setDeductionTypeID($value)
@@ -404,6 +414,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setSuperMembershipID($value)
@@ -424,6 +435,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setCalculationType($value)
@@ -444,6 +456,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setReimbursementTypeID($value)
@@ -464,6 +477,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setLeaveTypeID($value)
@@ -484,6 +498,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -127,6 +127,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param EarningsLine $value
+     *
      * @return PayTemplate
      */
     public function addEarningsLine(EarningsLine $value)
@@ -150,6 +151,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return PayTemplate
      */
     public function addDeductionLine(DeductionLine $value)
@@ -173,6 +175,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param SuperLine $value
+     *
      * @return PayTemplate
      */
     public function addSuperLine(SuperLine $value)
@@ -196,6 +199,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return PayTemplate
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -219,6 +223,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param LeaveLine $value
+     *
      * @return PayTemplate
      */
     public function addLeaveLine(LeaveLine $value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
@@ -115,6 +115,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setDeductionTypeID($value)
@@ -135,6 +136,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionLine
      */
     public function setCalculationType($value)
@@ -155,6 +157,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setPercentage($value)
@@ -175,6 +178,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return PayTemplate
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/EarningsLine.php
@@ -134,6 +134,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsLine
      */
     public function setEarningsRateID($value)
@@ -154,6 +155,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsLine
      */
     public function setCalculationType($value)
@@ -174,6 +176,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setNumberOfUnitsPerWeek($value)
@@ -194,6 +197,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setAnnualSalary($value)
@@ -214,6 +218,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setRatePerUnit($value)
@@ -234,6 +239,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setNormalNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/LeaveLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/LeaveLine.php
@@ -129,6 +129,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setLeaveTypeID($value)
@@ -149,6 +150,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsLine
      */
     public function setCalculationType($value)
@@ -169,6 +171,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setAnnualNumberOfUnit($value)
@@ -189,6 +192,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setFullTimeNumberOfUnitsPerPeriod($value)
@@ -209,6 +213,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setNumberOfUnit($value)
@@ -229,6 +234,7 @@ class LeaveLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setEntitlementFinalPayPayoutType($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
@@ -108,6 +108,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setReimbursementTypeID($value)
@@ -128,6 +129,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setDescription($value)
@@ -148,6 +150,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return ReimbursementLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
@@ -136,6 +136,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setSuperMembershipID($value)
@@ -156,6 +157,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setContributionType($value)
@@ -176,6 +178,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setCalculationType($value)
@@ -196,6 +199,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setExpenseAccountCode($value)
@@ -216,6 +220,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setLiabilityAccountCode($value)
@@ -236,6 +241,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setMinimumMonthlyEarning($value)
@@ -256,6 +262,7 @@ class SuperLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperLine
      */
     public function setPercentage($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/SuperMembership.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/SuperMembership.php
@@ -115,6 +115,7 @@ class SuperMembership extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperMembership
      */
     public function setSuperFundID($value)
@@ -135,6 +136,7 @@ class SuperMembership extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperMembership
      */
     public function setEmployeeNumber($value)
@@ -155,6 +157,7 @@ class SuperMembership extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperMembership
      */
     public function setSuperMembershipID($value)
@@ -175,6 +178,7 @@ class SuperMembership extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperMembership
      */
     public function setEmployeeID($value)

--- a/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
@@ -64,6 +64,7 @@ class TaxDeclaration extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property bool HasTSLDebt
+     *
      * @deprecated
      */
 
@@ -205,6 +206,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setEmployeeID($value)
@@ -225,6 +227,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setEmploymentBasis($value)
@@ -245,6 +248,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setTFNExemptionType($value)
@@ -265,6 +269,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setTaxFileNumber($value)
@@ -285,6 +290,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setAustralianResidentForTaxPurpose($value)
@@ -324,6 +330,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setTaxFreeThresholdClaimed($value)
@@ -344,6 +351,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TaxDeclaration
      */
     public function setTaxOffsetEstimatedAmount($value)
@@ -364,6 +372,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return TaxDeclaration
      */
     public function setHasHELPDebt($value)
@@ -384,6 +393,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return TaxDeclaration
      */
     public function setHasSFSSDebt($value)
@@ -396,6 +406,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @return bool
+     *
      * @deprecated
      */
     public function getHasTSLDebt()
@@ -405,7 +416,9 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return TaxDeclaration
+     *
      * @deprecated
      */
     public function setHasTSLDebt($value)
@@ -426,6 +439,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return TaxDeclaration
      */
     public function setHasTradeSupportLoanDebt($value)
@@ -446,6 +460,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setUpwardVariationTaxWithholdingAmount($value)
@@ -466,6 +481,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setEligibleToReceiveLeaveLoading($value)
@@ -486,6 +502,7 @@ class TaxDeclaration extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxDeclaration
      */
     public function setApprovedWithholdingVariationPercentage($value)

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -149,6 +149,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveApplication
      */
     public function setLeaveApplicationID($value)
@@ -169,6 +170,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveApplication
      */
     public function setEmployeeID($value)
@@ -189,6 +191,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveApplication
      */
     public function setLeaveTypeID($value)
@@ -209,6 +212,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveApplication
      */
     public function setTitle($value)
@@ -229,6 +233,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return LeaveApplication
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -249,6 +254,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return LeaveApplication
      */
     public function setEndDate(\DateTimeInterface $value)
@@ -269,6 +275,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveApplication
      */
     public function setDescription($value)
@@ -289,6 +296,7 @@ class LeaveApplication extends Remote\Model
 
     /**
      * @param LeavePeriod $value
+     *
      * @return LeaveApplication
      */
     public function addLeavePeriod(LeavePeriod $value)

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
@@ -115,6 +115,7 @@ class LeavePeriod extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeavePeriod
      */
     public function setNumberOfUnit($value)
@@ -135,6 +136,7 @@ class LeavePeriod extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return LeavePeriod
      */
     public function setPayPeriodEndDate(\DateTimeInterface $value)
@@ -155,6 +157,7 @@ class LeavePeriod extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return LeavePeriod
      */
     public function setPayPeriodStartDate(\DateTimeInterface $value)
@@ -175,6 +178,7 @@ class LeavePeriod extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeavePeriod
      */
     public function setLeavePeriodStatus($value)

--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -121,6 +121,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param EarningsRate $value
+     *
      * @return PayItem
      */
     public function addEarningsRate(EarningsRate $value)
@@ -144,6 +145,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param DeductionType $value
+     *
      * @return PayItem
      */
     public function addDeductionType(DeductionType $value)
@@ -167,6 +169,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param LeaveType $value
+     *
      * @return PayItem
      */
     public function addLeaveType(LeaveType $value)
@@ -190,6 +193,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param ReimbursementType $value
+     *
      * @return PayItem
      */
     public function addReimbursementType(ReimbursementType $value)

--- a/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
@@ -124,6 +124,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setName($value)
@@ -144,6 +145,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setAccountCode($value)
@@ -164,6 +166,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionType
      */
     public function setReducesTax($value)
@@ -184,6 +187,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setReducesSuper($value)
@@ -204,6 +208,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setDeductionTypeID($value)

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -16,6 +16,7 @@ class EarningsRate extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string DisplayName
+     *
      * @deprecated
      */
 
@@ -196,6 +197,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setName($value)
@@ -208,6 +210,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getDisplayName()
@@ -217,7 +220,9 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
+     *
      * @deprecated
      */
     public function setDisplayName($value)
@@ -238,6 +243,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setAccountCode($value)
@@ -258,6 +264,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setTypeOfUnit($value)
@@ -278,6 +285,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setIsExemptFromTax($value)
@@ -298,6 +306,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setIsExemptFromSuper($value)
@@ -318,6 +327,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setEarningsType($value)
@@ -338,6 +348,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setEarningsRateID($value)
@@ -358,6 +369,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsRate
      */
     public function setRateType($value)
@@ -378,6 +390,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsRate
      */
     public function setRatePerUnit($value)
@@ -398,6 +411,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsRate
      */
     public function setMultiplier($value)
@@ -418,6 +432,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsRate
      */
     public function setAccrueLeave($value)
@@ -438,6 +453,7 @@ class EarningsRate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsRate
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -138,6 +138,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setName($value)
@@ -158,6 +159,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setTypeOfUnits($value)
@@ -178,6 +180,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setIsPaidLeave($value)
@@ -198,6 +201,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setShowOnPayslip($value)
@@ -218,6 +222,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setLeaveTypeID($value)
@@ -238,6 +243,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveType
      */
     public function setNormalEntitlement($value)
@@ -258,6 +264,7 @@ class LeaveType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LeaveType
      */
     public function setLeaveLoadingRate($value)

--- a/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
@@ -108,6 +108,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementType
      */
     public function setName($value)
@@ -128,6 +129,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementType
      */
     public function setAccountCode($value)
@@ -148,6 +150,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementType
      */
     public function setReimbursementTypeID($value)

--- a/src/XeroPHP/Models/PayrollAU/PayRun.php
+++ b/src/XeroPHP/Models/PayrollAU/PayRun.php
@@ -187,6 +187,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayrollCalendarID($value)
@@ -207,6 +208,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayRunID($value)
@@ -227,6 +229,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayRun
      */
     public function setPayRunPeriodStartDate(\DateTimeInterface $value)
@@ -247,6 +250,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayRun
      */
     public function setPayRunPeriodEndDate(\DateTimeInterface $value)
@@ -267,6 +271,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayRunStatus($value)
@@ -287,6 +292,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayRun
      */
     public function setPaymentDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
+++ b/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
@@ -136,6 +136,7 @@ class PayrollCalendar extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayrollCalendar
      */
     public function setPayrollCalendarID($value)
@@ -156,6 +157,7 @@ class PayrollCalendar extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayrollCalendar
      */
     public function setName($value)
@@ -176,6 +178,7 @@ class PayrollCalendar extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayrollCalendar
      */
     public function setCalendarType($value)
@@ -196,6 +199,7 @@ class PayrollCalendar extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayrollCalendar
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -216,6 +220,7 @@ class PayrollCalendar extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayrollCalendar
      */
     public function setPaymentDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip.php
@@ -244,6 +244,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payslip
      */
     public function setEmployeeID($value)
@@ -264,6 +265,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payslip
      */
     public function setPayRunID($value)
@@ -284,6 +286,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Payslip
      */
     public function setPayslipID($value)
@@ -304,6 +307,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param EarningsLine $value
+     *
      * @return Payslip
      */
     public function addEarningsLine(EarningsLine $value)
@@ -327,6 +331,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param TimesheetEarningsLine $value
+     *
      * @return Payslip
      */
     public function addTimesheetEarningsLine(TimesheetEarningsLine $value)
@@ -350,6 +355,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return Payslip
      */
     public function addDeductionLine(DeductionLine $value)
@@ -373,6 +379,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param LeaveAccrualLine $value
+     *
      * @return Payslip
      */
     public function addLeaveAccrualLine(LeaveAccrualLine $value)
@@ -396,6 +403,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return Payslip
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -419,6 +427,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param SuperannuationLine $value
+     *
      * @return Payslip
      */
     public function addSuperannuationLine(SuperannuationLine $value)
@@ -442,6 +451,7 @@ class Payslip extends Remote\Model
 
     /**
      * @param TaxLine $value
+     *
      * @return Payslip
      */
     public function addTaxLine(TaxLine $value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
@@ -116,6 +116,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setDeductionTypeID($value)
@@ -136,6 +137,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionLine
      */
     public function setCalculationType($value)
@@ -156,6 +158,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setAmount($value)
@@ -176,6 +179,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setPercentage($value)
@@ -196,6 +200,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
@@ -115,6 +115,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsLine
      */
     public function setEarningsRateID($value)
@@ -135,6 +136,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setRatePerUnit($value)
@@ -155,6 +157,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setNumberOfUnits($value)
@@ -175,6 +178,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setFixedAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
@@ -108,6 +108,7 @@ class LeaveAccrualLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveAccrualLine
      */
     public function setLeaveTypeID($value)
@@ -128,6 +129,7 @@ class LeaveAccrualLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveAccrualLine
      */
     public function setNumberOfUnit($value)
@@ -148,6 +150,7 @@ class LeaveAccrualLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveAccrualLine
      */
     public function setAutoCalculate($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
@@ -108,6 +108,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveEarningsLine
      */
     public function setEarningsRateID($value)
@@ -128,6 +129,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LeaveEarningsLine
      */
     public function setRatePerUnit($value)
@@ -148,6 +150,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LeaveEarningsLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/ReimbursementLine.php
@@ -115,6 +115,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setReimbursementTypeID($value)
@@ -135,6 +136,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setDescription($value)
@@ -155,6 +157,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setExpenseAccount($value)
@@ -175,6 +178,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return ReimbursementLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
@@ -150,6 +150,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setSuperMembershipID($value)
@@ -170,6 +171,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setContributionType($value)
@@ -190,6 +192,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setCalculationType($value)
@@ -210,6 +213,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setMinimumMonthlyEarning($value)
@@ -230,6 +234,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setExpenseAccountCode($value)
@@ -250,6 +255,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setLiabilityAccountCode($value)
@@ -270,6 +276,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return SuperannuationLine
      */
     public function setPaymentDateForThisPeriod(\DateTimeInterface $value)
@@ -290,6 +297,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperannuationLine
      */
     public function setPercentage($value)
@@ -310,6 +318,7 @@ class SuperannuationLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return SuperannuationLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TaxLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TaxLine.php
@@ -116,6 +116,7 @@ class TaxLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxLine
      */
     public function setTaxTypeName($value)
@@ -136,6 +137,7 @@ class TaxLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxLine
      */
     public function setDescription($value)
@@ -156,6 +158,7 @@ class TaxLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TaxLine
      */
     public function setAmount($value)
@@ -176,6 +179,7 @@ class TaxLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TaxLine
      */
     public function setLiabilityAccount($value)

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
@@ -108,6 +108,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetEarningsLine
      */
     public function setEarningsRateID($value)
@@ -128,6 +129,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetEarningsLine
      */
     public function setRatePerUnit($value)
@@ -148,6 +150,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetEarningsLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollAU/Setting.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting.php
@@ -112,6 +112,7 @@ class Setting extends Remote\Model
 
     /**
      * @param Account $value
+     *
      * @return Setting
      */
     public function addAccount(Account $value)
@@ -135,6 +136,7 @@ class Setting extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return Setting
      */
     public function addTrackingCategory(TrackingCategory $value)
@@ -158,6 +160,7 @@ class Setting extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Setting
      */
     public function setDaysInPayrollYear($value)

--- a/src/XeroPHP/Models/PayrollAU/Setting/Account.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/Account.php
@@ -115,6 +115,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setAccountID($value)
@@ -135,6 +136,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setType($value)
@@ -155,6 +157,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setCode($value)
@@ -175,6 +178,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setName($value)

--- a/src/XeroPHP/Models/PayrollAU/Setting/TrackingCategory.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/TrackingCategory.php
@@ -101,6 +101,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryID($value)
@@ -121,6 +122,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryName($value)

--- a/src/XeroPHP/Models/PayrollAU/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund.php
@@ -124,6 +124,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setSuperFundID($value)
@@ -144,6 +145,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setType($value)
@@ -164,6 +166,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setABN($value)
@@ -184,6 +187,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setUSI($value)
@@ -206,6 +210,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setBSB($value)
@@ -226,6 +231,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setAccountNumber($value)
@@ -246,6 +252,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setAccountName($value)
@@ -266,6 +273,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setElectronicServiceAddress($value)
@@ -286,6 +294,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setEmployerNumber($value)
@@ -298,6 +307,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getSPIN()
@@ -307,7 +317,9 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
+     *
      * @deprecated
      */
     public function setSPIN($value)
@@ -328,6 +340,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setName($value)

--- a/src/XeroPHP/Models/PayrollAU/SuperFund/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund/SuperFund.php
@@ -67,6 +67,7 @@ class SuperFund extends Remote\Model
      * of SPIN.
      *
      * @property string SPIN
+     *
      * @deprecated
      */
     const TYPE_REGULATED = 'REGULATED';
@@ -164,6 +165,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setType($value)
@@ -184,6 +186,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setName($value)
@@ -204,6 +207,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setABN($value)
@@ -224,6 +228,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setBSB($value)
@@ -244,6 +249,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setAccountNumber($value)
@@ -264,6 +270,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setAccountName($value)
@@ -284,6 +291,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setElectronicServiceAddress($value)
@@ -304,6 +312,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setSuperFundID($value)
@@ -324,6 +333,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
      */
     public function setEmployerNumber($value)
@@ -336,6 +346,7 @@ class SuperFund extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getSPIN()
@@ -345,7 +356,9 @@ class SuperFund extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFund
+     *
      * @deprecated
      */
     public function setSPIN($value)

--- a/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
@@ -23,6 +23,7 @@ class SuperFundProduct extends Remote\Model
      * will not have a SPIN value.  The USI field should be used instead of SPIN.
      *
      * @property string SPIN
+     *
      * @deprecated
      */
 
@@ -118,6 +119,7 @@ class SuperFundProduct extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFundProduct
      */
     public function setABN($value)
@@ -138,6 +140,7 @@ class SuperFundProduct extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFundProduct
      */
     public function setUSI($value)
@@ -150,6 +153,7 @@ class SuperFundProduct extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getSPIN()
@@ -159,7 +163,9 @@ class SuperFundProduct extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFundProduct
+     *
      * @deprecated
      */
     public function setSPIN($value)
@@ -180,6 +186,7 @@ class SuperFundProduct extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SuperFundProduct
      */
     public function setProductName($value)

--- a/src/XeroPHP/Models/PayrollAU/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet.php
@@ -144,6 +144,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setEmployeeID($value)
@@ -164,6 +165,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Timesheet
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -184,6 +186,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Timesheet
      */
     public function setEndDate(\DateTimeInterface $value)
@@ -204,6 +207,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param TimesheetLine $value
+     *
      * @return Timesheet
      */
     public function addTimesheetLine(TimesheetLine $value)
@@ -227,6 +231,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setStatus($value)
@@ -247,6 +252,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setHour($value)
@@ -267,6 +273,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setTimesheetID($value)

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -109,6 +109,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetLine
      */
     public function setEarningsRateID($value)
@@ -129,6 +130,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetLine
      */
     public function setTrackingItemID($value)
@@ -149,6 +151,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -301,6 +301,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setFirstName($value)
@@ -321,6 +322,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setLastName($value)
@@ -341,6 +343,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setDateOfBirth(\DateTimeInterface $value)
@@ -361,6 +364,7 @@ class Employee extends Remote\Model
 
     /**
      * @param HomeAddress $value
+     *
      * @return Employee
      */
     public function setHomeAddress(HomeAddress $value)
@@ -381,6 +385,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setMiddleName($value)
@@ -401,6 +406,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setJobTitle($value)
@@ -421,6 +427,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmail($value)
@@ -441,6 +448,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setGender($value)
@@ -461,6 +469,7 @@ class Employee extends Remote\Model
 
     /**
      * @param MailingAddress $value
+     *
      * @return Employee
      */
     public function setMailingAddress(MailingAddress $value)
@@ -481,6 +490,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setPhone($value)
@@ -501,6 +511,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeNumber($value)
@@ -521,6 +532,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setSocialSecurityNumber($value)
@@ -541,6 +553,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -561,6 +574,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setTerminationDate(\DateTimeInterface $value)
@@ -581,6 +595,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setPayScheduleID($value)
@@ -601,6 +616,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeGroupName($value)
@@ -621,6 +637,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmploymentBasis($value)
@@ -641,6 +658,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setHolidayGroupID($value)
@@ -661,6 +679,7 @@ class Employee extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Employee
      */
     public function setIsAuthorisedToApproveTimeOff($value)
@@ -681,6 +700,7 @@ class Employee extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return Employee
      */
     public function setIsAuthorisedToApproveTimesheet($value)
@@ -701,6 +721,7 @@ class Employee extends Remote\Model
 
     /**
      * @param SalaryAndWage $value
+     *
      * @return Employee
      */
     public function addSalaryAndWage(SalaryAndWage $value)
@@ -724,6 +745,7 @@ class Employee extends Remote\Model
 
     /**
      * @param WorkLocation $value
+     *
      * @return Employee
      */
     public function addWorkLocation(WorkLocation $value)
@@ -747,6 +769,7 @@ class Employee extends Remote\Model
 
     /**
      * @param PaymentMethod $value
+     *
      * @return Employee
      */
     public function setPaymentMethod(PaymentMethod $value)
@@ -767,6 +790,7 @@ class Employee extends Remote\Model
 
     /**
      * @param PayTemplate $value
+     *
      * @return Employee
      */
     public function setPayTemplate(PayTemplate $value)
@@ -787,6 +811,7 @@ class Employee extends Remote\Model
 
     /**
      * @param OpeningBalance $value
+     *
      * @return Employee
      */
     public function addOpeningBalance(OpeningBalance $value)
@@ -810,6 +835,7 @@ class Employee extends Remote\Model
 
     /**
      * @param TimeOffBalance $value
+     *
      * @return Employee
      */
     public function addTimeOffBalance(TimeOffBalance $value)
@@ -833,6 +859,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setEmployeeID($value)
@@ -853,6 +880,7 @@ class Employee extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Employee
      */
     public function setStatus($value)
@@ -873,6 +901,7 @@ class Employee extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Employee
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/BankAccount.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/BankAccount.php
@@ -137,6 +137,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountHolderName($value)
@@ -157,6 +158,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setStatementText($value)
@@ -177,6 +179,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountType($value)
@@ -197,6 +200,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setRoutingNumber($value)
@@ -217,6 +221,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setAccountNumber($value)
@@ -237,6 +242,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BankAccount
      */
     public function setAmount($value)
@@ -257,6 +263,7 @@ class BankAccount extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BankAccount
      */
     public function setRemainder($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
@@ -136,6 +136,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setStreetAddress($value)
@@ -156,6 +157,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setSuiteOrAptOrUnit($value)
@@ -176,6 +178,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setCity($value)
@@ -196,6 +199,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setState($value)
@@ -216,6 +220,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setZip($value)
@@ -236,6 +241,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setLattitude($value)
@@ -256,6 +262,7 @@ class HomeAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return HomeAddress
      */
     public function setLongitude($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
@@ -136,6 +136,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setStreetAddress($value)
@@ -156,6 +157,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setSuiteOrAptOrUnit($value)
@@ -176,6 +178,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setCity($value)
@@ -196,6 +199,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setState($value)
@@ -216,6 +220,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setZip($value)
@@ -236,6 +241,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setLattitude($value)
@@ -256,6 +262,7 @@ class MailingAddress extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return MailingAddress
      */
     public function setLongitude($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
@@ -68,6 +68,7 @@ class OpeningBalance extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string EmployeeID
+     *
      * @deprecated
      */
 
@@ -162,6 +163,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param EarningsLine $value
+     *
      * @return OpeningBalance
      */
     public function addEarningsLine(EarningsLine $value)
@@ -185,6 +187,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param BenefitLine $value
+     *
      * @return OpeningBalance
      */
     public function addBenefitLine(BenefitLine $value)
@@ -208,6 +211,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return OpeningBalance
      */
     public function addDeductionLine(DeductionLine $value)
@@ -231,6 +235,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return OpeningBalance
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -254,6 +259,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setEarningsTypeID($value)
@@ -274,6 +280,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return OpeningBalance
      */
     public function setAmount($value)
@@ -294,6 +301,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setBenefitTypeID($value)
@@ -314,6 +322,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setDeductionTypeID($value)
@@ -334,6 +343,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
      */
     public function setReimbursementTypeID($value)
@@ -346,6 +356,7 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getEmployeeID()
@@ -355,7 +366,9 @@ class OpeningBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return OpeningBalance
+     *
      * @deprecated
      */
     public function setEmployeeID($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
@@ -204,6 +204,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return PayTemplate
      */
     public function addEarningsLine($value)
@@ -227,6 +228,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return PayTemplate
      */
     public function addDeductionLine(DeductionLine $value)
@@ -250,6 +252,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return PayTemplate
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -273,6 +276,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param BenefitLine $value
+     *
      * @return PayTemplate
      */
     public function addBenefitLine(BenefitLine $value)
@@ -296,6 +300,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setEarningsTypeID($value)
@@ -316,6 +321,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setUnitsOrHour($value)
@@ -336,6 +342,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return PayTemplate
      */
     public function setRatePerUnit($value)
@@ -356,6 +363,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return PayTemplate
      */
     public function setAmount($value)
@@ -376,6 +384,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setDeductionTypeID($value)
@@ -396,6 +405,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setCalculationType($value)
@@ -416,6 +426,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return PayTemplate
      */
     public function setEmployeeMax($value)
@@ -436,6 +447,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setPercentage($value)
@@ -456,6 +468,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setReimbursementTypeID($value)
@@ -476,6 +489,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setDescription($value)
@@ -496,6 +510,7 @@ class PayTemplate extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayTemplate
      */
     public function setBenefitTypeID($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
@@ -106,6 +106,7 @@ class PaymentMethod extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PaymentMethod
      */
     public function setPaymentMethodType($value)
@@ -126,6 +127,7 @@ class PaymentMethod extends Remote\Model
 
     /**
      * @param BankAccount $value
+     *
      * @return PaymentMethod
      */
     public function addBankAccount(BankAccount $value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/SalaryAndWage.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/SalaryAndWage.php
@@ -10,6 +10,7 @@ class SalaryAndWage extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string SalaryAndWageID
+     *
      * @deprecated
      */
 
@@ -136,6 +137,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getSalaryAndWageID()
@@ -145,7 +147,9 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
+     *
      * @deprecated
      */
     public function setSalaryAndWageID($value)
@@ -166,6 +170,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
      */
     public function setSalaryAndWagesID($value)
@@ -186,6 +191,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
      */
     public function setEarningsTypeID($value)
@@ -206,6 +212,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
      */
     public function setSalaryWagesType($value)
@@ -226,6 +233,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return SalaryAndWage
      */
     public function setHourlyRate($value)
@@ -246,6 +254,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
      */
     public function setAnnualSalary($value)
@@ -266,6 +275,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return SalaryAndWage
      */
     public function setStandardHoursPerWeek($value)
@@ -286,6 +296,7 @@ class SalaryAndWage extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return SalaryAndWage
      */
     public function setEffectiveDate(\DateTimeInterface $value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
@@ -123,6 +123,7 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffBalance
      */
     public function setTimeOffName($value)
@@ -143,6 +144,7 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @param PayItem $value
+     *
      * @return TimeOffBalance
      */
     public function setTimeOffTypeId(PayItem $value)
@@ -163,6 +165,7 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffBalance
      */
     public function setNumberOfUnit($value)
@@ -183,6 +186,7 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @param PayItem $value
+     *
      * @return TimeOffBalance
      */
     public function addTypeOfUnit(PayItem $value)
@@ -206,6 +210,7 @@ class TimeOffBalance extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffBalance
      */
     public function setEmployeeID($value)

--- a/src/XeroPHP/Models/PayrollUS/Employee/WorkLocation.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/WorkLocation.php
@@ -101,6 +101,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setWorkLocationID($value)
@@ -121,6 +122,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param bool $value
+     *
      * @return WorkLocation
      */
     public function setIsPrimary($value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem.php
@@ -129,6 +129,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param EarningsType $value
+     *
      * @return PayItem
      */
     public function addEarningsType(EarningsType $value)
@@ -152,6 +153,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param BenefitType $value
+     *
      * @return PayItem
      */
     public function addBenefitType(BenefitType $value)
@@ -175,6 +177,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param DeductionType $value
+     *
      * @return PayItem
      */
     public function addDeductionType(DeductionType $value)
@@ -198,6 +201,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param ReimbursementType $value
+     *
      * @return PayItem
      */
     public function addReimbursementType(ReimbursementType $value)
@@ -221,6 +225,7 @@ class PayItem extends Remote\Model
 
     /**
      * @param TimeOffType $value
+     *
      * @return PayItem
      */
     public function addTimeOffType(TimeOffType $value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
@@ -182,6 +182,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param BenefitType $value
+     *
      * @return BenefitType
      */
     public function setBenefitType(self $value)
@@ -202,6 +203,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitType
      */
     public function setBenefitCategory($value)
@@ -222,6 +224,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitType
      */
     public function setLiabilityAccountCode($value)
@@ -242,6 +245,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitType
      */
     public function setExpenseAccountCode($value)
@@ -262,6 +266,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitType
      */
     public function setBenefitTypeID($value)
@@ -282,6 +287,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BenefitType
      */
     public function setStandardAmount($value)
@@ -302,6 +308,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BenefitType
      */
     public function setCompanyMax($value)
@@ -322,6 +329,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitType
      */
     public function setPercentage($value)
@@ -342,6 +350,7 @@ class BenefitType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BenefitType
      */
     public function setShowBalanceOnPaystub($value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
@@ -178,6 +178,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param DeductionType $value
+     *
      * @return DeductionType
      */
     public function setDeductionType(self $value)
@@ -198,6 +199,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setDeductionCategory($value)
@@ -218,6 +220,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionType
      */
     public function setCalculationType($value)
@@ -238,6 +241,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setLiabilityAccountCode($value)
@@ -258,6 +262,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionType
      */
     public function setDeductionTypeID($value)
@@ -278,6 +283,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionType
      */
     public function setStandardAmount($value)
@@ -298,6 +304,7 @@ class DeductionType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionType
      */
     public function setCompanyMax($value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
@@ -16,6 +16,7 @@ class EarningsType extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string DisplayName
+     *
      * @deprecated
      */
 
@@ -47,6 +48,7 @@ class EarningsType extends Remote\Model
      * This property has been removed from the Xero API.
      *
      * @property string EarningsRateID
+     *
      * @deprecated
      */
 
@@ -206,6 +208,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param EarningsType $value
+     *
      * @return EarningsType
      */
     public function setEarningsType(self $value)
@@ -218,6 +221,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getDisplayName()
@@ -227,7 +231,9 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
+     *
      * @deprecated
      */
     public function setDisplayName($value)
@@ -248,6 +254,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setExpenseAccountCode($value)
@@ -268,6 +275,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setEarningsCategory($value)
@@ -288,6 +296,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setRateType($value)
@@ -308,6 +317,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setTypeOfUnit($value)
@@ -320,6 +330,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @return string
+     *
      * @deprecated
      */
     public function getEarningsRateID()
@@ -329,7 +340,9 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
+     *
      * @deprecated
      */
     public function setEarningsRateID($value)
@@ -350,6 +363,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setEarningsTypeID($value)
@@ -370,6 +384,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsType
      */
     public function setMultiple($value)
@@ -390,6 +405,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setDoNotAccrueTimeOff($value)
@@ -410,6 +426,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsType
      */
     public function setIsSupplemental($value)
@@ -430,6 +447,7 @@ class EarningsType extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsType
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
@@ -108,6 +108,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param ReimbursementType $value
+     *
      * @return ReimbursementType
      */
     public function setReimbursementType(self $value)
@@ -128,6 +129,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementType
      */
     public function setExpenseOrLiabilityAccountCode($value)
@@ -148,6 +150,7 @@ class ReimbursementType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementType
      */
     public function setReimbursementTypeID($value)

--- a/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
@@ -134,6 +134,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param TimeOffType $value
+     *
      * @return TimeOffType
      */
     public function setTimeOffType(self $value)
@@ -154,6 +155,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffType
      */
     public function setTimeOffCategory($value)
@@ -174,6 +176,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffType
      */
     public function setExpenseAccountCode($value)
@@ -194,6 +197,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffType
      */
     public function setLiabilityAccountCode($value)
@@ -214,6 +218,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffType
      */
     public function setTimeOffTypeID($value)
@@ -234,6 +239,7 @@ class TimeOffType extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffType
      */
     public function setShowBalanceToEmployee($value)

--- a/src/XeroPHP/Models/PayrollUS/PayRun.php
+++ b/src/XeroPHP/Models/PayrollUS/PayRun.php
@@ -173,6 +173,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayScheduleID($value)
@@ -193,6 +194,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PayRun
      */
     public function setPayRunPeriodEndDate(\DateTimeInterface $value)
@@ -213,6 +215,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayRunStatus($value)
@@ -233,6 +236,7 @@ class PayRun extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PayRun
      */
     public function setPayRunID($value)

--- a/src/XeroPHP/Models/PayrollUS/PaySchedule.php
+++ b/src/XeroPHP/Models/PayrollUS/PaySchedule.php
@@ -124,6 +124,7 @@ class PaySchedule extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PaySchedule
      */
     public function setPayScheduleName($value)
@@ -144,6 +145,7 @@ class PaySchedule extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PaySchedule
      */
     public function setPaymentDate(\DateTimeInterface $value)
@@ -164,6 +166,7 @@ class PaySchedule extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return PaySchedule
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -184,6 +187,7 @@ class PaySchedule extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PaySchedule
      */
     public function setScheduleType($value)
@@ -204,6 +208,7 @@ class PaySchedule extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return PaySchedule
      */
     public function setPayScheduleId($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub.php
@@ -229,6 +229,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setEmployeeID($value)
@@ -249,6 +250,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setPaystubID($value)
@@ -269,6 +271,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setPayRunID($value)
@@ -289,6 +292,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setFirstName($value)
@@ -309,6 +313,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setLastName($value)
@@ -329,6 +334,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Paystub
      */
     public function setLastEdited($value)
@@ -349,6 +355,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Paystub
      */
     public function addEarning($value)
@@ -372,6 +379,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Paystub
      */
     public function addDeduction($value)
@@ -395,6 +403,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Paystub
      */
     public function setTax($value)
@@ -415,6 +424,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Paystub
      */
     public function addReimbursement($value)
@@ -438,6 +448,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return Paystub
      */
     public function setNetPay($value)
@@ -458,6 +469,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Paystub
      */
     public function setUpdatedDateUTC(\DateTimeInterface $value)
@@ -478,6 +490,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param EarningsLine $value
+     *
      * @return Paystub
      */
     public function addEarningsLine(EarningsLine $value)
@@ -501,6 +514,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param LeaveEarningsLine $value
+     *
      * @return Paystub
      */
     public function addLeaveEarningsLine(LeaveEarningsLine $value)
@@ -524,6 +538,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param TimesheetEarningsLine $value
+     *
      * @return Paystub
      */
     public function addTimesheetEarningsLine(TimesheetEarningsLine $value)
@@ -547,6 +562,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param DeductionLine $value
+     *
      * @return Paystub
      */
     public function addDeductionLine(DeductionLine $value)
@@ -570,6 +586,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param ReimbursementLine $value
+     *
      * @return Paystub
      */
     public function addReimbursementLine(ReimbursementLine $value)
@@ -593,6 +610,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param BenefitLine $value
+     *
      * @return Paystub
      */
     public function addBenefitLine(BenefitLine $value)
@@ -616,6 +634,7 @@ class Paystub extends Remote\Model
 
     /**
      * @param TimeOffLine $value
+     *
      * @return Paystub
      */
     public function addTimeOffLine(TimeOffLine $value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/BenefitLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/BenefitLine.php
@@ -101,6 +101,7 @@ class BenefitLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return BenefitLine
      */
     public function setBenefitTypeID($value)
@@ -121,6 +122,7 @@ class BenefitLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return BenefitLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/DeductionLine.php
@@ -115,6 +115,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setDeductionTypeID($value)
@@ -135,6 +136,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setCalculationType($value)
@@ -155,6 +157,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return DeductionLine
      */
     public function setPercentage($value)
@@ -175,6 +178,7 @@ class DeductionLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return DeductionLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
@@ -108,6 +108,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return EarningsLine
      */
     public function setEarningsTypeID($value)
@@ -128,6 +129,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function setRatePerUnit($value)
@@ -148,6 +150,7 @@ class EarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return EarningsLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
@@ -108,6 +108,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return LeaveEarningsLine
      */
     public function setEarningsTypeID($value)
@@ -128,6 +129,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LeaveEarningsLine
      */
     public function setRatePerUnit($value)
@@ -148,6 +150,7 @@ class LeaveEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return LeaveEarningsLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/ReimbursementLine.php
@@ -115,6 +115,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setReimbursementTypeID($value)
@@ -135,6 +136,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setDescription($value)
@@ -155,6 +157,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return ReimbursementLine
      */
     public function setExpenseAccount($value)
@@ -175,6 +178,7 @@ class ReimbursementLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return ReimbursementLine
      */
     public function setAmount($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
@@ -108,6 +108,7 @@ class TimeOffLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffLine
      */
     public function setTimeOffTypeID($value)
@@ -128,6 +129,7 @@ class TimeOffLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffLine
      */
     public function setHour($value)
@@ -148,6 +150,7 @@ class TimeOffLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimeOffLine
      */
     public function setBalance($value)

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
@@ -108,6 +108,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetEarningsLine
      */
     public function setEarningsTypeID($value)
@@ -128,6 +129,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetEarningsLine
      */
     public function setRatePerUnit($value)
@@ -148,6 +150,7 @@ class TimesheetEarningsLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetEarningsLine
      */
     public function addNumberOfUnit($value)

--- a/src/XeroPHP/Models/PayrollUS/Setting.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting.php
@@ -104,6 +104,7 @@ class Setting extends Remote\Model
 
     /**
      * @param Account $value
+     *
      * @return Setting
      */
     public function addAccount(Account $value)
@@ -127,6 +128,7 @@ class Setting extends Remote\Model
 
     /**
      * @param TrackingCategory $value
+     *
      * @return Setting
      */
     public function addTrackingCategory(TrackingCategory $value)

--- a/src/XeroPHP/Models/PayrollUS/Setting/Account.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting/Account.php
@@ -115,6 +115,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setAccountID($value)
@@ -135,6 +136,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setType($value)
@@ -155,6 +157,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setCode($value)
@@ -175,6 +178,7 @@ class Account extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Account
      */
     public function setName($value)

--- a/src/XeroPHP/Models/PayrollUS/Setting/TrackingCategory.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting/TrackingCategory.php
@@ -101,6 +101,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryID($value)
@@ -121,6 +122,7 @@ class TrackingCategory extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TrackingCategory
      */
     public function setTrackingCategoryName($value)

--- a/src/XeroPHP/Models/PayrollUS/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet.php
@@ -144,6 +144,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setEmployeeID($value)
@@ -164,6 +165,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Timesheet
      */
     public function setStartDate(\DateTimeInterface $value)
@@ -184,6 +186,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param \DateTimeInterface $value
+     *
      * @return Timesheet
      */
     public function setEndDate(\DateTimeInterface $value)
@@ -204,6 +207,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param TimesheetLine $value
+     *
      * @return Timesheet
      */
     public function addTimesheetLine(TimesheetLine $value)
@@ -227,6 +231,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setStatus($value)
@@ -247,6 +252,7 @@ class Timesheet extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return Timesheet
      */
     public function setTimesheetID($value)

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -117,6 +117,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetLine
      */
     public function setEarningsTypeID($value)
@@ -137,6 +138,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetLine
      */
     public function setTrackingItemID($value)
@@ -157,6 +159,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param float $value
+     *
      * @return TimesheetLine
      */
     public function addNumberOfUnit($value)
@@ -180,6 +183,7 @@ class TimesheetLine extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return TimesheetLine
      */
     public function setWorkLocationID($value)

--- a/src/XeroPHP/Models/PayrollUS/WorkLocation.php
+++ b/src/XeroPHP/Models/PayrollUS/WorkLocation.php
@@ -145,6 +145,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setStreetAddress($value)
@@ -165,6 +166,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setCity($value)
@@ -185,6 +187,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setState($value)
@@ -205,6 +208,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setLatitude($value)
@@ -225,6 +229,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setLongitude($value)
@@ -245,6 +250,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setWorkLocationID($value)
@@ -265,6 +271,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setSuitOrAptOrUnit($value)
@@ -285,6 +292,7 @@ class WorkLocation extends Remote\Model
 
     /**
      * @param string $value
+     *
      * @return WorkLocation
      */
     public function setIsPrimary($value)

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -83,6 +83,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * but will have to be like this for BC until the next major version.
      *
      * @param Application $application
+     *
      * @return $this
      */
     public function setApplication(Application $application)
@@ -106,6 +107,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * If there have been any properties changed since load.
      *
      * @param null $property
+     *
      * @return bool
      */
     public function isDirty($property = null)
@@ -121,6 +123,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Manually set a property as dirty.
      *
      * @param $property
+     *
      * @return self
      */
     public function setDirty($property)
@@ -134,6 +137,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Manually set a property as clean.
      *
      * @param null $property
+     *
      * @return self
      */
     public function setClean($property = null)
@@ -167,6 +171,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     /**
      * @param string $guid
+     *
      * @return $this
      */
     public function setGUID($guid)
@@ -230,6 +235,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Convert the object into an array, and any non-primitives to string.
      *
      * @param mixed $dirty_only
+     *
      * @return array
      */
     public function toStringArray($dirty_only = false)
@@ -265,6 +271,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      *
      * @param $type
      * @param $value
+     *
      * @return string
      */
     public static function castToString($type, $value)
@@ -310,6 +317,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * @param $type
      * @param $value
      * @param $php_type
+     *
      * @return bool|\DateTimeInterface|float|int|string
      */
     public static function castFromString($type, $value, $php_type)
@@ -361,7 +369,9 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Validate the object and (optionally) the child objects recursively.
      *
      * @param bool $check_children
+     *
      * @throws Exception
+     *
      * @return bool
      */
     public function validate($check_children = true)
@@ -406,6 +416,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Shorthand save an object if it is instantiated with app context.
      *
      * @throws Exception
+     *
      * @return Response|null
      */
     public function save()
@@ -423,6 +434,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Shorthand delete an object if it is instantiated with app context.
      *
      * @throws Exception
+     *
      * @return Response|null
      */
     public function delete()
@@ -449,6 +461,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Magic method for testing if properties exist.
      *
      * @param $property
+     *
      * @return bool
      */
     public function __isset($property)
@@ -460,6 +473,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * Magic getter for accessing properties directly.
      *
      * @param $property
+     *
      * @return mixed
      */
     public function __get($property)
@@ -480,6 +494,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      *
      * @param $property
      * @param $value
+     *
      * @return mixed
      */
     public function __set($property, $value)
@@ -515,6 +530,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      * If the object supports a specific HTTP method.
      *
      * @param $method
+     *
      * @return bool
      */
     public static function supportsMethod($method)
@@ -534,6 +550,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     /**
      * @param mixed $offset
+     *
      * @return bool
      */
     public function offsetExists($offset)
@@ -543,6 +560,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     /**
      * @param mixed $offset
+     *
      * @return mixed
      */
     public function offsetGet($offset)
@@ -553,6 +571,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     /**
      * @param mixed $offset
      * @param mixed $value
+     *
      * @return mixed
      */
     public function offsetSet($offset, $value)

--- a/src/XeroPHP/Remote/OAuth/Client.php
+++ b/src/XeroPHP/Remote/OAuth/Client.php
@@ -54,6 +54,7 @@ class Client
      * This method puts it in the oauth params in the Authorization header by default.
      *
      * @param Request $request Request to sign
+     *
      * @throws Exception
      */
     public function sign(Request $request)
@@ -133,7 +134,9 @@ class Client
      * consistency, pass the same constructor to each one.
      *
      * @param Request $request
+     *
      * @throws Exception
+     *
      * @return string
      */
     private function getSignature(Request $request)
@@ -179,6 +182,7 @@ class Client
      * GET&https%3A%2F%2Fapi.xero.com%2Fapi.xro%2F2.0%2FContacts&oauth_consumer etc.
      *
      * @param Request $request
+     *
      * @return string
      */
     public function getSBS(Request $request)
@@ -223,6 +227,7 @@ class Client
      * server will reject any request that reuses one.
      *
      * @param int $length
+     *
      * @return string
      */
     private function getNonce($length = 20)
@@ -298,6 +303,7 @@ class Client
 
     /**
      * @param string|null $oauth_token
+     *
      * @return string
      */
     public function getAuthorizeURL($oauth_token = null)
@@ -317,6 +323,7 @@ class Client
      *
      * @param string $url
      * @param array $query
+     *
      * @return string
      */
     protected function appendUrlQuery($url, $query)
@@ -330,6 +337,7 @@ class Client
      * Determine if the URL has a query string.
      *
      * @param string $url
+     *
      * @return bool
      */
     protected function urlHasQuery($url)

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -50,6 +50,7 @@ class Query
 
     /**
      * @param string $class
+     *
      * @return $this
      */
     public function from($class)
@@ -95,6 +96,7 @@ class Query
     /**
      * @param string $operator
      * @param array $args
+     *
      * @return $this
      */
     public function addWhere($operator, $args)
@@ -142,6 +144,7 @@ class Query
     /**
      * @param string $order
      * @param string $direction
+     *
      * @return $this
      */
     public function orderBy($order, $direction = self::ORDER_ASC)
@@ -153,6 +156,7 @@ class Query
 
     /**
      * @param \DateTimeInterface|null $modifiedAfter
+     *
      * @return $this
      */
     public function modifiedAfter(\DateTimeInterface $modifiedAfter = null)
@@ -168,6 +172,7 @@ class Query
 
     /**
      * @param DateTime $fromDate
+     *
      * @return $this
      */
     public function fromDate(DateTime $fromDate)
@@ -179,6 +184,7 @@ class Query
 
     /**
      * @param DateTime $toDate
+     *
      * @return $this
      */
     public function toDate(DateTime $toDate)
@@ -190,6 +196,7 @@ class Query
 
     /**
      * @param DateTime $date
+     *
      * @return $this
      */
     public function date(DateTime $date)
@@ -201,7 +208,9 @@ class Query
 
     /**
      * @param int $page
+     *
      * @throws Exception
+     *
      * @return $this
      */
     public function page($page = 1)
@@ -220,6 +229,7 @@ class Query
 
     /**
      * @param int $offset
+     *
      * @return $this
      */
     public function offset($offset = 0)

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -159,6 +159,7 @@ class Request
 
     /**
      * @param $key string Name of the header
+     *
      * @return null|string Header or null if not defined
      */
     public function getHeader($key)

--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -9,6 +9,7 @@ use XeroPHP\Application;
  * OAuth related ones.
  *
  * Class URL
+ *
  * @author Michael Calcinai
  */
 class URL
@@ -43,6 +44,7 @@ class URL
      * @param Application $app
      * @param $endpoint
      * @param null $api
+     *
      * @throws Exception
      */
     public function __construct(Application $app, $endpoint, $api = null)

--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -12,6 +12,7 @@ trait PDFTrait
      * Get the raw content of the resource's PDF file.
      *
      * @throws \XeroPHP\Exception
+     *
      * @return string
      */
     public function getPDF()

--- a/src/XeroPHP/Webhook.php
+++ b/src/XeroPHP/Webhook.php
@@ -33,7 +33,9 @@ class Webhook
      * @param \XeroPHP\Application $application
      * @param string $payload
      * @param string|null $event
+     *
      * @throws \XeroPHP\Application\Exception
+     *
      * @return void
      */
     public function __construct($application, $payload, $event = null)
@@ -78,6 +80,7 @@ class Webhook
 
     /**
      * @param string $signature
+     *
      * @return bool
      */
     public function validate($signature)

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -55,6 +55,7 @@ class Event
      *
      * @param \XeroPHP\Webhook $webhook
      * @param array $event event details
+     *
      * @throws \XeroPHP\Application\Exception if the provided payload is malformed
      */
     public function __construct($webhook, $event)
@@ -173,6 +174,7 @@ class Event
      *
      * @param \XeroPHP\Application $application an optional application instance to use to retrieve the remote resource.
      *                                          Useful if you have separate instances with different oauth tokens based on the tenant
+     *
      * @return \XeroPHP\Remote\Model|array If the event category is known, returns the model, otherwise, returns the resource as an array
      */
     public function getResource($application = null)


### PR DESCRIPTION
Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.

See: https://github.com/FriendsOfPhp/PHP-CS-Fixer