### PR TITLE
Handle null guids in loadByGuid and loadByGuids

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -188,6 +188,10 @@ class Application
         /** @var Remote\Model $class */
         $class = $this->validateModelClass($model);
 
+        if(!$guid){
+            throw new Remote\Exception\NotFoundException;
+        }
+
         $uri = sprintf('%s/%s', $class::getResourceURI(), $guid);
         $api = $class::getAPIStem();
 
@@ -224,6 +228,10 @@ class Application
     {
         /** @var $class Remote\Model */
         $class = $this->validateModelClass($model);
+
+        if(empty($guids)){
+            return [];
+        }
 
         $uri = sprintf('%s', $class::getResourceURI());
         $api = $class::getAPIStem();


### PR DESCRIPTION
If we don't do this, then if the $guid property is null, we collect a page of models and then end up returning a random model. This behaviour is very unexpected to a consumer of this library