### PR TITLE
RemoteQuery: Match GUIDs without dot notation

### DIFF
--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -113,7 +113,7 @@ class Query
                 $this->where[] = sprintf('%s==%s', $args[0], $args[1]);
             } elseif (preg_match('/^(\'|")?(true|false)("|\')?$/i', $args[1])) {
                 $this->where[] = sprintf('%s=%s', $args[0], $args[1]);
-            } elseif (preg_match('/^([a-z]+)\\.\\1ID$/i', $args[0])
+            } elseif (preg_match('/^([a-z]+)(\\.\\1)?ID$/i', $args[0])
                 && preg_match(
                     '/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i',
                     $args[1]


### PR DESCRIPTION
Hi @calcinai, this is a PR that fixes the GUID query issues
Fixes #364 , Fixes #402 