### PR TITLE
Fix return types in Accounting/Item PHP Docs

### DIFF
--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -67,13 +67,13 @@ class Item extends Remote\Model
     /**
      * See Purchases & Sales.
      *
-     * @property Purchase[] PurchaseDetails
+     * @property Purchase PurchaseDetails
      */
 
     /**
      * See Purchases & Sales.
      *
-     * @property Sale[] SalesDetails
+     * @property Sale SalesDetails
      */
 
     /**
@@ -358,7 +358,7 @@ class Item extends Remote\Model
     }
 
     /**
-     * @return Purchase[]|Remote\Collection
+     * @return Purchase
      */
     public function getPurchaseDetails()
     {
@@ -390,7 +390,7 @@ class Item extends Remote\Model
     }
 
     /**
-     * @return Remote\Collection|Sale[]
+     * @return Sale
      */
     public function getSalesDetails()
     {


### PR DESCRIPTION
Item no longer returns an array of PurchaseDetails or SalesDetails, and should instead return a single object.
Simply updating the PHPDoc comments to reflect this