### PR TITLE
Fixing Item Code being required for products

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -247,7 +247,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             }
 
             //if we only want the dirty props, stop here
-            if ( ! $this->isNeeded($property) && $dirty_only && ! isset($this->_dirty[$property])) {
+            if ( ! $this->isRequired($property) && $dirty_only && ! isset($this->_dirty[$property])) {
                 continue;
             }
 
@@ -267,13 +267,13 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     }
 
     /**
-     * Checks to see if the property is needed, and skips dirty checking if it is
+     * Checks to see if the property is required, and skips dirty checking if it is
      *
      * @param string $property
      *
      * @return bool
      */
-    private function isNeeded($property)
+    private function isRequired($property)
     {
       switch( get_class($this) ) {
         case 'XeroPHP\Models\Accounting\Item':

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -246,8 +246,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 continue;
             }
 
-            //if we only want the dirty props, stop here
-            if ( ! $this->isRequired($property) && $dirty_only && ! isset($this->_dirty[$property])) {
+            //if we only want the dirty props, stop here, unless it is required
+            if ( $dirty_only && ! isset($this->_dirty[$property]) && ! $this->isRequired($property) ) {
                 continue;
             }
 
@@ -267,7 +267,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
     }
 
     /**
-     * Checks to see if the property is required, and skips dirty checking if it is
+     * Checks to see if the property is required
      *
      * @param string $property
      *

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -275,16 +275,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      */
     private function isRequired($property)
     {
-      switch( get_class($this) ) {
-        case 'XeroPHP\Models\Accounting\Item':
-          switch( $property ) {
-            case 'Code':
-              return true;
-          }
-
-      }
-
-      return false;
+      $properties = $this->getProperties();
+      return (isset($properties[$property]) && $properties[$property][0]);
     }
 
     /**

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -247,7 +247,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             }
 
             //if we only want the dirty props, stop here
-            if ($dirty_only && ! isset($this->_dirty[$property])) {
+            if ( ! $this->isNeeded($property) && $dirty_only && ! isset($this->_dirty[$property])) {
                 continue;
             }
 
@@ -264,6 +264,27 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         }
 
         return $out;
+    }
+
+    /**
+     * Checks to see if the property is needed, and skips dirty checking if it is
+     *
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function isNeeded($property)
+    {
+      switch( get_class($this) ) {
+        case 'XeroPHP\Models\Accounting\Item':
+          switch( $property ) {
+            case 'Code':
+              return true;
+          }
+
+      }
+
+      return false;
     }
 
     /**


### PR DESCRIPTION
This fixes #404 which I had an issue with myself when using the API.

The Item code is required for updating an item in the Xero API.

This is stripped out automatically by the dirty checker if you're updating an item because is hasn't changed, which throws an error.

The workaround I have put in place for my current project is just doing the below, to force the dirty flag to be set.
```
$item->setCode('abc');
$item->setCode($code);
```

In this Pull Request I have added a new function to the Remote Model, where it checks a property to see if it is required. If a property is class as required then it does not check if it's dirty or not, it always includes it.

I wrote it in a way so that the `isRequired` function can be easily extended if there are any other endpoints that require it

It looks like it may be required for Invoices, as LineItems, Contact and Type are all required, but I have not tested this yet as I am not currently using Invoices
