### PR TITLE
Fix timeout issue sending invoice email

### DIFF
--- a/src/XeroPHP/Traits/SendEmailTrait.php
+++ b/src/XeroPHP/Traits/SendEmailTrait.php
@@ -24,6 +24,7 @@ trait SendEmailTrait
 
         $url = new URL($this->_application, $uri);
         $request = new Request($this->_application, $url, Request::METHOD_POST);
+        $request->setBody('');
 
         $request->send();
 


### PR DESCRIPTION
Xero has recently started return a `411 Length Required` response when a send email request is made.
This commit adds the missing header.

Fixes #580 