### PR TITLE
fix hydrating remote collections from empty properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
    },
    "autoload": {
       "psr-4": {
-         "XeroPHP\\": "src/XeroPHP/"
+         "XeroPHP\\": "src/XeroPHP/",
+         "XeroPHP\\Tests\\": "tests/"
       }
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
    },
    "autoload": {
       "psr-4": {
-         "XeroPHP\\": "src/XeroPHP/",
+         "XeroPHP\\": "src/XeroPHP/"
+      }
+  },
+   "autoload-dev": {
+      "psr-4": {
          "XeroPHP\\Tests\\": "tests/"
       }
    }

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -193,6 +193,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         foreach (static::getProperties() as $property => $meta) {
             $type = $meta[self::KEY_TYPE];
             $php_type = $meta[self::KEY_PHP_TYPE];
+            $isArray = $meta[self::KEY_IS_ARRAY];
 
             //If set and NOT replace data, continue
             if (! $replace_data && isset($this->_data[$property])) {
@@ -205,10 +206,16 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
                 continue;
             }
 
+            if ($isArray && ! is_array($input_array[$property])) {
+                $this->_data[$property] = null;
+
+                continue;
+            }
+
             //Fix for an earlier assumption that the API didn't return more than
             //two levels of nested objects.
             //Handles Invoice > Contact > Address etc. in one build.
-            if (is_array($input_array[$property]) && Helpers::isAssoc($input_array[$property]) === false) {
+            if ($isArray && Helpers::isAssoc($input_array[$property]) === false) {
                 $collection = new Collection();
                 $collection->addAssociatedObject($property, $this);
                 foreach ($input_array[$property] as $assoc_element) {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace XeroPHP\tests;
+
+use XeroPHP\Helpers;
+
+class HelpersTest extends \PHPUnit_Framework_TestCase
+{
+    public function testXMLToArrayWithEmptyNodes()
+    {
+        $xml = new \SimpleXMLElement('<Test><A /><B></B></Test>');
+        $arr = Helpers::XMLToArray($xml);
+
+        $this->assertCount(2, $arr);
+        $this->assertSame('', $arr['A']);
+        $this->assertSame('', $arr['B']);
+    }
+
+    public function testXMLToArrayWithChildNodes()
+    {
+        $xml = new \SimpleXMLElement('<Test><Things><Thing>A</Thing><Thing>B</Thing></Things></Test>');
+        $arr = Helpers::XMLToArray($xml);
+
+        $this->assertCount(1, $arr);
+        $this->assertCount(2, $arr['Things']);
+        $this->assertContains('A', $arr['Things']);
+        $this->assertContains('B', $arr['Things']);
+    }
+
+    public function testXMLToArrayWithAssocChildNodes()
+    {
+        $xml = new \SimpleXMLElement('<Test><Thing><Item>A</Item><Item>B</Item><C/></Thing></Test>');
+        $arr = Helpers::XMLToArray($xml);
+
+        $this->assertCount(1, $arr);
+        $this->assertCount(2, $arr['Thing']);
+        $this->assertSame('B', $arr['Thing']['Item']);
+        $this->assertSame('', $arr['Thing']['C']);
+    }
+}

--- a/tests/Remote/Model/ModelWithCollection.php
+++ b/tests/Remote/Model/ModelWithCollection.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace XeroPHP\Tests\Remote\Model;
+
+use XeroPHP\Remote\Model;
+use XeroPHP\Remote\URL;
+
+class ModelWithCollection extends Model
+{
+    public static function getGUIDProperty()
+    {
+        return 'ModelID';
+    }
+
+    public static function getProperties()
+    {
+        return [
+            'ModelID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'EarningsLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Payslip\\EarningsLine', true, false],
+        ];
+    }
+
+    public static function getSupportedMethods()
+    {
+        return ['test'];
+    }
+
+    public static function getResourceURI()
+    {
+        return 'Model';
+    }
+
+    public static function isPageable()
+    {
+        return false;
+    }
+
+    public static function getAPIStem()
+    {
+        return URL::API_PAYROLL;
+    }
+
+    public static function getRootNodeName()
+    {
+        return 'Model';
+    }
+
+    public function getEarningsLines()
+    {
+        return isset($this->_data['EarningsLines']) ? $this->_data['EarningsLines'] : null;
+    }
+
+    public function getModelID()
+    {
+        return isset($this->_data['ModelID']) ? $this->_data['ModelID'] : null;
+    }
+}

--- a/tests/Remote/ModelTest.php
+++ b/tests/Remote/ModelTest.php
@@ -2,7 +2,14 @@
 
 namespace XeroPHP\Tests\Remote;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response;
+use XeroPHP\Application;
 use XeroPHP\Remote\Model;
+use XeroPHP\Tests\Remote\Model\ModelWithCollection;
 
 class ModelTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,6 +48,23 @@ class ModelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('5b96e86b-418e-48e8-8949-308c14aec278', $object->getGUID());
         $this->assertTrue($object->hasGUID());
+    }
+
+    public function testSetsEmptyCollection()
+    {
+        $testXML = '<Response><Models><Model><ModelID>test</ModelID><EarningsLines /></Model></Models></Response>';
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'text/xml'], $testXML),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+
+        $client = new Client(['handler' => $handlerStack]);
+        $app = new Application('', '');
+        $app->setTransport($client);
+
+        $model = $app->loadByGUID(ModelWithCollection::class, 'test');
+        $this->assertSame('test', $model->getModelID());
+        $this->assertNull($model->getEarningsLines());
     }
 }
 


### PR DESCRIPTION
This change aims to resolve #718 
The full details of this change can be found in this comment https://github.com/calcinai/xero-php/issues/718#issuecomment-610888438

This change now makes use of the previously unused "is array" meta property to determine if a remote collection is empty or not. Previously the hydration would treat the empty XML property as a string and create a singular empty object. Now, `null` is assigned to allow a remote collection to be created later.

I've drafted for now, I will add a couple of unit tests before marking as ready.