### PR TITLE
Fix for Tracking Category in settings

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/Setting/EmployeeGroup.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/EmployeeGroup.php
@@ -4,18 +4,18 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
-class TrackingCategory extends Remote\Model
+class EmployeeGroup extends Remote\Model
 {
     /**
-     * Employee Groups tracking category
+     * Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
      *
-     * @property EmployeeGroup employeeGroups
+     * @property string TrackingCategoryID
      */
 
     /**
-     * Timesheet Categories tracking category
+     * Name of tracking category.
      *
-     * @property TimesheetCategory timesheetCategories
+     * @property string TrackingCategoryName
      */
 
     /**
@@ -39,12 +39,13 @@ class TrackingCategory extends Remote\Model
     }
 
     /**
-     * Get the guid property. This model doesn't have one.
+     * Get the guid property.
      *
      * @return string
      */
-    public static function getGUIDProperty() {
-        return '';
+    public static function getGUIDProperty()
+    {
+        return 'TrackingCategoryID';
     }
 
     /**
@@ -63,7 +64,6 @@ class TrackingCategory extends Remote\Model
     public static function getSupportedMethods()
     {
         return [
-            Remote\Request::METHOD_GET
         ];
     }
 
@@ -80,8 +80,8 @@ class TrackingCategory extends Remote\Model
     public static function getProperties()
     {
         return [
-            'EmployeeGroups' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Setting\\EmployeeGroup', false, false],
-            'TimesheetCategories' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Setting\\TimesheetCategory', false, false],
+            'TrackingCategoryID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'TrackingCategoryName' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
         ];
     }
 
@@ -93,17 +93,42 @@ class TrackingCategory extends Remote\Model
     /**
      * @return string
      */
-    public function getEmployeeGroups()
+    public function getTrackingCategoryID()
     {
-        return $this->_data['EmployeeGroups'];
+        return $this->_data['TrackingCategoryID'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return TrackingCategory
+     */
+    public function setTrackingCategoryID($value)
+    {
+        $this->propertyUpdated('TrackingCategoryID', $value);
+        $this->_data['TrackingCategoryID'] = $value;
+
+        return $this;
     }
 
     /**
      * @return string
      */
-    public function getTimesheetCategories()
+    public function getTrackingCategoryName()
     {
-        return $this->_data['TimesheetCategories'];
+        return $this->_data['TrackingCategoryName'];
     }
 
+    /**
+     * @param string $value
+     *
+     * @return TrackingCategory
+     */
+    public function setTrackingCategoryName($value)
+    {
+        $this->propertyUpdated('TrackingCategoryName', $value);
+        $this->_data['TrackingCategoryName'] = $value;
+
+        return $this;
+    }
 }

--- a/src/XeroPHP/Models/PayrollAU/Setting/TimesheetCategory.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/TimesheetCategory.php
@@ -4,18 +4,18 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
-class TrackingCategory extends Remote\Model
+class TimesheetCategory extends Remote\Model
 {
     /**
-     * Employee Groups tracking category
+     * Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
      *
-     * @property EmployeeGroup employeeGroups
+     * @property string TrackingCategoryID
      */
 
     /**
-     * Timesheet Categories tracking category
+     * Name of tracking category.
      *
-     * @property TimesheetCategory timesheetCategories
+     * @property string TrackingCategoryName
      */
 
     /**
@@ -39,12 +39,13 @@ class TrackingCategory extends Remote\Model
     }
 
     /**
-     * Get the guid property. This model doesn't have one.
+     * Get the guid property.
      *
      * @return string
      */
-    public static function getGUIDProperty() {
-        return '';
+    public static function getGUIDProperty()
+    {
+        return 'TrackingCategoryID';
     }
 
     /**
@@ -63,7 +64,6 @@ class TrackingCategory extends Remote\Model
     public static function getSupportedMethods()
     {
         return [
-            Remote\Request::METHOD_GET
         ];
     }
 
@@ -80,8 +80,8 @@ class TrackingCategory extends Remote\Model
     public static function getProperties()
     {
         return [
-            'EmployeeGroups' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Setting\\EmployeeGroup', false, false],
-            'TimesheetCategories' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Setting\\TimesheetCategory', false, false],
+            'TrackingCategoryID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'TrackingCategoryName' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
         ];
     }
 
@@ -93,17 +93,42 @@ class TrackingCategory extends Remote\Model
     /**
      * @return string
      */
-    public function getEmployeeGroups()
+    public function getTrackingCategoryID()
     {
-        return $this->_data['EmployeeGroups'];
+        return $this->_data['TrackingCategoryID'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return TrackingCategory
+     */
+    public function setTrackingCategoryID($value)
+    {
+        $this->propertyUpdated('TrackingCategoryID', $value);
+        $this->_data['TrackingCategoryID'] = $value;
+
+        return $this;
     }
 
     /**
      * @return string
      */
-    public function getTimesheetCategories()
+    public function getTrackingCategoryName()
     {
-        return $this->_data['TimesheetCategories'];
+        return $this->_data['TrackingCategoryName'];
     }
 
+    /**
+     * @param string $value
+     *
+     * @return TrackingCategory
+     */
+    public function setTrackingCategoryName($value)
+    {
+        $this->propertyUpdated('TrackingCategoryName', $value);
+        $this->_data['TrackingCategoryName'] = $value;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The documentation was not very helpful for getting TrackingCategories from the Payroll AU \ Settings. This commit fixes that and enables you to get the EmployeeGroups tracking category setting and the TimesheetCategories setting.