### PR TITLE
Added termination-reason property to employee modal

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -170,6 +170,12 @@ class Employee extends Remote\Model
      */
 
     /**
+     * Employee Termination Reason
+     *
+     * @property string TerminationReason
+     */
+
+    /**
      * Xero unique identifier for an Employee.
      *
      * @property string EmployeeID
@@ -296,6 +302,7 @@ class Employee extends Remote\Model
             'LeaveBalances' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\LeaveBalance', true, false],
             'SuperMemberships' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\SuperMembership', true, false],
             'TerminationDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
+            'TerminationReason' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'EmployeeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'Status' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'UpdatedDateUTC' => [false, self::PROPERTY_TYPE_TIMESTAMP, '\\DateTimeInterface', false, false],
@@ -845,6 +852,27 @@ class Employee extends Remote\Model
     {
         $this->propertyUpdated('TerminationDate', $value);
         $this->_data['TerminationDate'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTerminationReason()
+    {
+        return $this->_data['TerminationReason'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return Employee
+     */
+    public function setTerminationReason($value)
+    {
+        $this->propertyUpdated('TerminationReason', $value);
+        $this->_data['TerminationReason'] = $value;
 
         return $this;
     }


### PR DESCRIPTION
Adds in a 'TerminationReason' property required by Xero since June this year for employees which are marked as TERMINATED.
Refers to issue #822 

it's part of the Australian Taxation Office's push for Single Touch Payroll;
https://developer.xero.com/documentation/api/payrollau/stp-changes