### PR TITLE
fix: parsing warnings in root response

### DIFF
--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -290,6 +290,8 @@ class Response
                         }
                     }
 
+                    unset($this->elements[$element_index]);
+
                     break;
 
                 default:
@@ -329,7 +331,15 @@ class Response
                     $this->elements[] = Helpers::XMLToArray($root_child);
 
                     break;
+                case 'Warnings':
+                    $warnings = [];
+                    foreach ($root_child->children() as $element_index => $element) {
+                        $warnings[] = Helpers::XMLToArray($element);
+                    }
 
+                    $this->elements[] = ['Warnings' => $warnings];
+
+                    break;
                 default:
                     //Happy to make the assumption that there will only be one
                     //root node with > than 2D children.
@@ -364,7 +374,15 @@ class Response
                     $this->elements[] = $root_child;
 
                     break;
+                case 'Warnings':
+                    $warnings = [];
+                    foreach ($root_child->children() as $element) {
+                        $warnings[] = $element;
+                    }
 
+                    $this->elements[] = ['Warnings' => $warnings];
+
+                    break;
                 default:
                     //Happy to make the assumption that there will only be one
                     //root node with > than 2D children.


### PR DESCRIPTION
Hello, we've come across a bug in XML parsing when receiving `Warnings` in the root of the XML response on e.g. `Invoices`. Supposedly this issue is related to the recent addition of https://developer.xero.com/documentation/api/efficient-data-retrieval checks in Xero's API.

I believe the handling of the warnings was not working properly. The warnings element was parsed as one of the elements which resulted in storing it in the `elements` array and was then returned to us as a member of the response elements as one of the invoices. But all the element values were null, this caused an error as based on type definitions the model does not allow null on either of the elements of an Invoice model.

I included the improved parsing in the JSON part as well, but I have not tested this behaviour with the API, but believe it will be the same.