### PR TITLE
Add the reference date to the model properties and the getMethod

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
+++ b/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
@@ -123,7 +123,8 @@ class PayrollCalendar extends Remote\Model
             'CalendarType' => [true, self::PROPERTY_TYPE_ENUM, null, false, false],
             'StartDate' => [true, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
             'PaymentDate' => [true, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
-            'UpdatedDateUTC' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false]
+            'UpdatedDateUTC' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false],
+            'ReferenceDate' => [false, self::PROPERTY_TYPE_DATE, '\\DateTimeInterface', false, false]
         ];
     }
 
@@ -243,5 +244,13 @@ class PayrollCalendar extends Remote\Model
     public function getUpdatedDateUTC()
     {
         return $this->_data['UpdatedDateUTC'];
+    }
+    
+    /**
+     * return \DateTimeInterface
+     */
+    public function getReferenceDate()
+    {
+        return $this->_data['ReferenceDate'];
     }
 }


### PR DESCRIPTION
The package is missing the reference field from the docs. I have added to the payroll and can confirm this works
https://developer.xero.com/documentation/api/payrollau/payrollcalendars/#get-payrollcalendars

```json
[
  {
    "Name": "Fortnightly",
    "StartDate": "2021-09-01",
    "PaymentDate": "2021-09-06",
    "CalendarType": "FORTNIGHTLY",
    "ReferenceDate": "2021-09-01",
    "UpdatedDateUTC": "2021-09-30",
    "PayrollCalendarID": "05682961-e905-47fc-b3be-e9c2b698388e"
  },
  {
    "Name": "Weekly",
    "StartDate": "2021-09-08",
    "PaymentDate": "2021-09-13",
    "CalendarType": "WEEKLY",
    "ReferenceDate": "2021-09-01",
    "UpdatedDateUTC": "2021-10-06",
    "PayrollCalendarID": "7a316b34-c1d9-40a7-bae0-10fcde430171"
  }
]
```

The ReferenceDate field is now returned