### PR TITLE
Removes PUT from supported methods TaxRate

### DIFF
--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -131,7 +131,6 @@ class TaxRate extends Remote\Model
     {
         return [
             Remote\Request::METHOD_GET,
-            Remote\Request::METHOD_PUT,
             Remote\Request::METHOD_POST,
         ];
     }


### PR DESCRIPTION
Removes PUT method from supported methods TaxRate because TaxRates in Xero must use POST for update and can also be created using POST. If PUT is supported then TaxRate cannot be updated since it has no GUID.