### PR TITLE
Initialise all properties when a new model is constructed

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -76,6 +76,14 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         $this->_dirty = [];
         $this->_data = [];
         $this->_associated_objects = [];
+
+        foreach (static::getProperties() as $property => $meta) {
+            if ($meta[self::KEY_IS_ARRAY]) {
+                $this->_data[$property] = new Collection();
+            } else {
+                $this->_data[$property] = null;
+            }
+        }
     }
 
     /**

--- a/tests/Remote/Model/ModelWithCollection.php
+++ b/tests/Remote/Model/ModelWithCollection.php
@@ -47,11 +47,11 @@ class ModelWithCollection extends Model
 
     public function getEarningsLines()
     {
-        return isset($this->_data['EarningsLines']) ? $this->_data['EarningsLines'] : null;
+        return $this->_data['EarningsLines'];
     }
 
     public function getModelID()
     {
-        return isset($this->_data['ModelID']) ? $this->_data['ModelID'] : null;
+        return $this->_data['ModelID'];
     }
 }

--- a/tests/Remote/ModelTest.php
+++ b/tests/Remote/ModelTest.php
@@ -5,9 +5,9 @@ namespace XeroPHP\Tests\Remote;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response;
 use XeroPHP\Application;
+use XeroPHP\Remote\Collection;
 use XeroPHP\Remote\Model;
 use XeroPHP\Tests\Remote\Model\ModelWithCollection;
 
@@ -64,7 +64,8 @@ class ModelTest extends \PHPUnit_Framework_TestCase
 
         $model = $app->loadByGUID(ModelWithCollection::class, 'test');
         $this->assertSame('test', $model->getModelID());
-        $this->assertNull($model->getEarningsLines());
+        $this->assertInstanceOf(Collection::class, $model->getEarningsLines());
+        $this->assertEquals(0, count($model->getEarningsLines()));
     }
 }
 
@@ -77,7 +78,9 @@ class SimpleModel extends Model
 
     public static function getProperties()
     {
-        return ['test'];
+        return [
+            'test' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+        ];
     }
 
     public static function getSupportedMethods()
@@ -105,7 +108,7 @@ class SimpleModel extends Model
      */
     public function getTest()
     {
-        return isset($this->_data['test']) ? $this->_data['test'] : null;
+        return $this->_data['test'];
     }
 
     /**


### PR DESCRIPTION
Set collection properties to an empty collection, other properties to null.
Prevents an ‘Undefined index’ notice when calling getters.

I've addressed this via the constructor of the base model class, so it doesn't matter if some of the getters already check for  `isset` and others don't. Let me know if you think this approach will do the job, or if it will create other issues.

Resolves #652