### PR TITLE
Added support for MergedToContactID.

### DIFF
--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -328,6 +328,7 @@ class Contact extends Remote\Model
             'IsCustomer' => [false, self::PROPERTY_TYPE_BOOLEAN, null, false, false],
             'DefaultCurrency' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'XeroNetworkKey' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'MergedToContactID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'SalesDefaultAccountCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'PurchasesDefaultAccountCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'SalesTrackingCategories' => [false, self::PROPERTY_TYPE_OBJECT, 'Accounting\\TrackingCategory', true, false],


### PR DESCRIPTION
<b>The Scenario</b>

Whenever a contact has been merged into another, we received a webhook event of an archived contact, but no additional information. We then had to perform a GET request by its 'resourceId' to get the contact.

The 'Before the addition of MergedToContactID:' screenshot below, show the payload we received when we made the GET request, but no 'MergedToContactID' was present.

The important aspect of this PR, is ensuring we received the 'MergedToContactID' value, allowing us to update our contact data with the newly updated ContactID.

<b>Before the addition of MergedToContactID:</b>

<img width="893" alt="image" src="https://github.com/calcinai/xero-php/assets/36923701/f99cdc12-2eae-4333-a8d7-179621c374c2">

<b>After the addition of MergedToContactID:</b>

<img width="883" alt="image" src="https://github.com/calcinai/xero-php/assets/36923701/eac67a67-9a49-4969-aa5b-c4558f0cde6b">
