### PR TITLE
Add AccountId field to Invoice Line Items

### DIFF
--- a/src/XeroPHP/Models/Accounting/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/LineItem.php
@@ -49,6 +49,12 @@ class LineItem extends Remote\Model
      */
 
     /**
+     * See Accounts.
+     * 
+     * @property string AccountId
+     */
+
+    /**
      * Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see
      * TaxTypes.
      *
@@ -169,6 +175,7 @@ class LineItem extends Remote\Model
             'UnitAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'ItemCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'AccountCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
+            'AccountId' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'TaxType' => [false, self::PROPERTY_TYPE_ENUM, null, false, false],
             'TaxAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
             'LineAmount' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
@@ -285,6 +292,27 @@ class LineItem extends Remote\Model
     {
         $this->propertyUpdated('AccountCode', $value);
         $this->_data['AccountCode'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountId()
+    {
+        return $this->_data['AccountId'];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return LineItem
+     */
+    public function setAccountId($value)
+    {
+        $this->propertyUpdated('AccountId', $value);
+        $this->_data['AccountId'] = $value;
 
         return $this;
     }


### PR DESCRIPTION
As part of recent Xero API changes, `AccountId` is now a valid alternative to `AccountCode`. They've helpfully only announced this via Email, so I can't link to a good source on the extent of other changes, but you can see that the API docs have been updated to reflect this:

[Xero Invoice Line Items](https://developer.xero.com/documentation/api/accounting/invoices#creating-updating-and-deleting-line-items-when-updating-invoices)