### PR TITLE
Adding default_content_type config value

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -16,6 +16,7 @@ class Application
     protected static $_config_defaults = [
         'xero' => [
             'base_url' => 'https://api.xero.com/',
+            'default_content_type' => Request::CONTENT_TYPE_XML,
 
             'core_version' => '2.0',
             'payroll_version' => '1.0',

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -79,7 +79,7 @@ class Request
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
-        $this->setHeader(self::HEADER_ACCEPT, self::CONTENT_TYPE_XML);
+        $this->setHeader(self::HEADER_ACCEPT, $app->getConfig('default_content_type'));
 
         $xero_config = $this->app->getConfig('xero');
         if (isset($xero_config['unitdp'])) {


### PR DESCRIPTION
This PR adds a new item to `$_config_defaults`, to allow users of the library to override the default content type (`text/xml`) used for `Accept` header on HTTP requests.

This might seem like an odd request because the library handles parsing of responses, but until recently the Xero API returned JSON for many calls even when sending requests with `Accept: text/xml` meaning that where we previously consumed JSON we're now consuming XML.