### PR TITLE
Remove PHP5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - hhvm
     - 7.0

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
 
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "ext-curl": "*",
         "ext-openssl": "*"
     },


### PR DESCRIPTION
As of December 2018 PHP 5 became End of Life, so this updated the requirement to 5.6 removes the failing builds on PHP 5.5.

Arguably it's time to drop PHP 5 entirely