### PR TITLE
Fix incorrect property on TimesheetEarningsLine

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
@@ -89,6 +89,7 @@ class TimesheetEarningsLine extends Remote\Model
             'EarningsRateID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'RatePerUnit' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'NumberOfUnits' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
+            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false]
         ];
     }
 
@@ -139,6 +140,31 @@ class TimesheetEarningsLine extends Remote\Model
         return $this;
     }
 
+    /**
+     * @return Amount
+     * 
+     * @deprecated
+     */
+    public function getAmount()
+    {
+        return $this->_data['Amount'];
+    }
+    
+    /**
+     * @param float $value
+     * 
+     * @return TimesheetEarningsLine
+     *
+     * @deprecated
+     */
+    public function setAmount()
+    {
+        $this->propertyUpdated('Amount', $value);
+        $this->_data['Amount'] = $value;
+
+        return $this;
+    }
+    
     /**
      * @return float
      */

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
@@ -157,7 +157,7 @@ class TimesheetEarningsLine extends Remote\Model
      *
      * @deprecated
      */
-    public function setAmount()
+    public function setAmount($value)
     {
         $this->propertyUpdated('Amount', $value);
         $this->_data['Amount'] = $value;

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
@@ -19,9 +19,9 @@ class TimesheetEarningsLine extends Remote\Model
      */
 
     /**
-     * The Amount of the Timesheet Earnings Line.
+     * The Number of Units of the Timesheet Earnings Line.
      *
-     * @property float Amount
+     * @property float NumberOfUnits
      */
 
     /**
@@ -88,7 +88,7 @@ class TimesheetEarningsLine extends Remote\Model
         return [
             'EarningsRateID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'RatePerUnit' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
+            'NumberOfUnits' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
         ];
     }
 
@@ -142,9 +142,9 @@ class TimesheetEarningsLine extends Remote\Model
     /**
      * @return float
      */
-    public function getAmount()
+    public function getNumberOfUnits()
     {
-        return $this->_data['Amount'];
+        return $this->_data['NumberOfUnits'];
     }
 
     /**
@@ -152,10 +152,10 @@ class TimesheetEarningsLine extends Remote\Model
      *
      * @return TimesheetEarningsLine
      */
-    public function setAmount($value)
+    public function setNumberOfUnits($value)
     {
-        $this->propertyUpdated('Amount', $value);
-        $this->_data['Amount'] = $value;
+        $this->propertyUpdated('NumberOfUnits', $value);
+        $this->_data['NumberOfUnits'] = $value;
 
         return $this;
     }


### PR DESCRIPTION
TimesheetEarningsLine actually uses NumberOfUnits not Amount

https://developer.xero.com/documentation/payroll-api/payslip#TimesheetEarningsLine