### PR TITLE
Remove slash from base url

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -15,7 +15,7 @@ class Application
 
     protected static $_config_defaults = [
         'xero' => [
-            'base_url' => 'https://api.xero.com/',
+            'base_url' => 'https://api.xero.com',
             'default_content_type' => Request::CONTENT_TYPE_XML,
             'core_version' => '2.0',
             'payroll_version' => '1.0',


### PR DESCRIPTION
The XeroPHP\Application\URL concatenates the Application config base_url with the path.

```
    /**
     * @return string
     */
    public function getFullURL()
    {
        $url = sprintf('%s/%s', $this->base_url, $this->path);

        return$url;
    }
```

resulting in a double slash after the base url. https://api.xero.com//api.xro/2.0/Journals?paymentsOnly=true&offset=33300.

Remove the trailing forward slash from the base_url.