### PR TITLE
Rename setter method for BankAccountDetails

### DIFF
--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -565,16 +565,28 @@ class Contact extends Remote\Model
     {
         return $this->_data['BankAccountDetails'];
     }
-
+    
     /**
      * @param string $value
      *
      * @return Contact
      */
-    public function setBankAccountDetail($value)
+    public function setBankAccountDetails($value)
     {
         $this->propertyUpdated('BankAccountDetails', $value);
         $this->_data['BankAccountDetails'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @deprecated Use setBankAccountDetails
+     * @return Contact
+     */
+    public function setBankAccountDetail($value)
+    {
+        $this->setBankAccountDetails($value);
 
         return $this;
     }


### PR DESCRIPTION
Fix for pluralisation issue.
Setter method setBankAccountDetail doesn't match the parameter name [BankAccountDetails] and is inconsistent with the getter method getBankAccountDetail**s**
Deprecate setBankAccountDetail and add setBankAccountDetails
