### PR TITLE
Throw exception on non-2xx response

### DIFF
--- a/src/XeroPHP/Remote/Exception/UnknownStatusException.php
+++ b/src/XeroPHP/Remote/Exception/UnknownStatusException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace XeroPHP\Remote\Exception;
+
+use XeroPHP\Remote\Exception;
+
+class UnknownStatusException extends Exception
+{
+    //
+}

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -14,6 +14,7 @@ use XeroPHP\Remote\Exception\OrganisationOfflineException;
 use XeroPHP\Remote\Exception\RateLimitExceededException;
 use XeroPHP\Remote\Exception\ReportPermissionMissingException;
 use XeroPHP\Remote\Exception\UnauthorizedException;
+use XeroPHP\Remote\Exception\UnknownStatusException;
 
 class Response
 {
@@ -78,6 +79,7 @@ class Response
      * @throws UnauthorizedException
      * @throws ForbiddenException
      * @throws ReportPermissionMissingException
+     * @throws UnknownStatusException
      */
     public function parse()
     {
@@ -136,6 +138,10 @@ class Response
                 }
 
                 throw new NotAvailableException();
+        }
+
+        if ($this->status !== self::STATUS_OK) {
+            throw new UnknownStatusException('The API returned a non-successful status code that is not recognised.', $this->status);
         }
     }
 

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -18,6 +18,19 @@ use XeroPHP\Remote\Exception\UnknownStatusException;
 
 class Response
 {
+    const STATUS_SUCCESS = [
+        'OK' => 200,
+        'CREATED' => 201,
+        'ACCEPTED' => 202,
+        'NON_AUTHORITATIVE_INFORMATION' => 203,
+        'NO_CONTENT' => 204,
+        'RESET_CONTENT' => 205,
+        'PARTIAL_CONTENT' => 206,
+        'MULTI_STATUS' => 207,
+        'ALREADY_REPORTED' => 208,
+        'IM_USED' => 226,
+    ];
+
     const STATUS_OK = 200;
 
     const STATUS_BAD_REQUEST = 400;
@@ -140,7 +153,7 @@ class Response
                 throw new NotAvailableException();
         }
 
-        if ($this->status !== self::STATUS_OK) {
+        if (!in_array($this->status, self::STATUS_SUCCESS)) {
             throw new UnknownStatusException('The API returned a non-successful status code that is not recognised.', $this->status);
         }
     }

--- a/tests/Remote/RequestTest.php
+++ b/tests/Remote/RequestTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response;
 use XeroPHP\Application;
+use XeroPHP\Remote\Exception\UnknownStatusException;
 use XeroPHP\Remote\Request as XeroRequest;
 use XeroPHP\Remote\URL;
 use XeroPHP\Remote\Exception\BadRequestException;
@@ -94,5 +95,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(RateLimitExceededException::class, $exception);
         $this->assertSame('minute', $exception->getRateLimitProblem());
         $this->assertSame(8, $exception->getRetryAfter());
+    }
+
+    public function testUnknownStatusExceptionIsThrown()
+    {
+        $app = $this->getMockedApplication([
+            new Response(599)
+        ]);
+        $request = new XeroRequest($app, new URL($app, 'test'));
+
+        $this->expectException(UnknownStatusException::class);
+        $request->send();
     }
 }


### PR DESCRIPTION
Something I would have found useful while working with this library is if the response class threw an exception when a non-2xx status code is returned from the API. 

In the case of my issue https://github.com/calcinai/xero-php/issues/739 I realise this has already been fixed as part of https://github.com/calcinai/xero-php/pull/732, however had the response class still returned a fallback exception on a non-200, this could saved a couple of headaches. 

Currently the [Xero Documentation](https://developer.xero.com/documentation/api/http-response-codes) shows a specific set of status codes, however it's clear that the Xero API can change what is returned at any time without documenting it.

So, in the event that an unsuccessful undocumented status code is returned that is not being handled by this library, the response class will assume the request was successful. 

When this happens, any consuming code can't easily detect if there was a request failure or if the query just returned no results. 

An improvement to this change could be to check for an array of success codes (201, 202, etc) just in case Xero ever decide to return these in the future, although these aren't currently documented. 

Would be interested to hear your thoughts. 

Test included. 