### PR TITLE
Add tax amount to bank transaction line item model

### DIFF
--- a/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/LineItem.php
@@ -138,6 +138,7 @@ class LineItem extends Remote\Model
             'ItemCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LineItemID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'TaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
+            'TaxAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'LineAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Tracking' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\TrackingCategory', true, false],
         ];
@@ -293,6 +294,14 @@ class LineItem extends Remote\Model
         $this->_data['TaxType'] = $value;
 
         return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getTaxAmount()
+    {
+        return $this->_data['TaxAmount'];
     }
 
     /**


### PR DESCRIPTION
Xero sometimes returns a TaxAmount for the line items of bank transactions (example below). I have added the code to access them through the library.

```xml
<Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Id>xxxx</Id>
  <Status>OK</Status>
  <ProviderName>Xero API Previewer</ProviderName>
  <DateTimeUTC>2019-08-06T19:05:06.7081652Z</DateTimeUTC>
  <BankTransactions>
    <BankTransaction>
      <Contact>
        <ContactID>xxxx</ContactID>
        <Name>Emirates</Name>
      </Contact>
      <Date>2019-08-07T00:00:00</Date>
      <Status>AUTHORISED</Status>
      <LineAmountTypes>Inclusive</LineAmountTypes>
      <LineItems>
        <LineItem>
          <Description>Test</Description>
          <UnitAmount>10.00</UnitAmount>
          <TaxType>TAX003</TaxType>
          <TaxAmount>3.74</TaxAmount>
          <LineAmount>20.00</LineAmount>
          <AccountCode>310</AccountCode>
          <Quantity>2.0000</Quantity>
          <LineItemID>xxxx</LineItemID>
        </LineItem>
      </LineItems>
      <SubTotal>16.26</SubTotal>
      <TotalTax>3.74</TotalTax>
      <Total>20.00</Total>
      <UpdatedDateUTC>2019-08-06T19:04:19.71</UpdatedDateUTC>
      <CurrencyCode>EUR</CurrencyCode>
      <BankTransactionID>xxxx</BankTransactionID>
      <BankAccount>
        <AccountID>xxxx</AccountID>
        <Name>Business Account</Name>
      </BankAccount>
      <Type>SPEND</Type>
      <IsReconciled>false</IsReconciled>
      <HasAttachments>false</HasAttachments>
    </BankTransaction>
  </BankTransactions>
</Response>
```