### PR TITLE
Add RequiredFieldException for better handling of missing field errors

### DIFF
--- a/src/XeroPHP/Remote/Exception/RequiredFieldException.php
+++ b/src/XeroPHP/Remote/Exception/RequiredFieldException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace XeroPHP\Remote\Exception;
+
+use Throwable;
+use XeroPHP\Remote\Exception;
+
+class RequiredFieldException extends Exception
+{
+    protected $class;
+    protected $field;
+
+    public function __construct($class, $field, $message = "", $code = 0, Throwable $previous = null)
+    {
+        $this->class = $class;
+        $this->field = $field;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    public function getField()
+    {
+        return $this->field;
+    }
+}

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -4,6 +4,7 @@ namespace XeroPHP\Remote;
 
 use XeroPHP\Helpers;
 use XeroPHP\Application;
+use XeroPHP\Remote\Exception\RequiredFieldException;
 
 /**
  * Class Model.
@@ -395,10 +396,13 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
             //If it's got a GUID, it's already going to be valid almost all cases
             if (! $this->hasGUID() && $mandatory) {
                 if (! isset($this->_data[$property]) || empty($this->_data[$property])) {
-                    throw new Exception(
+                    $class = get_class($this);
+                    throw new RequiredFieldException(
+                        $class,
+                        $property,
                         sprintf(
                             '%s::$%s is mandatory and is either missing or empty.',
-                            get_class($this),
+                            $class,
                             $property
                         )
                     );

--- a/src/XeroPHP/Webhook/Event.php
+++ b/src/XeroPHP/Webhook/Event.php
@@ -2,6 +2,7 @@
 
 namespace XeroPHP\Webhook;
 
+use XeroPHP\Remote\Exception\RequiredFieldException;
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
 
@@ -73,7 +74,11 @@ class Event
 
         foreach ($fields as $required) {
             if (!isset($event[$required])) {
-                throw new \XeroPHP\Exception("The event payload was malformed; missing required field {$required}");
+                throw new RequiredFieldException(
+                    get_class($this), 
+                    $required, 
+                    "The event payload was malformed; missing required field {$required}"
+                );
             }
 
             $this->{$required} = $event[$required];


### PR DESCRIPTION
Adds an exception to allow for easier handling of missing field errors. Exposing the class & field on the exception lets users build their own error messages, which in turn allows for more human error messages to end users.

While it is currently possible to achieve this with string manipulation on the existing messages, having a distinct exception allows for much greater flexibility: 
```php
private const XERO_MISSING_FIELD_TO_HUMAN = [
  Invoice::class => [ 
   '$Contact' => 'Xero Contact',
   '$LineItems' => 'Line Items',
   ...
  ],
  ...
];

...
try {
   $this->uploadInvoice($data);
} catch (RequiredFieldException $e) {
   $human_field = self::XERO_MISSING_FIELD_TO_HUMAN[$e->getClass()][$e->getField()] ?? 'Unknown Field';
   $message = sprintf('%s is a required field, can not upload invoice.', $human_field);
   $this->setUserFlash($message);
} catch (BadRequestException $e) {
   ...
}
```