### PR TITLE
Guzzle exception fix

### DIFF
--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -88,30 +88,6 @@ class Request
     }
 
     /**
-     * Parse Response from Guzzle / HTTP Client
-     * @param $response
-     * @throws Exception
-     * @throws Exception\BadRequestException
-     * @throws Exception\ForbiddenException
-     * @throws Exception\InternalErrorException
-     * @throws Exception\NotAvailableException
-     * @throws Exception\NotFoundException
-     * @throws Exception\NotImplementedException
-     * @throws Exception\OrganisationOfflineException
-     * @throws Exception\RateLimitExceededException
-     * @throws Exception\ReportPermissionMissingException
-     * @throws Exception\UnauthorizedException
-     */
-    private function parseResponse($response) {
-        $this->response = new Response($this,
-            $response->getBody()->getContents(),
-            $response->getStatusCode(),
-            $response->getHeaders()
-        );
-        $this->response->parse();
-    }
-
-    /**
      * @throws Exception
      * @throws Exception\BadRequestException
      * @throws Exception\ForbiddenException
@@ -132,14 +108,15 @@ class Request
 
         try {
             $guzzleResponse = $this->app->getTransport()->send($request);
-        } catch (\GuzzleHttp\Exception\BadResponseException $e) {
-            $response = $e->getResponse();
-            $this->parseResponse($response);
-            return $this->response;
-        } catch (\GuzzleHttp\Exception\GuzzleException $e) {
-            throw new Exception($e->getMessage(), $e->getCode());
+        }  catch (\GuzzleHttp\Exception\GuzzleException $e) {
+            $guzzleResponse = $e->getResponse();
         }
-        $this->parseResponse($guzzleResponse);
+        $this->response = new Response($this,
+            $guzzleResponse->getBody()->getContents(),
+            $guzzleResponse->getStatusCode(),
+            $guzzleResponse->getHeaders()
+        );
+        $this->response->parse();
         return $this->response;
     }
 

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -88,6 +88,7 @@ class Request
     }
 
     /**
+     * Parse Response from Guzzle / HTTP Client
      * @param $response
      * @throws Exception
      * @throws Exception\BadRequestException

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -88,7 +88,29 @@ class Request
     }
 
     /**
-     * @return Response
+     * @param $response
+     * @throws Exception
+     * @throws Exception\BadRequestException
+     * @throws Exception\ForbiddenException
+     * @throws Exception\InternalErrorException
+     * @throws Exception\NotAvailableException
+     * @throws Exception\NotFoundException
+     * @throws Exception\NotImplementedException
+     * @throws Exception\OrganisationOfflineException
+     * @throws Exception\RateLimitExceededException
+     * @throws Exception\ReportPermissionMissingException
+     * @throws Exception\UnauthorizedException
+     */
+    private function parseResponse($response) {
+        $this->response = new Response($this,
+            $response->getBody()->getContents(),
+            $response->getStatusCode(),
+            $response->getHeaders()
+        );
+        $this->response->parse();
+    }
+
+    /**
      * @throws Exception
      * @throws Exception\BadRequestException
      * @throws Exception\ForbiddenException
@@ -109,17 +131,14 @@ class Request
 
         try {
             $guzzleResponse = $this->app->getTransport()->send($request);
+        } catch (\GuzzleHttp\Exception\BadResponseException $e) {
+            $response = $e->getResponse();
+            $this->parseResponse($response);
+            return $this->response;
         } catch (\GuzzleHttp\Exception\GuzzleException $e) {
             throw new Exception($e->getMessage(), $e->getCode());
         }
-
-        $this->response = new Response($this,
-            $guzzleResponse->getBody()->getContents(),
-            $guzzleResponse->getStatusCode(),
-            $guzzleResponse->getHeaders()
-        );
-        $this->response->parse();
-
+        $this->parseResponse($guzzleResponse);
         return $this->response;
     }
 


### PR DESCRIPTION
Exceptions weren't been captured and parsed correctly when a Bad Response Exception was thrown by the server, resulting in a truncated message from Guzzle rather than a parsed exception