### PR TITLE
Update EarningsRate.php

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -188,7 +188,7 @@ class EarningsRate extends Remote\Model
             'RateType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'RatePerUnit' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'Multiplier' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
-            'AccrueLeave' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
+            'AccrueLeave' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'Amount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'CurrentRecord' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'AllowanceType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false]


### PR DESCRIPTION
Fix invalid property type definition for EarningsRate => AccrueLeave

Currently, if an EarningRate has AccrueLeave checked then data is hydrated like this
```
        "Name" => "24 hour care - payment per shift"
        // Other stuff
        "AccrueLeave" => 0.0
      ]
```
instead of true.