### PR TITLE
Fix an error in Response when Xero returns a 204

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -212,7 +212,10 @@ class Response
         $this->root_error = [];
 
         //Could possibly iterate these until a match
-        list($content_type) = explode(';', $this->headers[Request::HEADER_CONTENT_TYPE][0]);
+        $content_type = null;
+        if ($this->getStatus() !== 204) {
+            list($content_type) = explode(';', $this->headers[Request::HEADER_CONTENT_TYPE][0]);
+        }
 
         switch ($content_type) {
             case Request::CONTENT_TYPE_XML:


### PR DESCRIPTION
They do not return a `Content-Type` header with their `240` responses.

e.g. the send email endpoint returns a `204`