### PR TITLE
Add "Details" for Payment when used as a BatchPayment

### DIFF
--- a/src/XeroPHP/Models/Accounting/Payment.php
+++ b/src/XeroPHP/Models/Accounting/Payment.php
@@ -54,6 +54,12 @@ class Payment extends Remote\Model
      *
      * @property string Reference
      */
+    
+    /**
+     * An optional description for the payment used only when Payment is a child of BatchPayment.
+     *
+     * @property string Details
+     */
 
     /**
      * An optional parameter for the payment. A boolean indicating whether you would like the payment to be
@@ -187,6 +193,7 @@ class Payment extends Remote\Model
             'CurrencyRate' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Reference' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'Details' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'IsReconciled' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Status' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'PaymentType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
@@ -389,6 +396,27 @@ class Payment extends Remote\Model
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getDetails()
+    {
+        return $this->_data['Details'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return Payment
+     */
+    public function setDetails($value)
+    {
+        $this->propertyUpdated('Details', $value);
+        $this->_data['Details'] = $value;
+
+        return $this;
+    }
+    
     /**
      * @return string
      */

--- a/src/XeroPHP/Models/Accounting/Payment.php
+++ b/src/XeroPHP/Models/Accounting/Payment.php
@@ -56,7 +56,7 @@ class Payment extends Remote\Model
      */
     
     /**
-     * An optional description for the payment used only when Payment is a child of BatchPayment.
+     * An optional description to appear on a payee bank statement when Payment is a child of BatchPayment.
      *
      * @property string Details
      */


### PR DESCRIPTION
For consideration, 

Batch payment files are created with a user defined "Details" text where the Xero user can enter a message to transmit with payment for display on the recipients bank statement.

![image](https://user-images.githubusercontent.com/7894754/125806565-78a75fa2-0322-4072-b891-0d56e7d260c7.png)


https://developer.xero.com/documentation/api/accounting/batchpayments#get-batchpayments

![image](https://user-images.githubusercontent.com/7894754/125806389-260a8bbe-e9ee-4b47-bfef-48284382543c.png)

