### PR TITLE
ci: remove hhvm, add 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: php
 
 php:
-    - hhvm
+    - 5.6
     - 7.0
     - 7.1
     - 7.2
-
-matrix:
-    allow_failures:
-        - php: hhvm
 
 before_script:
     - composer install


### PR DESCRIPTION
As far as I can tell, hhvm never passed on travis. I would say it's fair to drop this from the config, as it currently takes by far the longest to complete (and fail).

5.6 was also [dropped recently](https://github.com/calcinai/xero-php/compare/e6b72c3f3702ed5923064a9579f6497bb6ed2049..43618d3b80b84ed40254d6b27229626c1cd81de8), but it seems beneficial to me to keep this version in the matrix whilst it is still supported. Any reason not to include it?