### PR TITLE
Update to use correct RootNodeName

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -51,7 +51,7 @@ class PayItem extends Remote\Model
      */
     public static function getRootNodeName()
     {
-        return 'PayItem';
+        return 'PayItems';
     }
 
     /**


### PR DESCRIPTION
Change to the getRootNodeName to allow saving of PayItem objects