### PR TITLE
add AttachmentTrait to Quote Model

### DIFF
--- a/src/XeroPHP/Models/Accounting/Quote.php
+++ b/src/XeroPHP/Models/Accounting/Quote.php
@@ -3,6 +3,7 @@
 namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
+use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Traits\PDFTrait;
 use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Models\Accounting\LineItem;
@@ -10,6 +11,7 @@ use XeroPHP\Models\Accounting\LineItem;
 class Quote extends Remote\Model
 {
     use PDFTrait;
+    use AttachmentTrait;
     use HistoryTrait;
 
     /**


### PR DESCRIPTION
Hi, @calcinai 
I have added AttachmentTrait for adding attachments to Quotes in Xero because this feature is supported in API and not in your SDK.