### PR TITLE
Fix: Handle Root Warnings and Access the Responses from Queries

### DIFF
--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -38,6 +38,9 @@ class Query
 
     private $params;
 
+    /** @var Response|null $response  */
+    private $response;
+
     public function __construct(Application $app)
     {
         $this->app = $app;
@@ -49,6 +52,7 @@ class Query
         $this->includeArchived = false;
         $this->createdByMyApp = false;
         $this->params = [];
+        $this->response = null;
     }
 
     /**
@@ -332,7 +336,8 @@ class Query
         $request->send();
 
         $elements = new Collection();
-        foreach ($request->getResponse()->getElements() as $element) {
+        $this->response = $request->getResponse();
+        foreach ($this->response->getElements() as $element) {
             /**
              * @var Model
              */
@@ -360,5 +365,13 @@ class Query
     public function getFrom()
     {
         return $this->from_class;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -72,6 +72,8 @@ class Response
 
     private $root_error;
 
+    private $root_warnings;
+
     public function __construct(Request $request, $response_body, $status, $headers)
     {
         $this->request = $request;
@@ -222,6 +224,11 @@ class Response
         return $this->root_error;
     }
 
+    public function getRootWarnings()
+    {
+        return $this->root_warnings;
+    }
+
     public function getOAuthResponse()
     {
         return $this->oauth_response;
@@ -233,6 +240,7 @@ class Response
         $this->element_errors = [];
         $this->element_warnings = [];
         $this->root_error = [];
+        $this->root_warnings = [];
 
         if (!isset($this->headers[Request::HEADER_CONTENT_TYPE])) {
             //Nothing to parse
@@ -321,6 +329,13 @@ class Response
                     $this->root_error['message'] = (string)$root_child;
 
                     break;
+                case 'Warnings':
+                    $this->root_warnings = [];
+                    foreach ($root_child->children() as $element_index => $element) {
+                        $this->root_warnings[] = Helpers::XMLToArray($element);
+                    }
+
+                    break;
                 case 'Payslip':
                 case 'PayItems':
                 case 'Settings':
@@ -356,6 +371,14 @@ class Response
                     break;
                 case 'Message':
                     $this->root_error['message'] = $root_child;
+
+                    break;
+                case 'Warnings':
+                    if (is_array($root_child)) {
+                        foreach ($root_child as $warning) {
+                            $this->root_warnings[] = $warning;
+                        }
+                    }
 
                     break;
                 case 'Payslip':

--- a/tests/Remote/ResponseTest.php
+++ b/tests/Remote/ResponseTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace XeroPHP\Tests\Remote;
+
+
+use XeroPHP\Application;
+use XeroPHP\Remote\Request;
+use XeroPHP\Remote\Response;
+use XeroPHP\Remote\URL;
+
+class ResponseTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRootWarningsAreParsedJson()
+    {
+        $app = $this->getApplication();
+        $response = new Response(new Request($app, new URL($app, 'test')),
+            '{
+  "Id": "1",
+  "Status": "OK",
+  "ProviderName": "",
+  "DateTimeUTC": "/Date(1714648586607)/",
+  "Invoices": [],
+  "Warnings": [
+    {
+	    "Message": "This is a Warning Message."
+    }
+  ]
+}', Response::STATUS_OK, [Request::HEADER_CONTENT_TYPE => [Request::CONTENT_TYPE_JSON.";"]]);
+
+        $response->parse();
+
+        $rootWarnings = $response->getRootWarnings();
+        $this->assertCount(1, $rootWarnings);
+        $this->assertArrayHasKey("Message", $rootWarnings[0]);
+        $this->assertEquals("This is a Warning Message.", $rootWarnings[0]["Message"]);
+    }
+
+    public function testRootWarningsAreParsedXML()
+    {
+        $app = $this->getApplication();
+        $response = new Response(new Request($app, new URL($app, 'test')),
+            '<Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>2</Id>
+    <Status>OK</Status>
+    <ProviderName></ProviderName>
+    <DateTimeUTC>2024-05-02T14:52:55.8388472Z</DateTimeUTC>
+    <Invoices></Invoices>
+    <Warnings>
+        <Warning><Message>This is a Warning Message.</Message></Warning>
+    </Warnings>
+</Response>', Response::STATUS_OK, [Request::HEADER_CONTENT_TYPE => [Request::CONTENT_TYPE_XML.";"]]);
+
+        $response->parse();
+
+        $rootWarnings = $response->getRootWarnings();
+        $this->assertCount(1, $rootWarnings);
+        $this->assertArrayHasKey("Message", $rootWarnings[0]);
+        $this->assertEquals("This is a Warning Message.", $rootWarnings[0]["Message"]);
+    }
+
+    protected function getApplication($config = [])
+    {
+        $xero_app = new Application('token', 'tenantId');
+        $xero_app->setConfig($config);
+
+        return $xero_app;
+    }
+}


### PR DESCRIPTION
Hi.
@p4vel mentioned in #888 there is a bug when accessing the warnings at the root of the response, because of the change mentioned here: https://developer.xero.com/documentation/api/efficient-data-retrieval

However, I don't think their solution is in keeping with how the system currently works, and I think adding it to the list of elements is likely going to lead to some issues with how other users are parsing the data.
As such, I've added it as a private property under the responses (similar to the root error).
I've also added proper handling for the json response, which I don't believe their solution would have worked with.
I've added a small unit test for this and confirmed that it did work.

Given the documentation indicates that this comes up in the query section, I've also added a private property on the query to save the response during the execution of the query, and a public method for accessing it.
This should allow users to access the response and parse any warnings that may have come through, while handling the content of the response as they like (and shouldn't interrupt any current implementations).

While I was doing this I noticed some issues with the inconsistent PHP versioning.
For example: in the Application file the private attributes on lines 32 to 35 (e.g. $lastApiCall) are all typed properties, however typed properties are not supported until PHP 7.4 (which is inconsistent with the composer PHP version of >=5.5.0).

I wasn't aware of whether you would want to update the composer version or remove the conflicts, so I've left them be for now.
If you'd like, I can make another pull request with the requisite change, should you tell me.
