### PR TITLE
Update Helpers to handle PayrollAU\Payslip\TimesheetEarningsLines

### DIFF
--- a/src/XeroPHP/Helpers.php
+++ b/src/XeroPHP/Helpers.php
@@ -85,7 +85,8 @@ class Helpers
             //don't make it assoc, as the keys will all be the same
             if ($child_name === $singular_node_name ||
                 //Handle strange XML
-                ($singular_node_name === 'Tracking' && $child_name === TrackingCategory::getRootNodeName())) {
+                ($singular_node_name === 'Tracking' && $child_name === TrackingCategory::getRootNodeName()) ||
+                ($singular_node_name == Payslip\TimesheetEarningsLine::getRootNodeName() && $child_name == 'EarningsLine')) {
                 $output[] = $node;
             } else {
                 $output[$child_name] = $node;


### PR DESCRIPTION
Update to the Helpers function to correctly parse the TimesheetEarningsLines data, which contains what the comments call "strange XML"