### PR TITLE
Add setPayslipMessage function

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayRun.php
+++ b/src/XeroPHP/Models/PayrollAU/PayRun.php
@@ -309,6 +309,19 @@ class PayRun extends Remote\Model
     {
         return $this->_data['PayslipMessage'];
     }
+    
+     /**
+     * @param string $value
+     *
+     * @return PayRun
+     */
+    public function setPayslipMessage($value)
+    {
+        $this->propertyUpdated('PayslipMessage', $value);
+        $this->_data['PayslipMessage'] = $value;
+
+        return $this;
+    }
 
     /**
      * @return Payslip[]|Remote\Collection


### PR DESCRIPTION
Missing method to set a PayRun's payslip message
I have tested this by adding the method, setting the message, saving, and verifying the change on Xero