### PR TITLE
Add in the PUT type to create new TaxRates

### DIFF
--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -132,6 +132,7 @@ class TaxRate extends Remote\Model
         return [
             Remote\Request::METHOD_GET,
             Remote\Request::METHOD_POST,
+            Remote\Request::METHOD_PUT,
         ];
     }
 


### PR DESCRIPTION
Was not able to create new tax types (although this used to work sometime ago) Added in the PUT type as per the documentation and now my original code works again.

API link here. https://developer.xero.com/documentation/api/accounting/taxrates