### PR TITLE
Fix Guzzle exception wrapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
       "ext-simplexml": "*"
    },
    "require-dev": {
-      "phpunit/phpunit": "~5"
+      "phpunit/phpunit": "^5"
    },
    "autoload": {
       "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
       "ext-simplexml": "*"
    },
    "require-dev": {
-      "phpunit/phpunit": "~4.7"
+      "phpunit/phpunit": "~5"
    },
    "autoload": {
       "psr-4": {

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -108,7 +108,7 @@ class Request
 
         try {
             $guzzleResponse = $this->app->getTransport()->send($request);
-        }  catch (\GuzzleHttp\Exception\GuzzleException $e) {
+        }  catch (\GuzzleHttp\Exception\BadResponseException $e) {
             $guzzleResponse = $e->getResponse();
         }
         $this->response = new Response($this,

--- a/tests/Remote/RequestTest.php
+++ b/tests/Remote/RequestTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace XeroPHP\Tests\Remote;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response;
+use XeroPHP\Application;
+use XeroPHP\Remote\Request as XeroRequest;
+use XeroPHP\Remote\URL;
+use XeroPHP\Remote\Exception\BadRequestException;
+
+class RequestTest extends \PHPUnit_Framework_TestCase
+{
+    private function getMockedApplication($mockedResponses)
+    {
+        $app = new Application('', '');
+        $mock = new MockHandler($mockedResponses);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $app->setTransport($client);
+        return $app;
+    }
+
+    public function testBadRequestException()
+    {
+        $app = $this->getMockedApplication([
+            new BadResponseException('Bad response', new GuzzleRequest('GET', 'test'), new Response(400))
+        ]);
+        $request = new XeroRequest($app, new URL($app, 'test'));
+
+        $this->expectException(BadRequestException::class);
+        $request->send();
+    }
+
+    public function testGuzzleExceptionsAreThrown()
+    {
+        $app = $this->getMockedApplication([
+            new ConnectException('Failed to connect', new GuzzleRequest('GET', 'test'))
+        ]);
+        $request = new XeroRequest($app, new URL($app, 'test'));
+
+        $this->expectException(ConnectException::class);
+        $request->send();
+    }
+}


### PR DESCRIPTION
resolves #711 (probably - based on the info available)

In https://github.com/calcinai/xero-php/pull/682 a fix was made to ensure that bad responses were caught by catching Guzzle exceptions. However, the catch is too broad and catches non-response related failures (`ConnectTimeout` etc), which do not have a wrapped `Response` object in the exception.

We should only catch `BadResponseException`s and allow Guzzle to throw other exceptions as necessary. Alternatively, we can start wrapping these other Guzzle exceptions into `XeroPHP\Remote\Exception`. I've chosen the former as 1.x didn't throw exceptions in those conditions.

I've added a test for the above behaviour. 
I've also bumped the phpunit version constraint (still 5.6 compatible) as there were no blockers to doing so. Let me know if you want me to split that into a separate PR.