### PR TITLE
Update Response.php

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -324,6 +324,7 @@ class Response
                 case 'Payslip':
                 case 'PayItems':
                 case 'Settings':
+                case 'Timesheet':
                     // some xero endpoints are 1D so we can parse them straight away
                     $this->elements[] = Helpers::XMLToArray($root_child);
 


### PR DESCRIPTION
When retrieving a timesheet by GUID, the elements are not parsed correctly, as shown in the following image. The top is using loadByGuid, the bottom $xero->load(Timesheet::class)->where(TimesheetId=GUID(xxxx))->execute()

![image](https://user-images.githubusercontent.com/13272508/103716467-3fd00780-5017-11eb-8939-02f738500e56.png)

Adding Timesheet to the 1D endpoints fixes this issue, near as I can tell