### PR TITLE
Removed redundant forward slash separating base_url and path

### DIFF
--- a/src/XeroPHP/Remote/URL.php
+++ b/src/XeroPHP/Remote/URL.php
@@ -96,6 +96,6 @@ class URL
      */
     public function getFullURL()
     {
-        return sprintf('%s/%s', $this->base_url, $this->path);
+        return sprintf('%s%s', $this->base_url, $this->path);
     }
 }


### PR DESCRIPTION
Getting
`https://api.xero.com//api.xro/2.0/BrandingThemes`
instead of
`https://api.xero.com/api.xro/2.0/BrandingThemes`