### PR TITLE
Bump Guzzle and PSR7 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
   "require": {
     "php": ">=5.5.0",
     "calcinai/oauth2-xero": "^1.0",
-    "guzzlehttp/guzzle": "^6.5",
-    "guzzlehttp/psr7": "^1.5",
+    "guzzlehttp/guzzle": "^6.5|^7.0",
+    "guzzlehttp/psr7": "^1.5|^1.6",
     "ext-json": "*",
     "ext-simplexml": "*"
   },


### PR DESCRIPTION
Bump the Guzzle version to support GuzzleHTTP ^7.0 and PRS7 ^1.6 to allow use with Laravel 8