### PR TITLE
Add CurrentRecord getters and setters to every PayItem model.

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
@@ -106,6 +106,7 @@ class DeductionType extends Remote\Model
             'ReducesTax' => [true, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'ReducesSuper' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'DeductionTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
 
@@ -215,6 +216,27 @@ class DeductionType extends Remote\Model
     {
         $this->propertyUpdated('DeductionTypeID', $value);
         $this->_data['DeductionTypeID'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentRecord()
+    {
+        return $this->_data['CurrentRecord'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return DeductionType
+     */
+    public function setCurrentRecord($value)
+    {
+        $this->propertyUpdated('CurrentRecord', $value);
+        $this->_data['CurrentRecord'] = $value;
 
         return $this;
     }

--- a/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
@@ -106,7 +106,7 @@ class DeductionType extends Remote\Model
             'ReducesTax' => [true, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'ReducesSuper' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'DeductionTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false]
         ];
     }
 
@@ -221,7 +221,7 @@ class DeductionType extends Remote\Model
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getCurrentRecord()
     {
@@ -229,7 +229,7 @@ class DeductionType extends Remote\Model
     }
 
     /**
-     * @param string $value
+     * @param bool $value
      *
      * @return DeductionType
      */

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -179,7 +179,7 @@ class EarningsRate extends Remote\Model
             'Multiplier' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'AccrueLeave' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false]
         ];
     }
 
@@ -466,7 +466,7 @@ class EarningsRate extends Remote\Model
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getCurrentRecord()
     {
@@ -474,7 +474,7 @@ class EarningsRate extends Remote\Model
     }
 
     /**
-     * @param string $value
+     * @param bool $value
      *
      * @return EarningsRate
      */

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -179,6 +179,7 @@ class EarningsRate extends Remote\Model
             'Multiplier' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'AccrueLeave' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
 
@@ -460,6 +461,27 @@ class EarningsRate extends Remote\Model
     {
         $this->propertyUpdated('Amount', $value);
         $this->_data['Amount'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentRecord()
+    {
+        return $this->_data['CurrentRecord'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return EarningsRate
+     */
+    public function setCurrentRecord($value)
+    {
+        $this->propertyUpdated('CurrentRecord', $value);
+        $this->_data['CurrentRecord'] = $value;
 
         return $this;
     }

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -120,6 +120,7 @@ class LeaveType extends Remote\Model
             'LeaveTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'NormalEntitlement' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LeaveLoadingRate' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
 
@@ -271,6 +272,27 @@ class LeaveType extends Remote\Model
     {
         $this->propertyUpdated('LeaveLoadingRate', $value);
         $this->_data['LeaveLoadingRate'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentRecord()
+    {
+        return $this->_data['CurrentRecord'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return LeaveType
+     */
+    public function setCurrentRecord($value)
+    {
+        $this->propertyUpdated('CurrentRecord', $value);
+        $this->_data['CurrentRecord'] = $value;
 
         return $this;
     }

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -120,7 +120,7 @@ class LeaveType extends Remote\Model
             'LeaveTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'NormalEntitlement' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LeaveLoadingRate' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false]
         ];
     }
 
@@ -277,7 +277,7 @@ class LeaveType extends Remote\Model
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getCurrentRecord()
     {
@@ -285,7 +285,7 @@ class LeaveType extends Remote\Model
     }
 
     /**
-     * @param string $value
+     * @param bool $value
      *
      * @return LeaveType
      */

--- a/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
@@ -90,6 +90,7 @@ class ReimbursementType extends Remote\Model
             'Name' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'AccountCode' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'ReimbursementTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
         ];
     }
 
@@ -157,6 +158,27 @@ class ReimbursementType extends Remote\Model
     {
         $this->propertyUpdated('ReimbursementTypeID', $value);
         $this->_data['ReimbursementTypeID'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentRecord()
+    {
+        return $this->_data['CurrentRecord'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return ReimbursementType
+     */
+    public function setCurrentRecord($value)
+    {
+        $this->propertyUpdated('CurrentRecord', $value);
+        $this->_data['CurrentRecord'] = $value;
 
         return $this;
     }

--- a/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
@@ -90,7 +90,7 @@ class ReimbursementType extends Remote\Model
             'Name' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'AccountCode' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'ReimbursementTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'CurrentRecord' => [false, self::PROPERTY_TYPE_STRING, null, false, false]
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false]
         ];
     }
 
@@ -163,7 +163,7 @@ class ReimbursementType extends Remote\Model
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getCurrentRecord()
     {
@@ -171,7 +171,7 @@ class ReimbursementType extends Remote\Model
     }
 
     /**
-     * @param string $value
+     * @param bool $value
      *
      * @return ReimbursementType
      */


### PR DESCRIPTION
I ran into some trouble with timesheet integrations where users had marked used EarningsRates as Inactive in Xero.

I found out that PayItems [now have a `CurrentRecord` attribute](https://developer.xero.com/documentation/payroll-api/payitems#EarningsRates) that indicates whether an item is active. 

This PR adds a getter and setter for `CurrentRecord` to every PayItem model so you can handle deactivated items.

