### PR TITLE
Update EarningsRate.php to include AllowanceType property

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -308,19 +308,21 @@ class EarningsRate extends Remote\Model
     /**
      * @return string
      */
-    public function getAllowanceType() {
+    public function getAllowanceType()
+    {
         return $this->_data['AllowanceType'];
     }
 
     /**
      * @param string $value
-     * 
+     *
      * @return EarningsRate
      */
-    public function setAllowanceType($value) {
+    public function setAllowanceType($value)
+    {
         $this->propertyUpdated('AllowanceType', $value);
         $this->_data['AllowanceType'] = $value;
-        
+
         return $this;
     }
 

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -75,6 +75,25 @@ class EarningsRate extends Remote\Model
      */
 
     /**
+     * Option AllowanceType for ALLOWANCE EarningsType EarningsRate.
+     * Used to group allowances for reporting to the ATO. Undocumented. Only applicable if EarningsType is ALLOWANCE.
+     *
+     * @property string AllowanceType
+     */
+    const ALLOWANCETYPE_CAR = 'CAR';
+
+    const ALLOWANCETYPE_LAUNDRY = 'LAUNDRY';
+
+    const ALLOWANCETYPE_MEALS = 'MEALS';
+
+    const ALLOWANCETYPE_TRANSPORT = 'TRANSPORT';
+
+    const ALLOWANCETYPE_TRAVEL = 'TRAVEL';
+
+    const ALLOWANCETYPE_OTHER = 'OTHER';
+
+
+    /**
      * Option Amount for FIXEDAMOUNT RateType EarningsRate.
      *
      * @property float Amount
@@ -171,7 +190,8 @@ class EarningsRate extends Remote\Model
             'Multiplier' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'AccrueLeave' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false]
+            'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
+            'AllowanceType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false]
         ];
     }
 
@@ -282,6 +302,25 @@ class EarningsRate extends Remote\Model
         $this->propertyUpdated('IsExemptFromSuper', $value);
         $this->_data['IsExemptFromSuper'] = $value;
 
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAllowanceType() {
+        return $this->_data['AllowanceType'];
+    }
+
+    /**
+     * @param string $value
+     * 
+     * @return EarningsRate
+     */
+    public function setAllowanceType($value) {
+        $this->propertyUpdated('AllowanceType', $value);
+        $this->_data['AllowanceType'] = $value;
+        
         return $this;
     }
 


### PR DESCRIPTION
Creating an Allowance in Xero requires or at least prefers an undocumented "AllowanceType" property.
This update adds the getters and setters, and constants for the possible values of the property.