### PR TITLE
fix getRootNodeName return

### DIFF
--- a/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
@@ -40,7 +40,7 @@ class TrackingOption extends Remote\Model
      */
     public static function getRootNodeName()
     {
-        return '';
+        return 'Option';
     }
 
     /**


### PR DESCRIPTION
A fix for the problem first raised in #871. 

This return from the `getRootNodeName` function was incorrectly deleted in #801, making it unable to save TrackingOptions correctly e.g. the following way:

```php
  $option = new TrackingOption();
  $option->setName($name);
  $tracking->addOption($option);
  $tracking->save();
```

The suggested change is to reinstate what it was previously and allow TrackingOptions to be saved properly. Interestingly, it seems to allow one TrackingOption to be generated but I try to add another to the same Tracking Category it does not save.