### PR TITLE
Implement Query->addWhere() Date support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Search for objects meeting certain criteria
 $xero->load(Invoice::class)
     ->where('Status', Invoice::INVOICE_STATUS_AUTHORISED)
     ->where('Type', Invoice::INVOICE_TYPE_ACCREC)
-    ->where('Date'), 'DateTime(2020,11,25)'
+    ->where('Date', 'DateTime(2020,11,25)')
     ->execute();
 
 $xero->load(Invoice::class)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $xero->load(Invoice::class)
 
 $xero->load(Invoice::class)
     ->where('Date >= DateTime(2020,11,25)')
-    ->where('Date <= DateTime(2020,12,25)')
+    ->where('Date < DateTime(2020,12,25)')
     ->execute();
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Search for objects meeting certain criteria
 $xero->load(Invoice::class)
     ->where('Status', Invoice::INVOICE_STATUS_AUTHORISED)
     ->where('Type', Invoice::INVOICE_TYPE_ACCREC)
+    ->where('Date'), 'DateTime(2020,11,25)'
+    ->execute();
+
+$xero->load(Invoice::class)
+    ->where('Date >= DateTime(2020,11,25)')
+    ->where('Date <= DateTime(2020,12,25)')
     ->execute();
 ```
 

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -123,6 +123,8 @@ class Query
                 )
             ) {
                 $this->where[] = sprintf('%s=Guid("%s")', $args[0], $args[1]);
+            } elseif (preg_match('/^DateTime\(.+\)$/', $args[1])) {
+                $this->where[] = sprintf('%s==%s', $args[0], $args[1]);
             } else {
                 $this->where[] = sprintf('%s=="%s"', $args[0], $args[1]);
             }

--- a/tests/Remote/QueryTest.php
+++ b/tests/Remote/QueryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace XeroPHP\Tests\Remote;
+
+use XeroPHP\Application;
+use XeroPHP\Remote\Query;
+
+class QueryTest extends \PHPUnit_Framework_TestCase
+{
+
+   function testWhere() {
+
+      $xero_app = $this->getApplication();
+
+      // Where: DateTime(yyyy,mm,dd)
+      $query = new Query($xero_app);
+      $query->where('SomeDateKey', 'DateTime(2020,11,25)');
+      $where = $query->getWhere();
+      $this->assertSame("SomeDateKey==DateTime(2020,11,25)", $where, "DateTime function in where string should not have surrounding quotes (as per xero api documentation v2.0)");
+
+      // Where: single parameter
+      $query = new Query($xero_app);
+      $single_param = 'SomeDateKey>=DateTime(2020,11,25)';
+      $query->where($single_param);
+      $where = $query->getWhere();
+      $this->assertSame($single_param, $where, "Single parameter should be unchanged in where string");
+
+      // Where: integer
+      $query = new Query($xero_app);
+      $query->where('SomeKey', 3);
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey==3", $where, "Integer in where string should not have surrounding quotes");
+
+      // Where: float
+      $query = new Query($xero_app);
+      $query->where('SomeKey', 3.7);
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey==3.7", $where, "Float in where string should not have surrounding quotes");
+
+      // Where: string
+      $query = new Query($xero_app);
+      $query->where('SomeKey', 'any string value');
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey==\"any string value\"", $where, "String in where string should have surrounding quotes");
+
+      // Where: string contains integer
+      $query = new Query($xero_app);
+      $query->where('SomeKey', '3');
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey==\"3\"", $where, "Integer passed as string, so should have surrounding quotes");
+
+      // Where: guid with key ending in ID
+      $query = new Query($xero_app);
+      $guid = "44aa0707-f718-4f1c-8d53-f2da9ca59533";
+      $query->where('KeyEndingWithID', $guid);
+      $where = $query->getWhere();
+      $this->assertSame("KeyEndingWithID=Guid(\"$guid\")", $where, "Key ends in ID, with guid as string, should have guid format in where string");
+
+      // Where: guid with key not ending in ID
+      $query = new Query($xero_app);
+      $guid = "44aa0707-f718-4f1c-8d53-f2da9ca59533";
+      $query->where('SomeKey', $guid);
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey==\"$guid\"", $where, "key does not end in ID, with guid should be formatted as a string in where string");
+
+      // Where: key ends in ID with non-guid value
+      $query = new Query($xero_app);
+      $not_a_guid = "Some-AlphaNu-meric-value9876";
+      $query->where('KeyEndingWithID', $not_a_guid);
+      $where = $query->getWhere();
+      $this->assertSame("KeyEndingWithID==\"$not_a_guid\"", $where, "Value is not a guid so should be formatted as a string in where string");
+
+      // Where: "true"
+      $query = new Query($xero_app);
+      $query->where('SomeKey', "true");
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey=true", $where, "'true' passed as string should have no quotes in where string");
+
+      // Where: true (bool)
+      $query = new Query($xero_app);
+      $query->where('SomeKey', true);
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey=true", $where, "true passed as bool should have no quotes in where string");
+
+      // Where: "false"
+      $query = new Query($xero_app);
+      $query->where('SomeKey', "false");
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey=false", $where, "'false' passed as string should have no quotes in where string");
+
+      // Where: false (bool)
+      $query = new Query($xero_app);
+      $query->where('SomeKey', false);
+      $where = $query->getWhere();
+      $this->assertSame("SomeKey=false", $where, "false passed as bool should have no quotes in where string");
+
+   }
+
+   function testAndWhere() {
+
+      $xero_app = $this->getApplication();
+      $query = new Query($xero_app);
+      $param_1 = 'SomeDateKey >= DateTime(2020,11,25)';
+      $param_2 = 'SomeDateKey < DateTime(2020,12,25)';
+      $query->where($param_1);
+      $query->andWhere($param_2);
+
+      $where = $query->getWhere();
+      $this->assertSame("$param_1 AND $param_2", $where, "Where conditions should be linked by 'AND'");
+
+   }
+
+   protected function getApplication($config = [])
+   {
+      $xero_app = new Application('token', 'tenantId');
+      $xero_app->setConfig($config);
+
+      return $xero_app;
+   }
+
+}

--- a/tests/Remote/QueryTest.php
+++ b/tests/Remote/QueryTest.php
@@ -47,28 +47,28 @@ class QueryTest extends \PHPUnit_Framework_TestCase
       $query = new Query($xero_app);
       $query->where('SomeKey', '3');
       $where = $query->getWhere();
-      $this->assertSame("SomeKey==\"3\"", $where, "Integer passed as string, so should have surrounding quotes");
+      $this->assertSame("SomeKey==\"3\"", $where, "Integer passed as string should have surrounding quotes");
 
       // Where: guid with key ending in ID
       $query = new Query($xero_app);
       $guid = "44aa0707-f718-4f1c-8d53-f2da9ca59533";
       $query->where('KeyEndingWithID', $guid);
       $where = $query->getWhere();
-      $this->assertSame("KeyEndingWithID=Guid(\"$guid\")", $where, "Key ends in ID, with guid as string, should have guid format in where string");
+      $this->assertSame("KeyEndingWithID=Guid(\"$guid\")", $where, "Key ends in ID and value is guid string, should have guid format in where string");
 
       // Where: guid with key not ending in ID
       $query = new Query($xero_app);
       $guid = "44aa0707-f718-4f1c-8d53-f2da9ca59533";
       $query->where('SomeKey', $guid);
       $where = $query->getWhere();
-      $this->assertSame("SomeKey==\"$guid\"", $where, "key does not end in ID, with guid should be formatted as a string in where string");
+      $this->assertSame("SomeKey==\"$guid\"", $where, "key does not end in ID and value is guid string, should be formatted as a string in where string");
 
       // Where: key ends in ID with non-guid value
       $query = new Query($xero_app);
       $not_a_guid = "Some-AlphaNu-meric-value9876";
       $query->where('KeyEndingWithID', $not_a_guid);
       $where = $query->getWhere();
-      $this->assertSame("KeyEndingWithID==\"$not_a_guid\"", $where, "Value is not a guid so should be formatted as a string in where string");
+      $this->assertSame("KeyEndingWithID==\"$not_a_guid\"", $where, "Key ends in ID but value is not a guid, should be formatted as a string in where string");
 
       // Where: "true"
       $query = new Query($xero_app);


### PR DESCRIPTION
Update Remote Query->addWhere()
Add PhpUnit Test for Query->where()
Update Readme to give date filtering example

--------------------------

'Date' is an optimised filtering parameter for several Xero Accounting models (e.g. [Invoices](https://developer.xero.com/documentation/api/invoices#optimised-parameters)), but

`$xero->load(Invoice::class)->where('Date', 'DateTime(2020,11,25)') `

fails with a Fatal Error:

`Fatal Error: Uncaught XeroPHP\Remote\Exception\BadRequestException: Operator '==' incompatible with operand types 'DateTime?' and 'String' ()`

This pull request updates the Remote Query addWhere function to recognise 'DateTime(...)' as a second parameter, and format it without enclosing quotes.

The addWhere function already has special cases to handle ints, floats, boolean values, and guids, so this is a two line change following the same format.

It also adds a unit test and updates the readme to give valid Date filtering examples.

**Additional Information**

Query has three date related functions: date(DateTime dt), fromDate(DateTime dt), toDate(DateTime dt)

These add parameters directly to the rest query url, rather than into the where clause of the url.
These parameters are not used in the 2.0 api for the Accounting Models that I have used. Invoice and Contact queries use date parameters within their where filters.
