### PR TITLE
Fix for current() returning null when used with Remote\Collection

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -408,7 +408,8 @@ abstract class Application
                 //Then actually save
                 $property_objects = $object->$property_name;
                 /** @var Remote\Model $property_type */
-                $property_type = get_class(current($property_objects));
+                $first_property = $property_objects->offsetGet(0);
+                $property_type = get_class($first_property);
 
                 $url = new URL($this, sprintf('%s/%s/%s', $object::getResourceURI(), $object->getGUID(), $property_type::getResourceURI()));
                 $request = new Request($this, $url, Request::METHOD_PUT);

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -408,8 +408,7 @@ abstract class Application
                 //Then actually save
                 $property_objects = $object->$property_name;
                 /** @var Remote\Model $property_type */
-                $first_property = $property_objects->offsetGet(0);
-                $property_type = get_class($first_property);
+                $property_type = get_class($property_objects->offsetGet(0));
 
                 $url = new URL($this, sprintf('%s/%s/%s', $object::getResourceURI(), $object->getGUID(), $property_type::getResourceURI()));
                 $request = new Request($this, $url, Request::METHOD_PUT);

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -408,7 +408,7 @@ abstract class Application
                 //Then actually save
                 $property_objects = $object->$property_name;
                 /** @var Remote\Model $property_type */
-                $property_type = get_class($property_objects->offsetGet(0));
+                $property_type = get_class(current($property_objects->getArrayCopy()));
 
                 $url = new URL($this, sprintf('%s/%s/%s', $object::getResourceURI(), $object->getGUID(), $property_type::getResourceURI()));
                 $request = new Request($this, $url, Request::METHOD_PUT);


### PR DESCRIPTION
I noticed credit note/overpayment allocations were not being sent to Xero, with the following message appearing in the logs:

> Warning Error: get_class() expects parameter 1 to be object, null given in [/var/www/app/Vendor/calcinai/xero-php/src/XeroPHP/Application.php, line 384]
> 
> Error: Class name must be a valid object or a string
> #0 /var/www/app/Vendor/calcinai/xero-php/src/XeroPHP/Application.php(273): XeroPHP\Application->savePropertiesDirectly()

After some investigation, I noticed the `current()` function when used with a `Remote\Collection` class always returns null. I replaced this with a `offsetGet(0)` method call on the object, and this appears to be working correctly.

For reference, I'm using PHP 7.4.