### PR TITLE
Fix Pay Template items with invalid is-array setting

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
@@ -100,7 +100,7 @@ class DeductionLine extends Remote\Model
             'DeductionTypeID' => [false, self::PROPERTY_TYPE_GUID, null, false, false],
             'CalculationType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'Percentage' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, true, false],
+            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
         ];
     }
 

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
@@ -88,7 +88,7 @@ class ReimbursementLine extends Remote\Model
         return [
             'ReimbursementTypeID' => [false, self::PROPERTY_TYPE_GUID, null, false, false],
             'Description' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
-            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, true, false],
+            'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
         ];
     }
 


### PR DESCRIPTION
Amount was listed as Is an Array, when it's supposed to be a simple float.

### To test
```
        $app = new \XeroPHP\Application('123', '123');
        $line = [
            'DeductionTypeID' => 1,
            'CalculationType' => 'FIXEDAMOUNT',
            'Amount' => 100
        ];

        $model = new \XeroPHP\Models\PayrollAU\Employee\PayTemplate\DeductionLine($app);
        $model->fromStringArray($line);
```

Before this change, $model->_data['Amount'] would be null. After this change, the ['Amount'] will be 100 as expected