### PR TITLE
Fix use of config array when accessing default_content_type value

### DIFF
--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -79,7 +79,7 @@ class Request
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
-        $this->setHeader(self::HEADER_ACCEPT, $app->getConfig('default_content_type'));
+        $this->setHeader(self::HEADER_ACCEPT, $app->getConfigOption('xero', 'default_content_type'));
 
         $xero_config = $this->app->getConfig('xero');
         if (isset($xero_config['unitdp'])) {


### PR DESCRIPTION
This PR fixes a bug introduced in #808 where the Application config was accessed incorrectly.