### PR TITLE
Update Model.php

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -77,6 +77,11 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         $this->_data = [];
         $this->_associated_objects = [];
     }
+    
+    public static function make(Application $application = null)
+    {
+        return new static($application);
+    }
 
     /**
      * This should be compulsory in the constructor in the future,


### PR DESCRIPTION
Add a static constructor so can more cleanly chain after instantiation, like this

`$rate = EarningsRate::make($application)->setEarningsType(...)->someOtherThing(...);`

Remove the `EARNINGTYPE_FIXED` rate because it's definitely not valid in Xero anymore. If you don't think that's the right call let me know.