### PR TITLE
docs: update webhook readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Refer to the [examples](examples) for more complex usage and nested/related obje
 If you are receiving webhooks from Xero there is `Webhook` class that can help with handling the request and parsing the associated event list.
 
 ```php
+// Configure the webhook signing key on the application
+$application->setConfig(['webhook' => ['signing_key' => 'xyz123']]);
 $webhook = new Webhook($application, $request->getContent());
 
 /**
@@ -229,7 +231,7 @@ See: [Webhooks documentation](https://developer.xero.com/documentation/webhooks/
 
 ### Validating Webhooks
 
-To ensure the webhooks are coming from Xero you should validate the incoming request header that Xero provides.
+To ensure the webhooks are coming from Xero you must validate the incoming request header that Xero provides.
 
 ```php
 if (! $webhook->validate($request->headers->get('x-xero-signature'))) {


### PR DESCRIPTION
In V2, the `Application` constructor no longer takes a config array, so you need to manually set the signing key onto the app before creating the webhook :)

PR updates the readme to make this clear, as it's different to v1