### PR TITLE
Initialise model $_data array to null

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -76,6 +76,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         $this->_dirty = [];
         $this->_data = [];
         $this->_associated_objects = [];
+        $this->fromStringArray([]);
     }
 
     /**


### PR DESCRIPTION
When creating and retrieving models eg PayrollAU\Employee various properties may not be set, resulting in undefined index errors when calling getters.
Eg PayrollAU\Employee::getBankAccounts() will throw an undefined index error if $_data['BankAccounts'] is not set:

```
/**
 * @return BankAccount[]|Remote\Collection
 */
 public function getBankAccounts()
 {
     return $this->_data['BankAccounts'];
 }
```
Rather than modifying multiple models to check that the property is set before returning, this pull request ensures all available properties are initialised to null upon model creation.