### PR TITLE
Feed back API rate limits requests to the application. Demonstrate how to handle rate limit exceptions with Guzzle Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,13 @@ You can provide a more graceful method of dealing with HTTP 429 responses by usi
 
 ```php
 
+// use GuzzleHttp\Client;
+// use GuzzleHttp\HandlerStack;
+// use GuzzleHttp\Middleware;
+// use GuzzleHttp\RetryMiddleware;
+// use Psr\Http\Message\RequestInterface;
+// use Psr\Http\Message\ResponseInterface;
+
 public function yourApplicationCreationMethod($accessToken, $tenantId): Application {
 
    // By default the contructor creates a Guzzle Client without any handlers. Pass a third argument 'false' to skip the general client constructor.

--- a/README.md
+++ b/README.md
@@ -337,8 +337,8 @@ For this you need to replace the transport client created when instantiating the
 
 public function yourApplicationCreationMethod($accessToken, tenantId): Application {
 
-   // The contructor creates a Guzzle Client without any handlers.
-   $xero = new Application($accessToken, $tenantId);
+   // By default the contructor creates a Guzzle Client without any handlers. Pass a third argument false to skip that general client constructor.
+   $xero = new Application($accessToken, $tenantId, false);
 
    // Create a new handler stack
    $stack = HandlerStack::create();

--- a/README.md
+++ b/README.md
@@ -318,10 +318,10 @@ These values can be used to decide if additional requests will throttled or sent
     $myExpectedApiCalls = 50;
 
     // Before executing a statement, you could check the the rate limits.
-    $apiCallsRemaining = $xero->getAppRateLimits();
+    $tenantDailyLimitRemaining = $xero->getTenantDayLimitRemining();
 
     // If the expected number of API calls is higher than the number remaining for the tenant then do something.
-    if($myExpectedApiCalls > $apiCallsRemaining['tenant-day-limit-remaining']){
+    if($myExpectedApiCalls > tenantDailyLimitRemaining){
        // Send the calls to a queue for processing at another time
        // Or throttle the calls to suit your needs.
     }

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ You can provide a more graceful method of dealing with HTTP 429 responses by usi
 
 ```php
 
-public function yourApplicationCreationMethod($accessToken, tenantId): Application {
+public function yourApplicationCreationMethod($accessToken, $tenantId): Application {
 
    // By default the contructor creates a Guzzle Client without any handlers. Pass a third argument 'false' to skip the general client constructor.
    $xero = new Application($accessToken, $tenantId, false);
@@ -365,36 +365,36 @@ public function yourApplicationCreationMethod($accessToken, tenantId): Applicati
  * Customise the RetryMiddeware to suit your needs. Perhaps creating log messages, or making decisions about when to retry or not.
  */
 protected function getRetryMiddleware(int $maxRetries): callable
-    {
-        $decider = function (
-            int $retries,
-            RequestInterface $request,
-            ResponseInterface $response = null
-        ) use (
-            $maxRetries
-        ): bool {
-            return
-                $retries < $maxRetries
-                && null !== $response
-                && \XeroPHP\Remote\Response::STATUS_TOO_MANY_REQUESTS === $response->getStatusCode();
-        };
+{
+    $decider = function (
+        int $retries,
+        RequestInterface $request,
+        ResponseInterface $response = null
+    ) use (
+        $maxRetries
+    ): bool {
+        return
+            $retries < $maxRetries
+            && null !== $response
+            && \XeroPHP\Remote\Response::STATUS_TOO_MANY_REQUESTS === $response->getStatusCode();
+    };
 
-        $delay = function (int $retries, ResponseInterface $response): int {
-            if (!$response->hasHeader('Retry-After')) {
-                return RetryMiddleware::exponentialDelay($retries);
-            }
+    $delay = function (int $retries, ResponseInterface $response): int {
+        if (!$response->hasHeader('Retry-After')) {
+            return RetryMiddleware::exponentialDelay($retries);
+        }
 
-            $retryAfter = $response->getHeaderLine('Retry-After');
+        $retryAfter = $response->getHeaderLine('Retry-After');
 
-            if (!is_numeric($retryAfter)) {
-                $retryAfter = (new \DateTime($retryAfter))->getTimestamp() - time();
-            }
+        if (!is_numeric($retryAfter)) {
+            $retryAfter = (new \DateTime($retryAfter))->getTimestamp() - time();
+        }
 
-            return (int)$retryAfter * 1000;
-        };
+        return (int)$retryAfter * 1000;
+    };
 
-        return Middleware::retry($decider, $delay);
-    }
+    return Middleware::retry($decider, $delay);
+}
 
 ```
 
@@ -409,7 +409,7 @@ This library will parse the response Xero returns and throw an exception when it
 | 403 Forbidden | `\XeroPHP\Remote\Exception\ForbiddenException` |
 | 403 ReportPermissionMissingException | `\XeroPHP\Remote\Exception\ReportPermissionMissingException` |
 | 404 Not Found | `\XeroPHP\Remote\Exception\NotFoundException` |
-| 429 Too Many Requests | `\XeroPHP\Remote\Exception\RateLimitException` |
+| 429 Too Many Requests | `\XeroPHP\Remote\Exception\RateLimitExceededException` |
 | 500 Internal Error | `\XeroPHP\Remote\Exception\InternalErrorException` |
 | 501 Not Implemented | `\XeroPHP\Remote\Exception\NotImplementedException` |
 | 503 Rate Limit Exceeded | `\XeroPHP\Remote\Exception\RateLimitExceededException` |

--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ protected function getRetryMiddleware(int $maxRetries): callable
     {
         $decider = function (
             int $retries,
-            \GuzzleHttp\Psr7\Request $request,
-            Response $response = null
+            RequestInterface $request,
+            ResponseInterface $response = null
         ) use (
             $maxRetries
         ): bool {
@@ -379,7 +379,7 @@ protected function getRetryMiddleware(int $maxRetries): callable
                 && \XeroPHP\Remote\Response::STATUS_TOO_MANY_REQUESTS === $response->getStatusCode();
         };
 
-        $delay = function (int $retries, Response $response): int {
+        $delay = function (int $retries, ResponseInterface $response): int {
             if (!$response->hasHeader('Retry-After')) {
                 return RetryMiddleware::exponentialDelay($retries);
             }

--- a/README.md
+++ b/README.md
@@ -301,43 +301,41 @@ These are just a couple of examples and you should read the official documentati
 
 ### Rate Limit Exceptions
 
-Xero returns headers indicating the number for calls remaining befpre reaching their API lmits.
+Xero returns header values indicating the number of calls remaining before reaching their API lmits.
 https://developer.xero.com/documentation/guides/oauth2/limits/
 
-The Application is updated following every request, so that you can track the number of requests remaining until hitting the Xero limit using the Application::getAppRateLimits() method. It returns an array with the following keys and associated integer values.
+The Application is updated following every request and you can track the number of requests remaining using the Application::getAppRateLimits() method. It returns an array with the following keys and associated integer values.
 
     'last-api-call' // The int timestamp of the last request made to the Xero API
-    'app-min-limit-remaining' // The number of requests remaining for the application as a whole in the current minute, limit is 10,000.
-    'tenant-day-limit-remaining' // The number of requests remaining for the individual tenant the minute, limit is 5,000.
-    'tenant-min-limit-remaining' // The number of requests remaining for the individual tenant the day, limit is 60.
+    'app-min-limit-remaining' // The number of requests remaining for the application as a whole in the current minute. The normal limit is 10,000.
+    'tenant-day-limit-remaining' // The number of requests remaining for the individual tenant by the day, limit is 5,000.
+    'tenant-min-limit-remaining' // The number of requests remaining for the individual tenant by the minute, limit is 60.
 
-This can be used to decide if additional requests will throttled or sent to some message queue. For example:
+These values can be used to decide if additional requests will throttled or sent to some message queue. For example:
 
 ``` php
     // If you know the number of API calls that you intend to make. 
     $myExpectedApiCalls = 50;
 
-    // Before executing a statement, you could call the rate limits.
+    // Before executing a statement, you could check the the rate limits.
     $apiCallsRemaining = $xero->getAppRateLimits();
 
-    // If the expected number of API calls is higher than the number remaining for the tenant.
+    // If the expected number of API calls is higher than the number remaining for the tenant then do something.
     if($myExpectedApiCalls > $apiCallsRemaining['tenant-day-limit-remaining']){
        // Send the calls to a queue for processing at another time
        // Or throttle the calls to suit your needs.
     }
 ```
 
-If the Application exceeds the rate limits, then Xero return an HTTP 429 Too Many Requests response. By default, this response is caught and thrown as a RateLimitException.
+If the Application exceeds the rate limits Xero will return an HTTP 429 Too Many Requests response. By default, this response is caught and thrown as a RateLimitException.
 
-You can provide a more graceful method of dealing with HTTP 429 responses from Xero by using GuzzleHttp\RetryMiddleware.
-
-For this you need to replace the transport client created when instantiating the Application. For example:
+You can provide a more graceful method of dealing with HTTP 429 responses by using the Guzzle RetryMiddleware. You need to replace the transport client created when instantiating the Application. For example:
 
 ```php
 
 public function yourApplicationCreationMethod($accessToken, tenantId): Application {
 
-   // By default the contructor creates a Guzzle Client without any handlers. Pass a third argument false to skip that general client constructor.
+   // By default the contructor creates a Guzzle Client without any handlers. Pass a third argument 'false' to skip the general client constructor.
    $xero = new Application($accessToken, $tenantId, false);
 
    // Create a new handler stack
@@ -346,7 +344,7 @@ public function yourApplicationCreationMethod($accessToken, tenantId): Applicati
    // Create the MiddleWare callable, in this case with a maximum limit of 5 retries.
    $stack->push($this->getRetryMiddleware(5));
 
-   // Create a new Guzzle Client.
+   // Create a new Guzzle Client
    $transport = new Client([
        'headers' => [
            'User-Agent' => sprintf(Application::USER_AGENT_STRING, Helpers::getPackageVersion()),
@@ -356,7 +354,7 @@ public function yourApplicationCreationMethod($accessToken, tenantId): Applicati
        'handler' => $stack
    ]);
 
-   // Replace the default Client from the application constructor with our new Client using the RetryMiddleware.
+   // Replace the default Client from the application constructor with our new Client using the RetryMiddleware
    $xero->setTransport($transport);
 
    return $xero
@@ -364,7 +362,7 @@ public function yourApplicationCreationMethod($accessToken, tenantId): Applicati
 }
 
 /**
- * Customise the Middeware to suit your needs. Perhaps creating log messages, or making decisions about when to retry or not.
+ * Customise the RetryMiddeware to suit your needs. Perhaps creating log messages, or making decisions about when to retry or not.
  */
 protected function getRetryMiddleware(int $maxRetries): callable
     {

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -22,6 +22,7 @@ class Application
             'payroll_version' => '1.0',
             'file_version' => '1.0',
             'practice_manager_version' => '3.0',
+            'api_limit_max_wait_seconds' => 3,
         ]
     ];
 

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -472,7 +472,6 @@ class Application
     public function updateTenantRateLimits(int $tenantDayLimitRemining, int $tenantMinLimitRemining)
     {
         $this->lastApiCall = time();
-        $this->appMinLimitRemining = $appMinLimitRemining;
         $this->tenantDayLimitRemining = $tenantDayLimitRemining;
         $this->tenantMinLimitRemining = $tenantMinLimitRemining;
         return $this;

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -17,12 +17,10 @@ class Application
         'xero' => [
             'base_url' => 'https://api.xero.com/',
             'default_content_type' => Request::CONTENT_TYPE_XML,
-
             'core_version' => '2.0',
             'payroll_version' => '1.0',
             'file_version' => '1.0',
-            'practice_manager_version' => '3.0',
-            'api_limit_max_wait_seconds' => 3,
+            'practice_manager_version' => '3.0'
         ]
     ];
 
@@ -44,21 +42,24 @@ class Application
     /**
      * @param $token
      * @param $tenantId
+     * $param $constructClient
      */
-    public function __construct($token, $tenantId)
+    public function __construct($token, $tenantId, ?bool $constructClient = true)
     {
         $this->config = static::$_config_defaults;
 
-        //Not sure if this is necessary, but it's one less thing to have to create outside the instance.
-        $transport = new Client([
-            'headers' => [
-                'User-Agent' => sprintf(static::USER_AGENT_STRING, Helpers::getPackageVersion()),
-                'Authorization' => sprintf('Bearer %s', $token),
-                'Xero-tenant-id' => $tenantId,
-            ]
-        ]);
-
-        $this->transport = $transport;
+        if($constructClient){
+            //Not sure if this is necessary, but it's one less thing to have to create outside the instance.
+            $transport = new Client([
+                'headers' => [
+                    'User-Agent' => sprintf(static::USER_AGENT_STRING, Helpers::getPackageVersion()),
+                    'Authorization' => sprintf('Bearer %s', $token),
+                    'Xero-tenant-id' => $tenantId,
+                ]
+            ]);
+    
+            $this->transport = $transport;
+        }
     }
 
 
@@ -461,7 +462,14 @@ class Application
         return $object;
     }
 
-    public function updateAppRateLimits(int $appMinLimitRemining,  int $tenantDayLimitRemining, int $tenantMinLimitRemining)
+    public function updateAppRateLimit(int $appMinLimitRemining)
+    {
+        $this->lastApiCall = time();
+        $this->appMinLimitRemining = $appMinLimitRemining;
+        return $this;
+    }
+
+    public function updateTenantRateLimits(int $tenantDayLimitRemining, int $tenantMinLimitRemining)
     {
         $this->lastApiCall = time();
         $this->appMinLimitRemining = $appMinLimitRemining;

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -31,6 +31,11 @@ class Application
      */
     protected $config;
 
+    private ?int $lastApiCall = null;
+    private ?int $appMinLimitRemining = null;
+    private ?int $tenantDayLimitRemining = null;
+    private ?int $tenantMinLimitRemining = null;
+
     /**
      * @var ClientInterface
      */
@@ -454,5 +459,24 @@ class Application
         }
 
         return $object;
+    }
+
+    public function updateAppRateLimits(int $appMinLimitRemining,  int $tenantDayLimitRemining, int $tenantMinLimitRemining)
+    {
+        $this->lastApiCall = time();
+        $this->appMinLimitRemining = $appMinLimitRemining;
+        $this->tenantDayLimitRemining = $tenantDayLimitRemining;
+        $this->tenantMinLimitRemining = $tenantMinLimitRemining;
+        return $this;
+    }
+
+    public function getAppRateLimits(): array
+    {
+        return [
+            'last-api-call' => $this->lastApiCall,
+            'app-min-limit-remaining' => $this->appMinLimitRemining,
+            'tenant-day-limit-remaining' => $this->tenantDayLimitRemining,
+            'tenant-min-limit-remaining' => $this->tenantMinLimitRemining,
+        ];
     }
 }

--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -477,13 +477,35 @@ class Application
         return $this;
     }
 
-    public function getAppRateLimits(): array
+    /**
+     * @return int|null Timestamp of last API call.
+     */
+    public function getLastApiCall(): ?int
     {
-        return [
-            'last-api-call' => $this->lastApiCall,
-            'app-min-limit-remaining' => $this->appMinLimitRemining,
-            'tenant-day-limit-remaining' => $this->tenantDayLimitRemining,
-            'tenant-min-limit-remaining' => $this->tenantMinLimitRemining,
-        ];
+        return $this->lastApiCall;
+    }
+
+    /**
+     * @return int|null Application call limit remaining across all tenants.
+     */
+    public function getAppMinLimitRemining(): ?int
+    {
+        return $this->appMinLimitRemining;
+    }
+
+    /**
+     * @return int|null Tenant daily call limit remaining
+     */
+    public function getTenantDayLimitRemining(): ?int
+    {
+        return $this->tenantDayLimitRemining;
+    }
+
+    /**
+     * @return int|null Tenant minute call limit remaining
+     */
+    public function getTenantMinLimitRemining(): ?int
+    {
+        return $this->tenantMinLimitRemining;
     }
 }

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -124,11 +124,13 @@ class Request
                 }
             }
 
-            $this->app->updateAppRateLimits(
-                $guzzleResponse->getHeader('X-AppMinLimit-Remaining')[0],
-                $guzzleResponse->getHeader('X-DayLimit-Remaining')[0],
-                $guzzleResponse->getHeader('X-MinLimit-Remaining')[0],
-            );
+            if($guzzleResponse->hasHeader('X-AppMinLimit-Remaining')){
+                $this->app->updateAppRateLimits(
+                    $guzzleResponse->getHeader('X-AppMinLimit-Remaining')[0],
+                    $guzzleResponse->getHeader('X-DayLimit-Remaining')[0],
+                    $guzzleResponse->getHeader('X-MinLimit-Remaining')[0],
+                );
+            }
         } while ($retry);
 
         $this->response = new Response($this,

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -120,6 +120,7 @@ class Request
                 }
                 if($retryAfter < (int) $configuredMaxWaitTime){
                     $retry = true;
+                    sleep($retryAfter);
                 }
             }
         } while ($retry);

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -123,6 +123,12 @@ class Request
                     sleep($retryAfter);
                 }
             }
+
+            $this->app->updateAppRateLimits(
+                $guzzleResponse->getHeader('X-AppMinLimit-Remaining')[0],
+                $guzzleResponse->getHeader('X-DayLimit-Remaining')[0],
+                $guzzleResponse->getHeader('X-MinLimit-Remaining')[0],
+            );
         } while ($retry);
 
         $this->response = new Response($this,


### PR DESCRIPTION
PR for issue #806

Pass the API Request Rate Limits back up to the Application to allow the user of the bundle to decide if they throttle api requests.

Have also added an option to throttle requests from within the bundle itself.

Set a configurable variable in the Application, which sets the maximum wait time that the application should delay if it hits an API limit. (Can be set false if no intention to retry requests)

Catch Xero 429 Response issues where the API limit has been reached.

Get the 'Retry-After' time from the Xero response header.

If the Retry-After period is less than the permitted maximum duration in the config, then sleep for the retry period, and retry the request.