### PR TITLE
Fix dependency on guzzlehttp/guzzle and guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,8 @@
    "require": {
       "php": ">=5.6.0",
       "calcinai/oauth2-xero": "^0.1.0",
+      "guzzlehttp/guzzle": "^6.5",
+      "guzzlehttp/psr7": "^1.5",
       "ext-json": "*",
       "ext-simplexml": "*"
    },


### PR DESCRIPTION
As this library now has a direct dependency on `guzzlehttp/guzzle` and `guzzlehttp/psr7`, it is best that we specify these two dependencies in our `composer.json` with a valid version constraint.

Currently, we are implicitly relying on Guzzle being available via `league/oauth2-client` (via `calcinai/oauth2-xero`) however, the version constraint that is indirectly requiring `psr7` is too low for our uses. We require a minimum version of `1.5` as we are using `Uri::withQueryValues`.