### PR TITLE
Fix throwing RateLimitExceededException

### DIFF
--- a/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
+++ b/src/XeroPHP/Remote/Exception/RateLimitExceededException.php
@@ -12,6 +12,21 @@ class RateLimitExceededException extends Exception
     protected $code = Response::STATUS_RATE_LIMIT_EXCEEDED;
 
     protected $rateLimitProblem;
+    protected $retryAfter;
+
+    public static function createFromHeaders($headers)
+    {
+        $headers = array_change_key_case($headers, CASE_LOWER);
+
+        $problem = isset($headers['x-rate-limit-problem']) ? current($headers['x-rate-limit-problem']) : null;
+        $retryAfter = isset($headers['retry-after']) ? current($headers['retry-after']) : null;
+
+        $exception = new self();
+        $exception->setRateLimitProblem($problem);
+        $exception->setRetryAfter($retryAfter);
+
+        return $exception;
+    }
 
     public function setRateLimitProblem($rateLimitProblem)
     {
@@ -21,5 +36,15 @@ class RateLimitExceededException extends Exception
     public function getRateLimitProblem()
     {
         return $this->rateLimitProblem;
+    }
+
+    public function setRetryAfter($retryAfter)
+    {
+        $this->retryAfter = (int) $retryAfter;
+    }
+
+    public function getRetryAfter()
+    {
+        return $this->retryAfter;
     }
 }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -38,6 +38,8 @@ class Response
 
     const STATUS_ORGANISATION_OFFLINE = 503;
 
+    const STATUS_TOO_MANY_REQUESTS = 429;
+
     private $request;
 
     private $headers;
@@ -118,6 +120,9 @@ class Response
             case self::STATUS_NOT_IMPLEMENTED:
                 throw new NotImplementedException();
 
+            case self::STATUS_TOO_MANY_REQUESTS:
+                throw RateLimitExceededException::createFromHeaders($this->headers);
+
             case self::STATUS_NOT_AVAILABLE:
             case self::STATUS_RATE_LIMIT_EXCEEDED:
             case self::STATUS_ORGANISATION_OFFLINE:
@@ -127,11 +132,7 @@ class Response
                     throw new OrganisationOfflineException();
                 }
                 if (false !== stripos($response, 'Rate limit exceeded')) {
-                    $problem = isset($this->headers['x-rate-limit-problem']) ? current($this->headers['x-rate-limit-problem']) : null;
-                    $exception = new RateLimitExceededException();
-                    $exception->setRateLimitProblem($problem);
-
-                    throw $exception;
+                    throw RateLimitExceededException::createFromHeaders($this->headers);
                 }
 
                 throw new NotAvailableException();


### PR DESCRIPTION
resolves #731 

This adds support for the new 429 response code in the oauth2 API whilst maintaining backwards compatibility with the oauth1 API. Additionally, the refactor to Guzzle caused the casing of headers to change - breaking the parsing of the rate limit info headers.

Exposes the new Retry-After header.

Tests included