### PR TITLE
fix: use correct @property syntax for all models (fixes #926)

### DIFF
--- a/src/XeroPHP/Models/Accounting/Account.php
+++ b/src/XeroPHP/Models/Accounting/Account.php
@@ -5,120 +5,30 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Traits\AttachmentTrait;
 
+/**
+ * @property string $Code Customer defined alpha numeric account code e.g 200 or SALES (max length = 10).
+ * @property string $Name Name of account (max length = 150).
+ * @property string $Type See Account Types.
+ * @property string $BankAccountNumber For bank accounts only (Account Type BANK).
+ * @property string $Status Accounts with a status of ACTIVE can be updated to ARCHIVED. See Account Status Codes.
+ * @property string $Description Description of the Account. Valid for all types of accounts except bank accounts (max length = 4000).
+ * @property string $BankAccountType For bank accounts only. See Bank Account types.
+ * @property string $CurrencyCode For bank accounts only.
+ * @property string $TaxType See Tax Types.
+ * @property bool $EnablePaymentsToAccount Boolean – describes whether account can have payments applied to it.
+ * @property bool $ShowInExpenseClaims Boolean – describes whether account code is available for use with expense claims.
+ * @property string $AccountID The Xero identifier for an account – specified as a string following the endpoint name e.g. /297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ * @property string $Class See Account Class Types.
+ * @property string $SystemAccount If this is a system account then this element is returned. See System Account types. Note that non-system accounts may have this element set as either “” or null.
+ * @property string $ReportingCode Shown if set.
+ * @property string $ReportingCodeName Shown if set.
+ * @property bool $HasAttachments boolean to indicate if an account has an attachment (read only).
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ */
 class Account extends Remote\Model
 {
     use AttachmentTrait;
 
-    /**
-     * Customer defined alpha numeric account code e.g 200 or SALES (max length = 10).
-     *
-     * @property string Code
-     */
-
-    /**
-     * Name of account (max length = 150).
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Account Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * For bank accounts only (Account Type BANK).
-     *
-     * @property string BankAccountNumber
-     */
-
-    /**
-     * Accounts with a status of ACTIVE can be updated to ARCHIVED. See Account Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Description of the Account. Valid for all types of accounts except bank accounts (max length = 4000).
-     *
-     * @property string Description
-     */
-
-    /**
-     * For bank accounts only. See Bank Account types.
-     *
-     * @property string BankAccountType
-     */
-
-    /**
-     * For bank accounts only.
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * See Tax Types.
-     *
-     * @property string TaxType
-     */
-
-    /**
-     * Boolean – describes whether account can have payments applied to it.
-     *
-     * @property bool EnablePaymentsToAccount
-     */
-
-    /**
-     * Boolean – describes whether account code is available for use with expense claims.
-     *
-     * @property bool ShowInExpenseClaims
-     */
-
-    /**
-     * The Xero identifier for an account – specified as a string following the endpoint name
-     * e.g.
-     * /297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * See Account Class Types.
-     *
-     * @property string Class
-     */
-
-    /**
-     * If this is a system account then this element is returned. See System Account types. Note that
-     * non-system accounts may have this element set as either “” or null.
-     *
-     * @property string SystemAccount
-     */
-
-    /**
-     * Shown if set.
-     *
-     * @property string ReportingCode
-     */
-
-    /**
-     * Shown if set.
-     *
-     * @property string ReportingCodeName
-     */
-
-    /**
-     * boolean to indicate if an account has an attachment (read only).
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
     const ACCOUNT_CLASS_TYPE_ASSET = 'ASSET';
 
     const ACCOUNT_CLASS_TYPE_EQUITY = 'EQUITY';

--- a/src/XeroPHP/Models/Accounting/Address.php
+++ b/src/XeroPHP/Models/Accounting/Address.php
@@ -4,65 +4,20 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $AddressType
+ * @property string $AddressLine1  max length = 500.
+ * @property string $AddressLine2  max length = 500.
+ * @property string $AddressLine3  max length = 500.
+ * @property string $AddressLine4  max length = 500.
+ * @property string $City  max length = 255.
+ * @property string $Region  max length = 255.
+ * @property string $PostalCode  max length = 50.
+ * @property string $Country  max length = 50, [A-Z], [a-z] only.
+ * @property string $AttentionTo  max length = 255.
+ */
 class Address extends Remote\Model
 {
-    /**
-     * @property string AddressType
-     */
-
-    /**
-     *  max length = 500.
-     *
-     * @property string AddressLine1
-     */
-
-    /**
-     *  max length = 500.
-     *
-     * @property string AddressLine2
-     */
-
-    /**
-     *  max length = 500.
-     *
-     * @property string AddressLine3
-     */
-
-    /**
-     *  max length = 500.
-     *
-     * @property string AddressLine4
-     */
-
-    /**
-     *  max length = 255.
-     *
-     * @property string City
-     */
-
-    /**
-     *  max length = 255.
-     *
-     * @property string Region
-     */
-
-    /**
-     *  max length = 50.
-     *
-     * @property string PostalCode
-     */
-
-    /**
-     *  max length = 50, [A-Z], [a-z] only.
-     *
-     * @property string Country
-     */
-
-    /**
-     *  max length = 255.
-     *
-     * @property string AttentionTo
-     */
     const ADDRESS_TYPE_POBOX = 'POBOX';
 
     const ADDRESS_TYPE_STREET = 'STREET';

--- a/src/XeroPHP/Models/Accounting/Attachment.php
+++ b/src/XeroPHP/Models/Accounting/Attachment.php
@@ -9,30 +9,15 @@ use XeroPHP\Application;
 use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 
+/**
+ * @property string $AttachmentID Xero Unique Identifier.
+ * @property string $FileName
+ * @property string $Url
+ * @property string $MimeType
+ * @property int $ContentLength
+ */
 class Attachment extends Model
 {
-    /**
-     * Xero Unique Identifier.
-     *
-     * @property string AttachmentID
-     */
-
-    /**
-     * @property string FileName
-     */
-
-    /**
-     * @property string Url
-     */
-
-    /**
-     * @property string MimeType
-     */
-
-    /**
-     * @property int ContentLength
-     */
-
     /**
      * Actual file content (binary).
      *

--- a/src/XeroPHP/Models/Accounting/BankTransaction.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction.php
@@ -8,137 +8,33 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 use XeroPHP\Models\Accounting\BankTransaction\BankAccount;
 
+/**
+ * @property string $Type See Bank Transaction Types.
+ * @property Contact $Contact See Contacts.
+ * @property LineItem[] $LineItems See LineItems.
+ * @property BankAccount $BankAccount Bank account for transaction. See BankAccount.
+ * @property bool $IsReconciled Boolean to show if transaction is reconciled.
+ * @property \DateTimeInterface $Date Date of transaction – YYYY-MM-DD.
+ * @property string $Reference Reference for the transaction. Only supported for SPEND and RECEIVE transactions.
+ * @property string $CurrencyCode The currency that bank transaction has been raised in (see Currencies). Setting currency is only supported on overpayments.
+ * @property float $CurrencyRate Exchange rate to base currency when money is spent or received. e.g. 0.7500 Only used for bank transactions in non base currency. If this isn’t specified for non base currency accounts then either the user-defined rate (preference) or the XE.com day rate will be used. Setting currency is only supported on overpayments.
+ * @property string $Url URL link to a source document – shown as “Go to App Name”.
+ * @property string $Status See Bank Transaction Status Codes.
+ * @property string $LineAmountTypes Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types.
+ * @property float $SubTotal Total of bank transaction excluding taxes.
+ * @property float $TotalTax Total tax on bank transaction.
+ * @property float $Total Total of bank transaction tax inclusive.
+ * @property string $BankTransactionID Xero generated unique identifier for bank transaction.
+ * @property string $PrepaymentID Xero generated unique identifier for a Prepayment. This will be returned on BankTransactions with a Type of SPEND-PREPAYMENT or RECEIVE-PREPAYMENT.
+ * @property string $OverpaymentID Xero generated unique identifier for an Overpayment. This will be returned on BankTransactions with a Type of SPEND-OVERPAYMENT or RECEIVE-OVERPAYMENT.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ * @property bool $HasAttachments Boolean to indicate if a bank transaction has an attachment.
+ */
 class BankTransaction extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * See Bank Transaction Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * See LineItems.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * Bank account for transaction. See BankAccount.
-     *
-     * @property BankAccount BankAccount
-     */
-
-    /**
-     * Boolean to show if transaction is reconciled.
-     *
-     * @property bool IsReconciled
-     */
-
-    /**
-     * Date of transaction – YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Reference for the transaction. Only supported for SPEND and RECEIVE transactions.
-     *
-     * @property string Reference
-     */
-
-    /**
-     * The currency that bank transaction has been raised in (see Currencies). Setting currency is only
-     * supported on overpayments.
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * Exchange rate to base currency when money is spent or received. e.g. 0.7500 Only used for bank
-     * transactions in non base currency. If this isn’t specified for non base currency accounts then
-     * either the user-defined rate (preference) or the XE.com day rate will be used. Setting currency is
-     * only supported on overpayments.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * URL link to a source document – shown as “Go to App Name”.
-     *
-     * @property string Url
-     */
-
-    /**
-     * See Bank Transaction Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount
-     * Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * Total of bank transaction excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on bank transaction.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of bank transaction tax inclusive.
-     *
-     * @property float Total
-     */
-
-    /**
-     * Xero generated unique identifier for bank transaction.
-     *
-     * @property string BankTransactionID
-     */
-
-    /**
-     * Xero generated unique identifier for a Prepayment. This will be returned on BankTransactions with a
-     * Type of SPEND-PREPAYMENT or RECEIVE-PREPAYMENT.
-     *
-     * @property string PrepaymentID
-     */
-
-    /**
-     * Xero generated unique identifier for an Overpayment. This will be returned on BankTransactions with
-     * a Type of SPEND-OVERPAYMENT or RECEIVE-OVERPAYMENT.
-     *
-     * @property string OverpaymentID
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Boolean to indicate if a bank transaction has an attachment.
-     *
-     * @property bool HasAttachments
-     */
     const TYPE_RECEIVE = 'RECEIVE';
 
     const TYPE_RECEIVE_OVERPAYMENT = 'RECEIVE-OVERPAYMENT';

--- a/src/XeroPHP/Models/Accounting/BankTransaction/BankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransaction/BankAccount.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\Accounting\BankTransaction;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Code BankAccount code (this value may not always be present for a bank account).
+ * @property string $AccountID BankAccount identifier.
+ */
 class BankAccount extends Remote\Model
 {
-    /**
-     * BankAccount code (this value may not always be present for a bank account).
-     *
-     * @property string Code
-     */
-
-    /**
-     * BankAccount identifier.
-     *
-     * @property string AccountID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/BankTransfer.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer.php
@@ -8,86 +8,25 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\BankTransfer\ToBankAccount;
 use XeroPHP\Models\Accounting\BankTransfer\FromBankAccount;
 
+/**
+ * @property FromBankAccount $FromBankAccount See FromBankAccount.
+ * @property ToBankAccount $ToBankAccount See ToBankAccount.
+ * @property string $Amount
+ * @property \DateTimeInterface $Date The date of the Transfer YYYY-MM-DD.
+ * @property string $BankTransferID The identifier of the Bank Transfer.
+ * @property string $Reference additional reference number (max length = 255).
+ * @property float $CurrencyRate The currency rate.
+ * @property string $FromBankTransactionID The Bank Transaction ID for the source account.
+ * @property string $ToBankTransactionID The Bank Transaction ID for the destination account.
+ * @property bool $FromIsReconciled Boolean to show if the from transaction is reconciled.
+ * @property bool $ToIsReconciled Boolean to show if the to transaction is reconciled.
+ * @property bool $HasAttachments Boolean to indicate if a Bank Transfer has an attachment.
+ * @property \DateTimeInterface $CreatedDateUTC UTC timestamp of creation date of bank transfer.
+ */
 class BankTransfer extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
-
-    /**
-     * See FromBankAccount.
-     *
-     * @property FromBankAccount FromBankAccount
-     */
-
-    /**
-     * See ToBankAccount.
-     *
-     * @property ToBankAccount ToBankAccount
-     */
-
-    /**
-     * @property string Amount
-     */
-
-    /**
-     * The date of the Transfer YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * The identifier of the Bank Transfer.
-     *
-     * @property string BankTransferID
-     */
-
-    /**
-     * additional reference number (max length = 255).
-     *
-     * @property string Reference
-     */
-
-    /**
-     * The currency rate.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * The Bank Transaction ID for the source account.
-     *
-     * @property string FromBankTransactionID
-     */
-
-    /**
-     * The Bank Transaction ID for the destination account.
-     *
-     * @property string ToBankTransactionID
-     */
-
-    /**
-     * Boolean to show if the from transaction is reconciled.
-     *
-     * @property bool FromIsReconciled
-     */
-
-    /**
-     * Boolean to show if the to transaction is reconciled.
-     *
-     * @property bool ToIsReconciled
-     */
-
-    /**
-     * Boolean to indicate if a Bank Transfer has an attachment.
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * UTC timestamp of creation date of bank transfer.
-     *
-     * @property \DateTimeInterface CreatedDateUTC
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc.

--- a/src/XeroPHP/Models/Accounting/BankTransfer/FromBankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer/FromBankAccount.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\Accounting\BankTransfer;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Code The Account Code of the Bank Account.
+ * @property string $AccountID The ID of the Bank Account.
+ * @property string $Name The Name Bank Account.
+ */
 class FromBankAccount extends Remote\Model
 {
-    /**
-     * The Account Code of the Bank Account.
-     *
-     * @property string Code
-     */
-
-    /**
-     * The ID of the Bank Account.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * The Name Bank Account.
-     *
-     * @property string Name
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/BankTransfer/ToBankAccount.php
+++ b/src/XeroPHP/Models/Accounting/BankTransfer/ToBankAccount.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\Accounting\BankTransfer;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Code The Account Code of the Bank Account.
+ * @property string $AccountID The ID of the Bank Account.
+ * @property string $Name The Name Bank Account.
+ */
 class ToBankAccount extends Remote\Model
 {
-    /**
-     * The Account Code of the Bank Account.
-     *
-     * @property string Code
-     */
-
-    /**
-     * The ID of the Bank Account.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * The Name Bank Account.
-     *
-     * @property string Name
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/BatchPayment.php
+++ b/src/XeroPHP/Models/Accounting/BatchPayment.php
@@ -4,53 +4,23 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property \DateTimeInterface $Date Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
+ * @property string $BatchPaymentID The Xero identifier for an Batch Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
+ * @property string $Narrative (UK Only) Only shows on the statement line in Xero. Max length =18
+ * @property string $PaymentType See Types.
+ * @property string $Particulars (NZ Only) Optional references for the batch payment transaction.
+ * @property string $Code (NZ Only) Optional references for the batch payment transaction.
+ * @property string $Reference (NZ Only) Optional references for the batch payment transaction.
+ * @property Account $Account
+ */
 class BatchPayment extends Remote\Model
 {
-
-    /**
-     * Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Particulars, Code, Reference (NZ Only) Optional references for the batch payment transaction.
-     *
-     * @property string Particulars
-     * @property string Code
-     * @property string Reference
-     */
-
-    /**
-     *
-     *
-     * @property Account Account
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc
      *
      * @return string
      */
-
-    /**
-     * The Xero identifier for an Batch Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
-     *
-     * @property string BatchPaymentID
-     */
-
-    /**
-     * (UK Only) Only shows on the statement line in Xero. Max length =18
-     *
-     * @property string Narrative
-     */ 
-
-    /**
-     * See Types.
-     *
-     * @property string PaymentType
-     */        
-
     public static function getResourceURI()
     {
         return 'BatchPayments';

--- a/src/XeroPHP/Models/Accounting/BrandingTheme.php
+++ b/src/XeroPHP/Models/Accounting/BrandingTheme.php
@@ -4,43 +4,16 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $BrandingThemeID Xero identifier.
+ * @property string $Name Name of branding theme.
+ * @property string $LogoUrl The URL of the logo used on the branding theme
+ * @property string $Type The type of document that the branding theme can be appplied to
+ * @property int $SortOrder Integer – ranked order of branding theme. The default branding theme has a value of 0.
+ * @property \DateTimeInterface $CreatedDateUTC UTC timestamp of creation date of branding theme.
+ */
 class BrandingTheme extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * Name of branding theme.
-     *
-     * @property string Name
-     */
-
-    /**
-     * The URL of the logo used on the branding theme
-     *
-     * @property string LogoUrl
-     */
-
-    /**
-     * The type of document that the branding theme can be appplied to
-     * @property string Type
-     */
-
-    /**
-     * Integer – ranked order of branding theme. The default branding theme has a value of 0.
-     *
-     * @property int SortOrder
-     */
-
-    /**
-     * UTC timestamp of creation date of branding theme.
-     *
-     * @property \DateTimeInterface CreatedDateUTC
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Contact.php
+++ b/src/XeroPHP/Models/Accounting/Contact.php
@@ -8,236 +8,49 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\Contact\ContactPerson;
 use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 
+/**
+ * @property string $ContactID Xero identifier.
+ * @property string $ContactNumber This can be updated via the API only i.e. This field is read only on the Xero contact screen, used to identify contacts in external systems (max length = 50). If the Contact Number is used, this is displayed as Contact Code in the Contacts UI in Xero.
+ * @property string $AccountNumber A user defined account number. This can be updated via the API and the Xero UI (max length = 50).
+ * @property string $ContactStatus Current status of a contact – see contact status types.
+ * @property string $Name Full name of contact/organisation (max length = 255).
+ * @property string $FirstName First name of contact person (max length = 255).
+ * @property string $LastName Last name of contact person (max length = 255).
+ * @property string $EmailAddress Email address of contact person (umlauts not supported) (max length = 255).
+ * @property string $SkypeUserName Skype user name of contact.
+ * @property ContactPerson[] $ContactPersons See contact persons.
+ * @property string $BankAccountDetails Bank account number of contact.
+ * @property string $TaxNumber Tax number of contact – this is also known as the ABN (Australia), GST Number (New Zealand), VAT Number (UK) or Tax ID Number (US and global) in the Xero UI depending on which regionalized version of Xero you are using (max length = 50).
+ * @property string $CompanyNumber Company registration number. Max 50 char.
+ * @property string $AccountsReceivableTaxType Default tax type used for contact on AR invoices.
+ * @property string $AccountsPayableTaxType Default tax type used for contact on AP invoices.
+ * @property Address[] $Addresses Store certain address types for a contact – see address types.
+ * @property Phone[] $Phones Store certain phone types for a contact – see phone types.
+ * @property bool $IsSupplier true or false – Boolean that describes if a contact that has any AP invoices entered against them. Cannot be set via PUT or POST – it is automatically set when an accounts payable invoice is generated against this contact.
+ * @property bool $IsCustomer true or false – Boolean that describes if a contact has any AR invoices entered against them. Cannot be set via PUT or POST – it is automatically set when an accounts receivable invoice is generated against this contact.
+ * @property string $DefaultCurrency Default currency for raising invoices against contact.
+ * @property string $XeroNetworkKey Store XeroNetworkKey for contacts.
+ * @property string $SalesDefaultAccountCode The default sales account code for contacts.
+ * @property string $PurchasesDefaultAccountCode The default purchases account code for contacts.
+ * @property TrackingCategory[] $SalesTrackingCategories The default sales tracking categories for contacts.
+ * @property TrackingCategory[] $PurchasesTrackingCategories The default purchases tracking categories for contacts.
+ * @property string $TrackingCategoryName The name of the Tracking Category assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories.
+ * @property string $TrackingCategoryOption The name of the Tracking Option assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories.
+ * @property PaymentTerm $PaymentTerms The default payment terms for the contact – see Payment Terms.
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of last update to contact.
+ * @property ContactGroup[] $ContactGroups Displays which contact groups a contact is included in.
+ * @property string $Website Website address for contact (read only).
+ * @property BrandingTheme $BrandingTheme Default branding theme for contact (read only) – see Branding Themes.
+ * @property string $BatchPayments batch payment details for contact (read only).
+ * @property float $Discount The default discount rate for the contact (read only).
+ * @property string $Balances The raw AccountsReceivable(sales invoices) and AccountsPayable(bills) outstanding and overdue amounts, not converted to base currency (read only).
+ * @property bool $HasAttachments A boolean to indicate if a contact has an attachment.
+ */
 class Contact extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * Xero identifier.
-     *
-     * @property string ContactID
-     */
-
-    /**
-     * This can be updated via the API only i.e. This field is read only on the Xero contact screen, used
-     * to identify contacts in external systems (max length = 50). If the Contact Number is used, this is
-     * displayed as Contact Code in the Contacts UI in Xero.
-     *
-     * @property string ContactNumber
-     */
-
-    /**
-     * A user defined account number. This can be updated via the API and the Xero UI (max length = 50).
-     *
-     * @property string AccountNumber
-     */
-
-    /**
-     * Current status of a contact – see contact status types.
-     *
-     * @property string ContactStatus
-     */
-
-    /**
-     * Full name of contact/organisation (max length = 255).
-     *
-     * @property string Name
-     */
-
-    /**
-     * First name of contact person (max length = 255).
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of contact person (max length = 255).
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Email address of contact person (umlauts not supported) (max length = 255).
-     *
-     * @property string EmailAddress
-     */
-
-    /**
-     * Skype user name of contact.
-     *
-     * @property string SkypeUserName
-     */
-
-    /**
-     * See contact persons.
-     *
-     * @property ContactPerson[] ContactPersons
-     */
-
-    /**
-     * Bank account number of contact.
-     *
-     * @property string BankAccountDetails
-     */
-
-    /**
-     * Tax number of contact – this is also known as the ABN (Australia), GST Number (New Zealand), VAT
-     * Number (UK) or Tax ID Number (US and global) in the Xero UI depending on which regionalized version
-     * of Xero you are using (max length = 50).
-     *
-     * @property string TaxNumber
-     */
-
-    /**
-     * Company registration number. Max 50 char.
-     * @property string CompanyNumber
-     */
-
-    /**
-     * Default tax type used for contact on AR invoices.
-     *
-     * @property string AccountsReceivableTaxType
-     */
-
-    /**
-     * Default tax type used for contact on AP invoices.
-     *
-     * @property string AccountsPayableTaxType
-     */
-
-    /**
-     * Store certain address types for a contact – see address types.
-     *
-     * @property Address[] Addresses
-     */
-
-    /**
-     * Store certain phone types for a contact – see phone types.
-     *
-     * @property Phone[] Phones
-     */
-
-    /**
-     * true or false – Boolean that describes if a contact that has any AP invoices entered against them.
-     * Cannot be set via PUT or POST – it is automatically set when an accounts payable invoice is
-     * generated against this contact.
-     *
-     * @property bool IsSupplier
-     */
-
-    /**
-     * true or false – Boolean that describes if a contact has any AR invoices entered against them.
-     * Cannot be set via PUT or POST – it is automatically set when an accounts receivable invoice is
-     * generated against this contact.
-     *
-     * @property bool IsCustomer
-     */
-
-    /**
-     * Default currency for raising invoices against contact.
-     *
-     * @property string DefaultCurrency
-     */
-
-    /**
-     * Store XeroNetworkKey for contacts.
-     *
-     * @property string XeroNetworkKey
-     */
-
-    /**
-     * The default sales account code for contacts.
-     *
-     * @property string SalesDefaultAccountCode
-     */
-
-    /**
-     * The default purchases account code for contacts.
-     *
-     * @property string PurchasesDefaultAccountCode
-     */
-
-    /**
-     * The default sales tracking categories for contacts.
-     *
-     * @property TrackingCategory[] SalesTrackingCategories
-     */
-
-    /**
-     * The default purchases tracking categories for contacts.
-     *
-     * @property TrackingCategory[] PurchasesTrackingCategories
-     */
-
-    /**
-     * The name of the Tracking Category assigned to the contact under SalesTrackingCategories and
-     * PurchasesTrackingCategories.
-     *
-     * @property string TrackingCategoryName
-     */
-
-    /**
-     * The name of the Tracking Option assigned to the contact under SalesTrackingCategories and
-     * PurchasesTrackingCategories.
-     *
-     * @property string TrackingCategoryOption
-     */
-
-    /**
-     * The default payment terms for the contact – see Payment Terms.
-     *
-     * @property PaymentTerm PaymentTerms
-     */
-
-    /**
-     * UTC timestamp of last update to contact.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Displays which contact groups a contact is included in.
-     *
-     * @property ContactGroup[] ContactGroups
-     */
-
-    /**
-     * Website address for contact (read only).
-     *
-     * @property string Website
-     */
-
-    /**
-     * Default branding theme for contact (read only) – see Branding Themes.
-     *
-     * @property BrandingTheme BrandingTheme
-     */
-
-    /**
-     * batch payment details for contact (read only).
-     *
-     * @property string BatchPayments
-     */
-
-    /**
-     * The default discount rate for the contact (read only).
-     *
-     * @property float Discount
-     */
-
-    /**
-     * The raw AccountsReceivable(sales invoices) and AccountsPayable(bills) outstanding and overdue
-     * amounts, not converted to base currency (read only).
-     *
-     * @property string Balances
-     */
-
-    /**
-     * A boolean to indicate if a contact has an attachment.
-     *
-     * @property bool HasAttachments
-     */
     const CONTACT_STATUS_ACTIVE = 'ACTIVE';
 
     const CONTACT_STATUS_ARCHIVED = 'ARCHIVED';

--- a/src/XeroPHP/Models/Accounting/Contact/ContactPerson.php
+++ b/src/XeroPHP/Models/Accounting/Contact/ContactPerson.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\Accounting\Contact;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $FirstName First name of person.
+ * @property string $LastName Last name of person.
+ * @property string $EmailAddress Email address of person.
+ * @property bool $IncludeInEmails boolean to indicate whether contact should be included on emails with invoices etc.
+ */
 class ContactPerson extends Remote\Model
 {
-    /**
-     * First name of person.
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of person.
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Email address of person.
-     *
-     * @property string EmailAddress
-     */
-
-    /**
-     * boolean to indicate whether contact should be included on emails with invoices etc.
-     *
-     * @property bool IncludeInEmails
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/ContactGroup.php
+++ b/src/XeroPHP/Models/Accounting/ContactGroup.php
@@ -4,36 +4,14 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name The Name of the contact group. Required when creating a new contact group.
+ * @property string $Status The Status of a contact group. To delete a contact group update the status to DELETED. Only contact groups with a status of ACTIVE are returned on GETs.
+ * @property string $ContactGroupID The Xero identifier for an contact group – specified as a string following the endpoint name. e.g. /297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ * @property Contact[] $Contacts The ContactID and Name of Contacts in a contact group. Returned on GETs when the ContactGroupID is supplied in the URL.
+ */
 class ContactGroup extends Remote\Model
 {
-    /**
-     * The Name of the contact group. Required when creating a new contact group.
-     *
-     * @property string Name
-     */
-
-    /**
-     * The Status of a contact group. To delete a contact group update the status to DELETED. Only contact
-     * groups with a status of ACTIVE are returned on GETs.
-     *
-     * @property string Status
-     */
-
-    /**
-     * The Xero identifier for an contact group – specified as a string following the endpoint name.
-     * e.g.
-     * /297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string ContactGroupID
-     */
-
-    /**
-     * The ContactID and Name of Contacts in a contact group. Returned on GETs when the ContactGroupID is
-     * supplied in the URL.
-     *
-     * @property Contact[] Contacts
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/CreditNote.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote.php
@@ -9,139 +9,35 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 use XeroPHP\Models\Accounting\CreditNote\Allocation;
 
+/**
+ * @property string $Type See Credit Note Types.
+ * @property Contact $Contact See Contacts.
+ * @property \DateTimeInterface $Date The date the credit note is issued YYYY-MM-DD.
+ * @property string $Status See Credit Note Status Codes.
+ * @property string $LineAmountTypes See Invoice Line Amount Types.
+ * @property LineItem[] $LineItems See Invoice Line Items.
+ * @property float $SubTotal The subtotal of the credit note excluding taxes.
+ * @property float $TotalTax The total tax on the credit note.
+ * @property float $Total The total of the Credit Note(subtotal + total tax).
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of last update to the credit note.
+ * @property string $CurrencyCode Currency used for the Credit Note.
+ * @property \DateTimeInterface $FullyPaidOnDate Date when credit note was fully paid(UTC format).
+ * @property string $CreditNoteID Xero generated unique identifier.
+ * @property string $CreditNoteNumber ACCRECCREDIT – Unique alpha numeric code identifying credit note (when missing will auto-generate from your Organisation Invoice Settings).
+ * @property string $Reference ACCRECCREDIT only – additional reference number.
+ * @property bool $SentToContact boolean to indicate if a credit note has been sent to a contact via the Xero app (currently read only).
+ * @property float $CurrencyRate The currency rate for a multicurrency invoice. If no rate is specified, the XE.com day rate is used.
+ * @property string $RemainingCredit The remaining credit balance on the Credit Note.
+ * @property Allocation[] $Allocations See Allocations.
+ * @property string $BrandingThemeID See BrandingThemes.
+ * @property bool $HasAttachments boolean to indicate if a credit note has an attachment.
+ */
 class CreditNote extends Remote\Model
 {
     use PDFTrait;
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * See Credit Note Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * The date the credit note is issued YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * See Credit Note Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * See Invoice Line Amount Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * See Invoice Line Items.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * The subtotal of the credit note excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * The total tax on the credit note.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * The total of the Credit Note(subtotal + total tax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * UTC timestamp of last update to the credit note.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Currency used for the Credit Note.
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * Date when credit note was fully paid(UTC format).
-     *
-     * @property \DateTimeInterface FullyPaidOnDate
-     */
-
-    /**
-     * Xero generated unique identifier.
-     *
-     * @property string CreditNoteID
-     */
-
-    /**
-     * ACCRECCREDIT – Unique alpha numeric code identifying credit note (when missing will auto-generate
-     * from your Organisation Invoice Settings).
-     *
-     * @property string CreditNoteNumber
-     */
-
-    /**
-     * ACCRECCREDIT only – additional reference number.
-     *
-     * @property string Reference
-     */
-
-    /**
-     * boolean to indicate if a credit note has been sent to a contact via the Xero app (currently read
-     * only).
-     *
-     * @property bool SentToContact
-     */
-
-    /**
-     * The currency rate for a multicurrency invoice. If no rate is specified, the XE.com day rate is used.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * The remaining credit balance on the Credit Note.
-     *
-     * @property string RemainingCredit
-     */
-
-    /**
-     * See Allocations.
-     *
-     * @property Allocation[] Allocations
-     */
-
-    /**
-     * See BrandingThemes.
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * boolean to indicate if a credit note has an attachment.
-     *
-     * @property bool HasAttachments
-     */
     const CREDIT_NOTE_TYPE_ACCPAYCREDIT = 'ACCPAYCREDIT';
 
     const CREDIT_NOTE_TYPE_ACCRECCREDIT = 'ACCRECCREDIT';

--- a/src/XeroPHP/Models/Accounting/CreditNote/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/CreditNote/Allocation.php
@@ -5,27 +5,13 @@ namespace XeroPHP\Models\Accounting\CreditNote;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Invoice;
 
+/**
+ * @property Invoice $Invoice the invoice the credit note is being allocated against.
+ * @property float $AppliedAmount the amount being applied to the invoice.
+ * @property \DateTimeInterface $Date the date the credit note is applied YYYY-MM-DD (read-only). This will be the latter of the invoice date and the credit note date.
+ */
 class Allocation extends Remote\Model
 {
-    /**
-     * the invoice the credit note is being allocated against.
-     *
-     * @property Invoice Invoice
-     */
-
-    /**
-     * the amount being applied to the invoice.
-     *
-     * @property float AppliedAmount
-     */
-
-    /**
-     * the date the credit note is applied YYYY-MM-DD (read-only). This will be the latter of the invoice
-     * date and the credit note date.
-     *
-     * @property \DateTimeInterface Date
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Currency.php
+++ b/src/XeroPHP/Models/Accounting/Currency.php
@@ -4,28 +4,13 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Code 3 letter alpha code for the currency – see list of currency codes.
+ * @property string $Description Name of Currency.
+ * @property string $ModifiedAfter Deprecated: this property has been removed from the Xero API.
+ */
 class Currency extends Remote\Model
 {
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string ModifiedAfter
-     *
-     * @deprecated
-     */
-
-    /**
-     * 3 letter alpha code for the currency – see list of currency codes.
-     *
-     * @property string Code
-     */
-
-    /**
-     * Name of Currency.
-     *
-     * @property string Description
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Employee.php
+++ b/src/XeroPHP/Models/Accounting/Employee.php
@@ -5,41 +5,15 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Organisation\ExternalLink;
 
+/**
+ * @property string $EmployeeID Xero identifier.
+ * @property string $Status Current status of an employee – see contact status types.
+ * @property string $FirstName First name of an employee (max length = 255).
+ * @property string $LastName Last name of an employee (max length = 255).
+ * @property ExternalLink $ExternalLink Link to an external resource, for example, an employee record in an external system. You can specify the URL element. The description of the link is auto-generated in the form “Go to <App name>”. <App name> refers to the Xero application name that is making the API call.
+ */
 class Employee extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * Current status of an employee – see contact status types.
-     *
-     * @property string Status
-     */
-
-    /**
-     * First name of an employee (max length = 255).
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of an employee (max length = 255).
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Link to an external resource, for example, an employee record in an external system. You can specify
-     * the URL element.
-     * The description of the link is auto-generated in the form “Go to <App name>”.
-     * <App name> refers to the Xero application name that is making the API call.
-     *
-     * @property ExternalLink ExternalLink
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim.php
@@ -6,28 +6,16 @@ use XeroPHP\Remote;
 use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Traits\AttachmentTrait;
 
+/**
+ * @property string $ExpenseClaimID Xero identifier.
+ * @property User $User See Users.
+ * @property Receipt[] $Receipts See Receipts.
+ */
 class ExpenseClaim extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * Xero identifier.
-     *
-     * @property string ExpenseClaimID
-     */
-
-    /**
-     * See Users.
-     *
-     * @property User User
-     */
-
-    /**
-     * See Receipts.
-     *
-     * @property Receipt[] Receipts
-     */
     const EXPENSE_CLAIM_STATUS_SUBMITTED = 'SUBMITTED';
 
     const EXPENSE_CLAIM_STATUS_AUTHORISED = 'AUTHORISED';

--- a/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
+++ b/src/XeroPHP/Models/Accounting/ExpenseClaim/ExpenseClaim.php
@@ -5,68 +5,20 @@ namespace XeroPHP\Models\Accounting\ExpenseClaim;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Payment;
 
+/**
+ * @property string $ExpenseClaimID Xero generated unique identifier for an expense claim.
+ * @property Payment[] $Payments See Payments.
+ * @property string $Status Current status of an expense claim – see status types.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ * @property float $Total The total of an expense claim being paid.
+ * @property float $AmountDue The amount due to be paid for an expense claim.
+ * @property float $AmountPaid The amount still to pay for an expense claim.
+ * @property \DateTimeInterface $PaymentDueDate The date when the expense claim is due to be paid YYYY-MM-DD.
+ * @property \DateTimeInterface $ReportingDate The date the expense claim will be reported in Xero YYYY-MM-DD.
+ * @property string $ReceiptID The Xero identifier for the Receipt e.g. e59a2c7f-1306-4078-a0f3-73537afcbba9.
+ */
 class ExpenseClaim extends Remote\Model
 {
-    /**
-     * Xero generated unique identifier for an expense claim.
-     *
-     * @property string ExpenseClaimID
-     */
-
-    /**
-     * See Payments.
-     *
-     * @property Payment[] Payments
-     */
-
-    /**
-     * Current status of an expense claim – see status types.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The total of an expense claim being paid.
-     *
-     * @property float Total
-     */
-
-    /**
-     * The amount due to be paid for an expense claim.
-     *
-     * @property float AmountDue
-     */
-
-    /**
-     * The amount still to pay for an expense claim.
-     *
-     * @property float AmountPaid
-     */
-
-    /**
-     * The date when the expense claim is due to be paid YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface PaymentDueDate
-     */
-
-    /**
-     * The date the expense claim will be reported in Xero YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface ReportingDate
-     */
-
-    /**
-     * The Xero identifier for the Receipt e.g. e59a2c7f-1306-4078-a0f3-73537afcbba9.
-     *
-     * @property string ReceiptID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/History.php
+++ b/src/XeroPHP/Models/Accounting/History.php
@@ -5,32 +5,14 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 
+/**
+ * @property string $Changes The type of change recorded against the document.
+ * @property \DateTimeInterface $DateUTC UTC date that the history record was created.
+ * @property string $User The user responsible for the change ("System Generated" when the change happens via API).
+ * @property string $Details Description of the change event or transaction.
+ */
 class History extends Model
 {
-    /**
-     * The type of change recorded against the document.
-     *
-     * @property string Changes
-     */
-
-    /**
-     * UTC date that the history record was created.
-     *
-     * @property \DateTimeInterface DateUTC
-     */
-
-    /**
-     * The user responsible for the change ("System Generated" when the change happens via API).
-     *
-     * @property string User
-     */
-
-    /**
-     * Description of the change event or transaction.
-     *
-     * @property string Details
-     */
-
     /**
      * Get the GUID Property if it exists.
      *

--- a/src/XeroPHP/Models/Accounting/Invoice.php
+++ b/src/XeroPHP/Models/Accounting/Invoice.php
@@ -10,6 +10,40 @@ use XeroPHP\Traits\SendEmailTrait;
 use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 
+/**
+ * @property string $Type See Invoice Types.
+ * @property Contact $Contact See Contacts.
+ * @property LineItem[] $LineItems See LineItems.
+ * @property \DateTimeInterface $Date Date invoice was issued – YYYY-MM-DD. Learn more.
+ * @property \DateTimeInterface $DueDate Date invoice is due – YYYY-MM-DD.
+ * @property string $LineAmountTypes Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types.
+ * @property string $InvoiceNumber ACCREC – Unique alpha numeric code identifying invoice (when missing will auto-generate from your Organisation Invoice Settings) (max length = 255).
+ * @property string $Reference ACCREC only – additional reference number (max length = 255).
+ * @property string $BrandingThemeID See BrandingThemes.
+ * @property string $Url URL link to a source document – shown as “Go to [appName]” in the Xero app.
+ * @property string $CurrencyCode The currency that invoice has been raised in (see Currencies).
+ * @property float $CurrencyRate The currency rate for a multicurrency invoice. If no rate is specified, the XE.com day rate is used. (max length = [18].[6]).
+ * @property string $Status See Invoice Status Codes.
+ * @property bool $SentToContact Boolean to set whether the invoice in the Xero app should be marked as “sent”. This can be set only on invoices that have been approved.
+ * @property \DateTimeInterface $ExpectedPaymentDate Shown on sales invoices (Accounts Receivable) when this has been set.
+ * @property \DateTimeInterface $PlannedPaymentDate Shown on bills (Accounts Payable) when this has been set.
+ * @property float $SubTotal Total of invoice excluding taxes.
+ * @property float $TotalTax Total tax on invoice.
+ * @property float $Total Total of Invoice tax inclusive (i.e. SubTotal + TotalTax). This will be ignored if it doesn’t equal the sum of the LineAmounts.
+ * @property float $TotalDiscount Total of discounts applied on the invoice line items.
+ * @property string $InvoiceID Xero generated unique identifier for invoice.
+ * @property string $RepeatingInvoiceID See RepeatingInvoices.
+ * @property bool $HasAttachments boolean to indicate if an invoice has an attachment.
+ * @property Payment[] $Payments See Payments.
+ * @property Prepayment[] $Prepayments See Prepayments.
+ * @property Overpayment[] $Overpayments See Overpayments.
+ * @property float $AmountDue Amount remaining to be paid on invoice.
+ * @property float $AmountPaid Sum of payments received for invoice.
+ * @property \DateTimeInterface $FullyPaidOnDate The date the invoice was fully paid. Only returned on fully paid invoices.
+ * @property float $AmountCredited Sum of all credit notes, over-payments and pre-payments applied to invoice.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ * @property CreditNote[] $CreditNotes Details of credit notes that have been applied to an invoice.
+ */
 class Invoice extends Remote\Model
 {
     use PDFTrait;
@@ -17,202 +51,6 @@ class Invoice extends Remote\Model
     use SendEmailTrait;
     use HistoryTrait;
 
-    /**
-     * See Invoice Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * See LineItems.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * Date invoice was issued – YYYY-MM-DD. Learn more.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Date invoice is due – YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface DueDate
-     */
-
-    /**
-     * Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount
-     * Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * ACCREC – Unique alpha numeric code identifying invoice (when missing will auto-generate from your
-     * Organisation Invoice Settings) (max length = 255).
-     *
-     * @property string InvoiceNumber
-     */
-
-    /**
-     * ACCREC only – additional reference number (max length = 255).
-     *
-     * @property string Reference
-     */
-
-    /**
-     * See BrandingThemes.
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * URL link to a source document – shown as “Go to [appName]” in the Xero app.
-     *
-     * @property string Url
-     */
-
-    /**
-     * The currency that invoice has been raised in (see Currencies).
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * The currency rate for a multicurrency invoice. If no rate is specified, the XE.com day rate is used.
-     * (max length = [18].[6]).
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * See Invoice Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Boolean to set whether the invoice in the Xero app should be marked as “sent”. This can be set
-     * only on invoices that have been approved.
-     *
-     * @property bool SentToContact
-     */
-
-    /**
-     * Shown on sales invoices (Accounts Receivable) when this has been set.
-     *
-     * @property \DateTimeInterface ExpectedPaymentDate
-     */
-
-    /**
-     * Shown on bills (Accounts Payable) when this has been set.
-     *
-     * @property \DateTimeInterface PlannedPaymentDate
-     */
-
-    /**
-     * Total of invoice excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on invoice.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of Invoice tax inclusive (i.e. SubTotal + TotalTax). This will be ignored if it doesn’t
-     * equal the sum of the LineAmounts.
-     *
-     * @property float Total
-     */
-
-    /**
-     * Total of discounts applied on the invoice line items.
-     *
-     * @property float TotalDiscount
-     */
-
-    /**
-     * Xero generated unique identifier for invoice.
-     *
-     * @property string InvoiceID
-     */
-
-    /**
-     * See RepeatingInvoices.
-     *
-     * @property string RepeatingInvoiceID
-     */
-
-    /**
-     * boolean to indicate if an invoice has an attachment.
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * See Payments.
-     *
-     * @property Payment[] Payments
-     */
-
-    /**
-     * See Prepayments.
-     *
-     * @property Prepayment[] Prepayments
-     */
-
-    /**
-     * See Overpayments.
-     *
-     * @property Overpayment[] Overpayments
-     */
-
-    /**
-     * Amount remaining to be paid on invoice.
-     *
-     * @property float AmountDue
-     */
-
-    /**
-     * Sum of payments received for invoice.
-     *
-     * @property float AmountPaid
-     */
-
-    /**
-     * The date the invoice was fully paid. Only returned on fully paid invoices.
-     *
-     * @property \DateTimeInterface FullyPaidOnDate
-     */
-
-    /**
-     * Sum of all credit notes, over-payments and pre-payments applied to invoice.
-     *
-     * @property float AmountCredited
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Details of credit notes that have been applied to an invoice.
-     *
-     * @property CreditNote[] CreditNotes
-     */
     const INVOICE_TYPE_ACCPAY = 'ACCPAY';
 
     const INVOICE_TYPE_ACCREC = 'ACCREC';

--- a/src/XeroPHP/Models/Accounting/InvoiceReminder.php
+++ b/src/XeroPHP/Models/Accounting/InvoiceReminder.php
@@ -4,14 +4,11 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property bool $Enabled Boolean to set when InvocieReminders are turned on in Xero.
+ */
 class InvoiceReminder extends Remote\Model
 {
-    /**
-     * Boolean to set when InvocieReminders are turned on in Xero.
-     *
-     * @property bool Enabled
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Item.php
+++ b/src/XeroPHP/Models/Accounting/Item.php
@@ -7,99 +7,25 @@ use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Models\Accounting\Item\Sale;
 use XeroPHP\Models\Accounting\Item\Purchase;
 
+/**
+ * @property string $ItemID Xero identifier.
+ * @property string $Code User defined item code (max length = 30).
+ * @property string $InventoryAssetAccountCode The inventory asset account for the item. The account must be of type INVENTORY. The COGSAccountCode in PurchaseDetails is also required to create a tracked item.
+ * @property string $Name The name of the item (max length = 50).
+ * @property bool $IsSold Boolean value, defaults to true. When IsSold is true the item will be available on sales transactions in the Xero UI. If IsSold is updated to false then Description and SalesDetails values will be nulled.
+ * @property bool $IsPurchased Boolean value, defaults to true. When IsPurchased is true the item is available for purchase transactions in the Xero UI. If IsPurchased is updated to false then PurchaseDescription and PurchaseDetails values will be nulled.
+ * @property string $Description The sales description of the item (max length = 4000).
+ * @property string $PurchaseDescription The purchase description of the item (max length = 4000).
+ * @property Purchase $PurchaseDetails See Purchases & Sales.
+ * @property Sale $SalesDetails See Purchases & Sales.
+ * @property bool $IsTrackedAsInventory True for items that are tracked as inventory. An item will be tracked as inventory if the InventoryAssetAccountCode and COGSAccountCode are set.
+ * @property string $TotalCostPool The value of the item on hand. Calculated using average cost accounting.
+ * @property string $QuantityOnHand The quantity of the item on hand.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date in UTC format.
+ */
 class Item extends Remote\Model
 {
     use HistoryTrait;
-
-    /**
-     * Xero identifier.
-     *
-     * @property string ItemID
-     */
-
-    /**
-     * User defined item code (max length = 30).
-     *
-     * @property string Code
-     */
-
-    /**
-     * The inventory asset account for the item. The account must be of type INVENTORY. The
-     * COGSAccountCode in PurchaseDetails is also required to create a tracked item.
-     *
-     * @property string InventoryAssetAccountCode
-     */
-
-    /**
-     * The name of the item (max length = 50).
-     *
-     * @property string Name
-     */
-
-    /**
-     * Boolean value, defaults to true. When IsSold is true the item will be available on sales
-     * transactions in the Xero UI. If IsSold is updated to false then Description and SalesDetails values
-     * will be nulled.
-     *
-     * @property bool IsSold
-     */
-
-    /**
-     * Boolean value, defaults to true. When IsPurchased is true the item is available for purchase
-     * transactions in the Xero UI. If IsPurchased is updated to false then PurchaseDescription and
-     * PurchaseDetails values will be nulled.
-     *
-     * @property bool IsPurchased
-     */
-
-    /**
-     * The sales description of the item (max length = 4000).
-     *
-     * @property string Description
-     */
-
-    /**
-     * The purchase description of the item (max length = 4000).
-     *
-     * @property string PurchaseDescription
-     */
-
-    /**
-     * See Purchases & Sales.
-     *
-     * @property Purchase PurchaseDetails
-     */
-
-    /**
-     * See Purchases & Sales.
-     *
-     * @property Sale SalesDetails
-     */
-
-    /**
-     * True for items that are tracked as inventory. An item will be tracked as inventory if the
-     * InventoryAssetAccountCode and COGSAccountCode are set.
-     *
-     * @property bool IsTrackedAsInventory
-     */
-
-    /**
-     * The value of the item on hand. Calculated using average cost accounting.
-     *
-     * @property string TotalCostPool
-     */
-
-    /**
-     * The quantity of the item on hand.
-     *
-     * @property string QuantityOnHand
-     */
-
-    /**
-     * Last modified date in UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc.

--- a/src/XeroPHP/Models/Accounting/Item/Purchase.php
+++ b/src/XeroPHP/Models/Accounting/Item/Purchase.php
@@ -4,43 +4,15 @@ namespace XeroPHP\Models\Accounting\Item;
 
 use XeroPHP\Remote;
 
+/**
+ * @property float $UnitPrice Unit Price of the item. By default UnitPrice is rounded to two decimal places. You can use 4 decimal places by adding the unitdp=4 querystring parameter to your request.
+ * @property string $AccountCode Default account code to be used for purchased/sale. Not applicable to the purchase details of tracked items.
+ * @property string $COGSAccountCode Cost of goods sold account. Only applicable to the purchase details of tracked items.
+ * @property string $TaxType Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see TaxTypes.
+ * @property \DateTimeInterface $UpdatedDateUTC Deprecated: this property has been removed from the Xero API.
+ */
 class Purchase extends Remote\Model
 {
-    /**
-     * Unit Price of the item. By default UnitPrice is rounded to two decimal places. You can use 4 decimal
-     * places by adding the unitdp=4 querystring parameter to your request.
-     *
-     * @property float UnitPrice
-     */
-
-    /**
-     * Default account code to be used for purchased/sale. Not applicable to the purchase details of
-     * tracked items.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Cost of goods sold account. Only applicable to the purchase details of tracked items.
-     *
-     * @property string COGSAccountCode
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     *
-     * @deprecated
-     */
-
-    /**
-     * Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see
-     * TaxTypes.
-     *
-     * @property string TaxType
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Item/Sale.php
+++ b/src/XeroPHP/Models/Accounting/Item/Sale.php
@@ -4,43 +4,15 @@ namespace XeroPHP\Models\Accounting\Item;
 
 use XeroPHP\Remote;
 
+/**
+ * @property float $UnitPrice Unit Price of the item. By default UnitPrice is rounded to two decimal places. You can use 4 decimal places by adding the unitdp=4 querystring parameter to your request.
+ * @property string $AccountCode Default account code to be used for purchased/sale. Not applicable to the purchase details of tracked items.
+ * @property string $COGSAccountCode Cost of goods sold account. Only applicable to the purchase details of tracked items.
+ * @property string $TaxType Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see TaxTypes.
+ * @property \DateTimeInterface $UpdatedDateUTC Deprecated: this property has been removed from the Xero API.
+ */
 class Sale extends Remote\Model
 {
-    /**
-     * Unit Price of the item. By default UnitPrice is rounded to two decimal places. You can use 4 decimal
-     * places by adding the unitdp=4 querystring parameter to your request.
-     *
-     * @property float UnitPrice
-     */
-
-    /**
-     * Default account code to be used for purchased/sale. Not applicable to the purchase details of
-     * tracked items.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Cost of goods sold account. Only applicable to the purchase details of tracked items.
-     *
-     * @property string COGSAccountCode
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     *
-     * @deprecated
-     */
-
-    /**
-     * Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see
-     * TaxTypes.
-     *
-     * @property string TaxType
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Journal.php
+++ b/src/XeroPHP/Models/Accounting/Journal.php
@@ -5,53 +5,18 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Journal\JournalLine;
 
+/**
+ * @property string $JournalID Xero identifier.
+ * @property \DateTimeInterface $JournalDate Date the journal was posted.
+ * @property string $JournalNumber Xero generated journal number.
+ * @property \DateTimeInterface $CreatedDateUTC Created date UTC format.
+ * @property string $Reference
+ * @property string $SourceID The identifier for the source transaction (e.g. InvoiceID).
+ * @property string $SourceType The journal source type. The type of transaction that created the journal.
+ * @property JournalLine[] $JournalLines See JournalLines.
+ */
 class Journal extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string JournalID
-     */
-
-    /**
-     * Date the journal was posted.
-     *
-     * @property \DateTimeInterface JournalDate
-     */
-
-    /**
-     * Xero generated journal number.
-     *
-     * @property string JournalNumber
-     */
-
-    /**
-     * Created date UTC format.
-     *
-     * @property \DateTimeInterface CreatedDateUTC
-     */
-
-    /**
-     * @property string Reference
-     */
-
-    /**
-     * The identifier for the source transaction (e.g. InvoiceID).
-     *
-     * @property string SourceID
-     */
-
-    /**
-     * The journal source type. The type of transaction that created the journal.
-     *
-     * @property string SourceType
-     */
-
-    /**
-     * See JournalLines.
-     *
-     * @property JournalLine[] JournalLines
-     */
     const JOURNAL_SOURCE_TYPE_ACCREC = 'ACCREC';
 
     const JOURNAL_SOURCE_TYPE_ACCPAY = 'ACCPAY';

--- a/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/Journal/JournalLine.php
@@ -6,80 +6,22 @@ use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\TaxRate;
 use XeroPHP\Models\Accounting\TrackingCategory;
 
+/**
+ * @property string $JournalLineID Xero identifier.
+ * @property string $AccountID See Accounts.
+ * @property string $AccountCode See Accounts.
+ * @property string $AccountType See Account Types.
+ * @property string $AccountName See AccountCodes.
+ * @property string $Description The description from the source transaction line item. Only returned if populated.
+ * @property float $NetAmount Net amount of journal line. This will be a positive value for a debit and negative for a credit.
+ * @property float $GrossAmount Gross amount of journal line (NetAmount + TaxAmount).
+ * @property float $TaxAmount Total tax on a journal line.
+ * @property string $TaxType see TaxTypes.
+ * @property TaxRate $TaxName see TaxRates.
+ * @property TrackingCategory[] $TrackingCategories see Tracking.
+ */
 class JournalLine extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string JournalLineID
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * See Account Types.
-     *
-     * @property string AccountType
-     */
-
-    /**
-     * See AccountCodes.
-     *
-     * @property string AccountName
-     */
-
-    /**
-     * The description from the source transaction line item. Only returned if populated.
-     *
-     * @property string Description
-     */
-
-    /**
-     * Net amount of journal line. This will be a positive value for a debit and negative for a credit.
-     *
-     * @property float NetAmount
-     */
-
-    /**
-     * Gross amount of journal line (NetAmount + TaxAmount).
-     *
-     * @property float GrossAmount
-     */
-
-    /**
-     * Total tax on a journal line.
-     *
-     * @property float TaxAmount
-     */
-
-    /**
-     * see TaxTypes.
-     *
-     * @property string TaxType
-     */
-
-    /**
-     * see TaxRates.
-     *
-     * @property TaxRate TaxName
-     */
-
-    /**
-     * see Tracking.
-     *
-     * @property TrackingCategory[] TrackingCategories
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/LineItem.php
+++ b/src/XeroPHP/Models/Accounting/LineItem.php
@@ -5,102 +5,24 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\TrackingCategory;
 
+/**
+ * @property string $LineItemID The Xero generated identifier for a LineItem. If LineItemIDs are not included with line items in an update request then the line items are deleted and recreated.
+ * @property string $Description Description needs to be at least 1 char long. A line item with just a description (i.e no unit amount or quantity) can be created by specifying just a <Description> element that contains at least 1 character.
+ * @property string $Quantity LineItem Quantity (max length = 13).
+ * @property float $UnitAmount Lineitem unit amount. By default, unit amount will be rounded to two decimal places. You can opt in to use four decimal places by adding the querystring parameter unitdp=4 to your query. See the Rounding in Xero guide for more information.
+ * @property string $ItemCode See Items.
+ * @property string $AccountCode See Accounts.
+ * @property string $AccountId See Accounts.
+ * @property string $TaxType Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see TaxTypes.
+ * @property float $TaxAmount The tax amount is auto calculated as a percentage of the LineAmount based on the tax rate. This value can be overriden if the calculated <TaxAmount> is not correct.
+ * @property float $LineAmount The line amount reflects the discounted price if a DiscountRate has been used i.e LineAmount = Quantity Unit Amount ((100 – DiscountRate)/100)  (can’t exceed 9,999,999,999.99).
+ * @property TrackingCategory[] $Tracking Optional Tracking Category – see Tracking. Any LineItem can have a maximum of 2 <TrackingCategory> elements.
+ * @property string $DiscountRate Percentage discount being applied to a line item (only supported on ACCREC invoices – ACC PAY invoices and credit notes in Xero do not support discounts.
+ * @property float $DiscountAmount Discount amount being applied to a line item.
+ * @property string $RepeatingInvoiceID The Xero identifier for a Repeating Invoice.
+ */
 class LineItem extends Remote\Model
 {
-    /**
-     * The Xero generated identifier for a LineItem. If LineItemIDs are not included with line items in an
-     * update request then the line items are deleted and recreated.
-     *
-     * @property string LineItemID
-     */
-
-    /**
-     * Description needs to be at least 1 char long. A line item with just a description (i.e no unit
-     * amount or quantity) can be created by specifying just a <Description> element that
-     * contains at least 1 character.
-     *
-     * @property string Description
-     */
-
-    /**
-     * LineItem Quantity (max length = 13).
-     *
-     * @property string Quantity
-     */
-
-    /**
-     * Lineitem unit amount. By default, unit amount will be rounded to two decimal places. You can opt in
-     * to use four decimal places by adding the querystring parameter unitdp=4 to your query. See the
-     * Rounding in Xero guide for more information.
-     *
-     * @property float UnitAmount
-     */
-
-    /**
-     * See Items.
-     *
-     * @property string ItemCode
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * See Accounts.
-     * 
-     * @property string AccountId
-     */
-
-    /**
-     * Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see
-     * TaxTypes.
-     *
-     * @property string TaxType
-     */
-
-    /**
-     * The tax amount is auto calculated as a percentage of the LineAmount based on the tax
-     * rate. This value can be overriden if the calculated <TaxAmount> is not correct.
-     *
-     * @property float TaxAmount
-     */
-
-    /**
-     * The line amount reflects the discounted price if a DiscountRate has been used i.e LineAmount =
-     * Quantity * Unit Amount * ((100 – DiscountRate)/100)  (can’t exceed 9,999,999,999.99).
-     *
-     * @property float LineAmount
-     */
-
-    /**
-     * Optional Tracking Category – see Tracking. Any LineItem can have a maximum of 2 <TrackingCategory>
-     * elements.
-     *
-     * @property TrackingCategory[] Tracking
-     */
-
-    /**
-     * Percentage discount being applied to a line item (only supported on ACCREC invoices – ACC PAY
-     * invoices and credit notes in Xero do not support discounts.
-     *
-     * @property string DiscountRate
-     */
-
-    /**
-     * Discount amount being applied to a line item.
-     *
-     * @property float DiscountAmount
-     */
-
-    /**
-     * The Xero identifier for a Repeating Invoice.
-     *
-     * @property string RepeatingInvoiceID
-     */
-
     const TYPE_EXCLUSIVE = 'Exclusive';
 
     const TYPE_INCLUSIVE = 'Inclusive';

--- a/src/XeroPHP/Models/Accounting/LinkedTransaction.php
+++ b/src/XeroPHP/Models/Accounting/LinkedTransaction.php
@@ -4,76 +4,20 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SourceTransactionID Filter by the SourceTransactionID. Get all the linked transactions created from a particular ACCPAY invoice.
+ * @property string $SourceLineItemID The line item identifier from the source transaction.
+ * @property string $ContactID Filter by the combination of ContactID and Status. Get all the linked transactions that have been assigned to a particular customer and have a particular status e.g. GET /LinkedTransactions?ContactID=4bb34b03-3378-4bb2-a0ed-6345abf3224e&Status=APPROVED.
+ * @property string $TargetTransactionID Filter by the TargetTransactionID. Get all the linked transactions allocated to a particular ACCREC invoice.
+ * @property string $TargetLineItemID The line item identifier from the target transaction. It is possible to link multiple billable expenses to the same TargetLineItemID.
+ * @property string $LinkedTransactionID The Xero identifier for an Linked Transaction e.g. /LinkedTransactions/297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ * @property string $Status Filter by the combination of ContactID and Status. Get all the linked transactions that have been assigned to a particular customer and have a particular status e.g. GET /LinkedTransactions?ContactID=4bb34b03-3378-4bb2-a0ed-6345abf3224e&Status=APPROVED.
+ * @property string $Type This will always be BILLABLEEXPENSE. More types may be added in future.
+ * @property \DateTimeInterface $UpdatedDateUTC The last modified date in UTC format.
+ * @property string $SourceTransactionTypeCode The Type of the source tranasction. This will be ACCPAY if the linked transaction was created from an invoice and SPEND if it was created from a bank transaction.
+ */
 class LinkedTransaction extends Remote\Model
 {
-    /**
-     * Filter by the SourceTransactionID. Get all the linked transactions created from a particular ACCPAY
-     * invoice.
-     *
-     * @property string SourceTransactionID
-     */
-
-    /**
-     * The line item identifier from the source transaction.
-     *
-     * @property string SourceLineItemID
-     */
-
-    /**
-     * Filter by the combination of ContactID and Status. Get all the linked transactions that have been
-     * assigned to a particular customer and have a particular status e.g. GET
-     * /LinkedTransactions?ContactID=4bb34b03-3378-4bb2-a0ed-6345abf3224e&Status=APPROVED.
-     *
-     * @property string ContactID
-     */
-
-    /**
-     * Filter by the TargetTransactionID. Get all the linked transactions allocated to a particular ACCREC
-     * invoice.
-     *
-     * @property string TargetTransactionID
-     */
-
-    /**
-     * The line item identifier from the target transaction. It is possible to link multiple billable
-     * expenses to the same TargetLineItemID.
-     *
-     * @property string TargetLineItemID
-     */
-
-    /**
-     * The Xero identifier for an Linked Transaction e.g.
-     * /LinkedTransactions/297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string LinkedTransactionID
-     */
-
-    /**
-     * Filter by the combination of ContactID and Status. Get all the linked transactions that have been
-     * assigned to a particular customer and have a particular status e.g. GET
-     * /LinkedTransactions?ContactID=4bb34b03-3378-4bb2-a0ed-6345abf3224e&Status=APPROVED.
-     *
-     * @property string Status
-     */
-
-    /**
-     * This will always be BILLABLEEXPENSE. More types may be added in future.
-     *
-     * @property string Type
-     */
-
-    /**
-     * The last modified date in UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The Type of the source tranasction. This will be ACCPAY if the linked transaction was created from
-     * an invoice and SPEND if it was created from a bank transaction.
-     *
-     * @property string SourceTransactionTypeCode
-     */
     const LINKED_TRANSACTION_STATUS_DRAFT = 'DRAFT';
 
     const LINKED_TRANSACTION_STATUS_APPROVED = 'APPROVED';

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -6,69 +6,22 @@ use XeroPHP\Remote;
 use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\ManualJournal\JournalLine;
 
+/**
+ * @property string $ManualJournalID Xero identifier.
+ * @property string $Narration Description of journal being posted.
+ * @property JournalLine[] $JournalLines See JournalLines.
+ * @property \DateTimeInterface $Date Date journal was posted – YYYY-MM-DD.
+ * @property string $LineAmountTypes NoTax by default if you don’t specify this element. See Line Amount Types.
+ * @property string $Status See Manual Journal Status Codes.
+ * @property string $Url Url link to a source document – shown as “Go to [appName]” in the Xero app.
+ * @property bool $ShowOnCashBasisReports Boolean – default is true if not specified.
+ * @property bool $HasAttachments Boolean to indicate if a manual journal has an attachment.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ */
 class ManualJournal extends Remote\Model
 {
     use AttachmentTrait;
 
-    /**
-     * Xero identifier.
-     *
-     * @property string ManualJournalID
-     */
-
-    /**
-     * Description of journal being posted.
-     *
-     * @property string Narration
-     */
-
-    /**
-     * See JournalLines.
-     *
-     * @property JournalLine[] JournalLines
-     */
-
-    /**
-     * Date journal was posted – YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * NoTax by default if you don’t specify this element. See Line Amount Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * See Manual Journal Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Url link to a source document – shown as “Go to [appName]” in the Xero app.
-     *
-     * @property string Url
-     */
-
-    /**
-     * Boolean – default is true if not specified.
-     *
-     * @property bool ShowOnCashBasisReports
-     */
-
-    /**
-     * Boolean to indicate if a manual journal has an attachment.
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
     const MANUAL_JOURNAL_STATUS_DRAFT = 'DRAFT';
 
     const MANUAL_JOURNAL_STATUS_POSTED = 'POSTED';

--- a/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal/JournalLine.php
@@ -5,46 +5,16 @@ namespace XeroPHP\Models\Accounting\ManualJournal;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\TrackingCategory;
 
+/**
+ * @property string $LineAmount total for line. Debits are positive, credits are negative value.
+ * @property string $AccountCode See Accounts.
+ * @property string $Description Description for journal line.
+ * @property string $TaxType Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see TaxTypes.
+ * @property TrackingCategory[] $Tracking Optional Tracking Category – see Tracking. Any JournalLine can have a maximum of 2 <TrackingCategory> elements.
+ * @property float $TaxAmount The calculated tax amount based on the TaxType and LineAmount.
+ */
 class JournalLine extends Remote\Model
 {
-    /**
-     * total for line. Debits are positive, credits are negative value.
-     *
-     * @property string LineAmount
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Description for journal line.
-     *
-     * @property string Description
-     */
-
-    /**
-     * Used as an override if the default Tax Code for the selected <AccountCode> is not correct – see
-     * TaxTypes.
-     *
-     * @property string TaxType
-     */
-
-    /**
-     * Optional Tracking Category – see Tracking. Any JournalLine can have a maximum of 2
-     * <TrackingCategory> elements.
-     *
-     * @property TrackingCategory[] Tracking
-     */
-
-    /**
-     * The calculated tax amount based on the TaxType and LineAmount.
-     *
-     * @property float TaxAmount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Organisation.php
+++ b/src/XeroPHP/Models/Accounting/Organisation.php
@@ -6,190 +6,40 @@ use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Organisation\PaymentTerm;
 use XeroPHP\Models\Accounting\Organisation\ExternalLink;
 
+/**
+ * @property string $APIKey Display a unique key used for Xero-to-Xero transactions.
+ * @property string $Class OrganisationClass
+ * @property string $Name Display name of organisation shown in Xero.
+ * @property string $LegalName Organisation name shown on Reports.
+ * @property bool $PaysTax Boolean to describe if organisation is registered with a local tax authority i.e. true, false.
+ * @property string $Version See Version Types.
+ * @property string $OrganisationType Organisation Type.
+ * @property string $BaseCurrency Default currency for organisation. See ISO 4217 Currency Codes.
+ * @property string $CountryCode Country code for organisation. See ISO 3166-2 Country Codes.
+ * @property bool $IsDemoCompany Boolean to describe if organisation is a demo company.
+ * @property string $OrganisationStatus Will be set to ACTIVE if you can connect to organisation via the Xero API.
+ * @property string $RegistrationNumber Shows for New Zealand, Australian and UK organisations.
+ * @property string $TaxNumber Shown if set. Displays in the Xero UI as Tax File Number (AU), GST Number (NZ), VAT Number (UK) and Tax ID Number (US & Global).
+ * @property string $FinancialYearEndDay Calendar day e.g. 0-31.
+ * @property string $FinancialYearEndMonth Calendar Month e.g. 1-12.
+ * @property string $SalesTaxBasis The accounting basis used for tax returns. See Sales Tax Basis.
+ * @property string $SalesTaxPeriod The frequency with which tax returns are processed. See Sales Tax Period.
+ * @property string $DefaultSalesTax The default for LineAmountTypes on sales transactions.
+ * @property string $DefaultPurchasesTax The default for LineAmountTypes on purchase transactions.
+ * @property string $PeriodLockDate Shown if set. See lock dates.
+ * @property string $EndOfYearLockDate Shown if set. See lock dates.
+ * @property \DateTimeInterface $CreatedDateUTC Timestamp when the organisation was created in Xero.
+ * @property string $Timezone Timezone specifications.
+ * @property string $OrganisationEntityType Organisation Type.
+ * @property string $ShortCode A unique identifier for the organisation. Potential uses.
+ * @property string $LineOfBusiness Description of business type as defined in Organisation settings.
+ * @property Address[] $Addresses Address details for organisation – see Addresses.
+ * @property Phone[] $Phones Phones details for organisation – see Phones.
+ * @property ExternalLink[] $ExternalLinks Organisation profile links for popular services such as Facebook, Twitter, GooglePlus and LinkedIn. You can also add link to your website here. Shown if Organisation settings  is updated in Xero. See ExternalLinks below.
+ * @property PaymentTerm[] $PaymentTerms Default payment terms for the organisation if set – See Payment Terms below.
+ */
 class Organisation extends Remote\Model
 {
-    /**
-     * Display a unique key used for Xero-to-Xero transactions.
-     *
-     * @property string APIKey
-     */
-
-    /**
-     * OrganisationClass
-     *
-     * @property string Class
-     */
-
-    /**
-     * Display name of organisation shown in Xero.
-     *
-     * @property string Name
-     */
-
-    /**
-     * Organisation name shown on Reports.
-     *
-     * @property string LegalName
-     */
-
-    /**
-     * Boolean to describe if organisation is registered with a local tax authority i.e. true, false.
-     *
-     * @property bool PaysTax
-     */
-
-    /**
-     * See Version Types.
-     *
-     * @property string Version
-     */
-
-    /**
-     * Organisation Type.
-     *
-     * @property string OrganisationType
-     */
-
-    /**
-     * Default currency for organisation. See ISO 4217 Currency Codes.
-     *
-     * @property string BaseCurrency
-     */
-
-    /**
-     * Country code for organisation. See ISO 3166-2 Country Codes.
-     *
-     * @property string CountryCode
-     */
-
-    /**
-     * Boolean to describe if organisation is a demo company.
-     *
-     * @property bool IsDemoCompany
-     */
-
-    /**
-     * Will be set to ACTIVE if you can connect to organisation via the Xero API.
-     *
-     * @property string OrganisationStatus
-     */
-
-    /**
-     * Shows for New Zealand, Australian and UK organisations.
-     *
-     * @property string RegistrationNumber
-     */
-
-    /**
-     * Shown if set. Displays in the Xero UI as Tax File Number (AU), GST Number (NZ), VAT Number (UK) and
-     * Tax ID Number (US & Global).
-     *
-     * @property string TaxNumber
-     */
-
-    /**
-     * Calendar day e.g. 0-31.
-     *
-     * @property string FinancialYearEndDay
-     */
-
-    /**
-     * Calendar Month e.g. 1-12.
-     *
-     * @property string FinancialYearEndMonth
-     */
-
-    /**
-     * The accounting basis used for tax returns. See Sales Tax Basis.
-     *
-     * @property string SalesTaxBasis
-     */
-
-    /**
-     * The frequency with which tax returns are processed. See Sales Tax Period.
-     *
-     * @property string SalesTaxPeriod
-     */
-
-    /**
-     * The default for LineAmountTypes on sales transactions.
-     *
-     * @property string DefaultSalesTax
-     */
-
-    /**
-     * The default for LineAmountTypes on purchase transactions.
-     *
-     * @property string DefaultPurchasesTax
-     */
-
-    /**
-     * Shown if set. See lock dates.
-     *
-     * @property string PeriodLockDate
-     */
-
-    /**
-     * Shown if set. See lock dates.
-     *
-     * @property string EndOfYearLockDate
-     */
-
-    /**
-     * Timestamp when the organisation was created in Xero.
-     *
-     * @property \DateTimeInterface CreatedDateUTC
-     */
-
-    /**
-     * Timezone specifications.
-     *
-     * @property string Timezone
-     */
-
-    /**
-     * Organisation Type.
-     *
-     * @property string OrganisationEntityType
-     */
-
-    /**
-     * A unique identifier for the organisation. Potential uses.
-     *
-     * @property string ShortCode
-     */
-
-    /**
-     * Description of business type as defined in Organisation settings.
-     *
-     * @property string LineOfBusiness
-     */
-
-    /**
-     * Address details for organisation – see Addresses.
-     *
-     * @property Address[] Addresses
-     */
-
-    /**
-     * Phones details for organisation – see Phones.
-     *
-     * @property Phone[] Phones
-     */
-
-    /**
-     * Organisation profile links for popular services such as Facebook, Twitter, GooglePlus and LinkedIn.
-     * You can also add link to your website here. Shown if Organisation settings  is updated in Xero. See
-     * ExternalLinks below.
-     *
-     * @property ExternalLink[] ExternalLinks
-     */
-
-    /**
-     * Default payment terms for the organisation if set – See Payment Terms below.
-     *
-     * @property PaymentTerm[] PaymentTerms
-     */
     const VERSION_TYPE_AU = 'AU';
 
     const VERSION_TYPE_NZ = 'NZ';

--- a/src/XeroPHP/Models/Accounting/Organisation/Bill.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/Bill.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\Accounting\Organisation;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Day Day of Month (0-31).
+ * @property string $Type One of the following values OFFOLLOWINGMONTH/DAYSAFTERBILLDATE/OFCURRENTMONTH.
+ */
 class Bill extends Remote\Model
 {
-    /**
-     * Day of Month (0-31).
-     *
-     * @property string Day
-     */
-
-    /**
-     * One of the following values OFFOLLOWINGMONTH/DAYSAFTERBILLDATE/OFCURRENTMONTH.
-     *
-     * @property string Type
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Organisation/ExternalLink.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/ExternalLink.php
@@ -4,19 +4,12 @@ namespace XeroPHP\Models\Accounting\Organisation;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $LinkType See External link types.
+ * @property string $Url URL for service e.g. http://twitter.com/xeroapi.
+ */
 class ExternalLink extends Remote\Model
 {
-    /**
-     * See External link types.
-     *
-     * @property string LinkType
-     */
-
-    /**
-     * URL for service e.g. http://twitter.com/xeroapi.
-     *
-     * @property string Url
-     */
     const EXTERNAL_LINK_TYPE_FACEBOOK = 'Facebook';
 
     const EXTERNAL_LINK_TYPE_GOOGLEPLUS = 'GooglePlus';

--- a/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/PaymentTerm.php
@@ -4,19 +4,12 @@ namespace XeroPHP\Models\Accounting\Organisation;
 
 use XeroPHP\Remote;
 
+/**
+ * @property Bill $Bills Default payment terms for bills (accounts payable) – see Payment Terms.
+ * @property Sale $Sales Default payment terms for sales invoices(accounts receivable) – see Payment Terms.
+ */
 class PaymentTerm extends Remote\Model
 {
-     /**
-      * Default payment terms for bills (accounts payable) – see Payment Terms.
-      *
-      * @property Bill Bills
-      */
-
-     /**
-      * Default payment terms for sales invoices(accounts receivable) – see Payment Terms.
-      *
-      * @property Sale Sales
-      */
      const DAYSAFTERBILLDATE = 'DAYSAFTERBILLDATE';
 
      const DAYSAFTERBILLMONTH = 'DAYSAFTERBILLMONTH';

--- a/src/XeroPHP/Models/Accounting/Organisation/Sale.php
+++ b/src/XeroPHP/Models/Accounting/Organisation/Sale.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\Accounting\Organisation;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Day Day of Month (0-31).
+ * @property string $Type One of the following values OFFOLLOWINGMONTH/DAYSAFTERBILLDATE/OFCURRENTMONTH.
+ */
 class Sale extends Remote\Model
 {
-    /**
-     * Day of Month (0-31).
-     *
-     * @property string Day
-     */
-
-    /**
-     * One of the following values OFFOLLOWINGMONTH/DAYSAFTERBILLDATE/OFCURRENTMONTH.
-     *
-     * @property string Type
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Overpayment.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment.php
@@ -8,129 +8,32 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 use XeroPHP\Models\Accounting\Overpayment\Allocation;
 
+/**
+ * @property string $Type See Overpayment Types.
+ * @property Contact $Contact See Contacts.
+ * @property \DateTimeInterface $Date The date the overpayment is created YYYY-MM-DD.
+ * @property string $Status See Overpayment Status Codes.
+ * @property string $LineAmountTypes See Overpayment Line Amount Types.
+ * @property LineItem[] $LineItems See Overpayment Line Items.
+ * @property float $SubTotal The subtotal of the overpayment excluding taxes.
+ * @property float $TotalTax The total tax on the overpayment.
+ * @property float $Total The total of the overpayment (subtotal + total tax).
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of last update to the overpayment.
+ * @property string $CurrencyCode Currency used for the overpayment.
+ * @property string $OverpaymentID Xero generated unique identifier.
+ * @property float $CurrencyRate The currency rate for a multicurrency overpayment. If no rate is specified, the XE.com day rate is used.
+ * @property string $RemainingCredit The remaining credit balance on the overpayment.
+ * @property Allocation[] $Allocations See Allocations.
+ * @property Payment[] $Payments See Payments.
+ * @property bool $HasAttachments boolean to indicate if a overpayment has an attachment.
+ * @property string $Reference Deprecated: this property has been removed from the Xero API.
+ * @property string $FullyPaidOnDate Deprecated: this property has been removed from the Xero API.
+ */
 class Overpayment extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string Reference
-     *
-     * @deprecated
-     */
-
-    /**
-     * See Overpayment Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * The date the overpayment is created YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * See Overpayment Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * See Overpayment Line Amount Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * See Overpayment Line Items.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * The subtotal of the overpayment excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * The total tax on the overpayment.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * The total of the overpayment (subtotal + total tax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * UTC timestamp of last update to the overpayment.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Currency used for the overpayment.
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string FullyPaidOnDate
-     *
-     * @deprecated
-     */
-
-    /**
-     * Xero generated unique identifier.
-     *
-     * @property string OverpaymentID
-     */
-
-    /**
-     * The currency rate for a multicurrency overpayment. If no rate is specified, the XE.com day rate is
-     * used.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * The remaining credit balance on the overpayment.
-     *
-     * @property string RemainingCredit
-     */
-
-    /**
-     * See Allocations.
-     *
-     * @property Allocation[] Allocations
-     */
-
-    /**
-     * See Payments.
-     *
-     * @property Payment[] Payments
-     */
-
-    /**
-     * boolean to indicate if a overpayment has an attachment.
-     *
-     * @property bool HasAttachments
-     */
     const TYPE_RECEIVE_OVERPAYMENT = 'RECEIVE-OVERPAYMENT';
 
     const TYPE_SPEND_OVERPAYMENT = 'SPEND-OVERPAYMENT';

--- a/src/XeroPHP/Models/Accounting/Overpayment/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/Overpayment/Allocation.php
@@ -5,27 +5,13 @@ namespace XeroPHP\Models\Accounting\Overpayment;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Invoice;
 
+/**
+ * @property Invoice $Invoice the invoice the overpayment is being allocated against.
+ * @property float $AppliedAmount the amount being applied to the invoice.
+ * @property \DateTimeInterface $Date the date the overpayment is applied YYYY-MM-DD (read-only). This will be the latter of the invoice date and the overpayment date.
+ */
 class Allocation extends Remote\Model
 {
-    /**
-     * the invoice the overpayment is being allocated against.
-     *
-     * @property Invoice Invoice
-     */
-
-    /**
-     * the amount being applied to the invoice.
-     *
-     * @property float AppliedAmount
-     */
-
-    /**
-     * the date the overpayment is applied YYYY-MM-DD (read-only). This will be the latter of the invoice
-     * date and the overpayment date.
-     *
-     * @property \DateTimeInterface Date
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Payment.php
+++ b/src/XeroPHP/Models/Accounting/Payment.php
@@ -5,92 +5,27 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Traits\HistoryTrait;
 
+/**
+ * @property Invoice $Invoice
+ * @property CreditNote $CreditNote
+ * @property Prepayment $Prepayment
+ * @property Overpayment $Overpayment
+ * @property Account $Account
+ * @property \DateTimeInterface $Date Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06.
+ * @property float $CurrencyRate Exchange rate when payment is received. Only used for non base currency invoices and credit notes e.g. 0.7500.
+ * @property float $Amount The amount of the payment. Must be less than or equal to the outstanding amount owing on the invoice e.g. 200.00.
+ * @property string $Reference An optional description for the payment e.g. Direct Debit.
+ * @property string $BatchPayment An optional description to appear on a payee bank statement when Payment is a child of BatchPayment.
+ * @property string $IsReconciled An optional parameter for the payment. A boolean indicating whether you would like the payment to be created as reconciled when using PUT, or whether a payment has been reconciled when using GET.
+ * @property string $Status The status of the payment.
+ * @property string $PaymentType See Payment Types.
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of last update to the payment.
+ * @property string $PaymentID The Xero identifier for an Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ */
 class Payment extends Remote\Model
 {
     use HistoryTrait;
 
-    /**
-     * @property Invoice Invoice
-     */
-
-    /**
-     * @property CreditNote CreditNote
-     */
-
-    /**
-     * @property Prepayment Prepayment
-     */
-
-    /**
-     * @property Overpayment Overpayment
-     */
-
-    /**
-     * @property Account Account
-     */
-
-    /**
-     * Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Exchange rate when payment is received. Only used for non base currency invoices and credit notes
-     * e.g. 0.7500.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * The amount of the payment. Must be less than or equal to the outstanding amount owing on the invoice
-     * e.g. 200.00.
-     *
-     * @property float Amount
-     */
-
-    /**
-     * An optional description for the payment e.g. Direct Debit.
-     *
-     * @property string Reference
-     */
-    
-    /**
-     * An optional description to appear on a payee bank statement when Payment is a child of BatchPayment.
-     *
-     * @property string BatchPayment
-     */
-
-    /**
-     * An optional parameter for the payment. A boolean indicating whether you would like the payment to be
-     * created as reconciled when using PUT, or whether a payment has been reconciled when using GET.
-     *
-     * @property string IsReconciled
-     */
-
-    /**
-     * The status of the payment.
-     *
-     * @property string Status
-     */
-
-    /**
-     * See Payment Types.
-     *
-     * @property string PaymentType
-     */
-
-    /**
-     * UTC timestamp of last update to the payment.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The Xero identifier for an Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string PaymentID
-     */
     const PAYMENT_STATUS_AUTHORISED = 'AUTHORISED';
 
     const PAYMENT_STATUS_DELETED = 'DELETED';

--- a/src/XeroPHP/Models/Accounting/PaymentService.php
+++ b/src/XeroPHP/Models/Accounting/PaymentService.php
@@ -4,22 +4,12 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PaymentServiceID Xero identifier
+ * @property string $Name Name of Payment Service
+ */
 class PaymentService extends Remote\Model
 {
-
-    /**
-     * Xero identifier
-     *
-     * @property string PaymentServiceID
-     */
-
-    /**
-     * Name of Payment Service
-     *
-     * @property string Name
-     */
-
-
     /**
      * Get the resource uri of the class (Contacts) etc
      *

--- a/src/XeroPHP/Models/Accounting/Phone.php
+++ b/src/XeroPHP/Models/Accounting/Phone.php
@@ -4,29 +4,14 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PhoneType
+ * @property string $PhoneNumber  max length = 50.
+ * @property string $PhoneAreaCode  max length = 10.
+ * @property string $PhoneCountryCode  max length = 20.
+ */
 class Phone extends Remote\Model
 {
-    /**
-     * @property string PhoneType
-     */
-
-    /**
-     *  max length = 50.
-     *
-     * @property string PhoneNumber
-     */
-
-    /**
-     *  max length = 10.
-     *
-     * @property string PhoneAreaCode
-     */
-
-    /**
-     *  max length = 20.
-     *
-     * @property string PhoneCountryCode
-     */
     const PHONE_TYPE_DEFAULT = 'DEFAULT';
 
     const PHONE_TYPE_DDI = 'DDI';

--- a/src/XeroPHP/Models/Accounting/Prepayment.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment.php
@@ -8,123 +8,31 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 use XeroPHP\Models\Accounting\Prepayment\Allocation;
 
+/**
+ * @property string $Type See Prepayment Types.
+ * @property Contact $Contact See Contacts.
+ * @property \DateTimeInterface $Date The date the prepayment is created YYYY-MM-DD.
+ * @property string $Status See Prepayment Status Codes.
+ * @property string $LineAmountTypes See Prepayment Line Amount Types.
+ * @property LineItem[] $LineItems See Prepayment Line Items.
+ * @property float $SubTotal The subtotal of the prepayment excluding taxes.
+ * @property float $TotalTax The total tax on the prepayment.
+ * @property float $Total The total of the prepayment(subtotal + total tax).
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of last update to the prepayment.
+ * @property string $CurrencyCode Currency used for the prepayment.
+ * @property string $PrepaymentID Xero generated unique identifier.
+ * @property float $CurrencyRate The currency rate for a multicurrency prepayment. If no rate is specified, the XE.com day rate is used.
+ * @property string $RemainingCredit The remaining credit balance on the prepayment.
+ * @property Allocation[] $Allocations See Allocations.
+ * @property bool $HasAttachments boolean to indicate if a prepayment has an attachment.
+ * @property string $Reference Deprecated: this property has been removed from the Xero API.
+ * @property string $FullyPaidOnDate Deprecated: this property has been removed from the Xero API.
+ */
 class Prepayment extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string Reference
-     *
-     * @deprecated
-     */
-
-    /**
-     * See Prepayment Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * The date the prepayment is created YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * See Prepayment Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * See Prepayment Line Amount Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * See Prepayment Line Items.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * The subtotal of the prepayment excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * The total tax on the prepayment.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * The total of the prepayment(subtotal + total tax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * UTC timestamp of last update to the prepayment.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Currency used for the prepayment.
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string FullyPaidOnDate
-     *
-     * @deprecated
-     */
-
-    /**
-     * Xero generated unique identifier.
-     *
-     * @property string PrepaymentID
-     */
-
-    /**
-     * The currency rate for a multicurrency prepayment. If no rate is specified, the XE.com day rate is
-     * used.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * The remaining credit balance on the prepayment.
-     *
-     * @property string RemainingCredit
-     */
-
-    /**
-     * See Allocations.
-     *
-     * @property Allocation[] Allocations
-     */
-
-    /**
-     * boolean to indicate if a prepayment has an attachment.
-     *
-     * @property bool HasAttachments
-     */
     const TYPE_RECEIVE_PREPAYMENT = 'RECEIVE-PREPAYMENT';
 
     const TYPE_SPEND_PREPAYMENT = 'SPEND-PREPAYMENT';

--- a/src/XeroPHP/Models/Accounting/Prepayment/Allocation.php
+++ b/src/XeroPHP/Models/Accounting/Prepayment/Allocation.php
@@ -5,27 +5,13 @@ namespace XeroPHP\Models\Accounting\Prepayment;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\Invoice;
 
+/**
+ * @property Invoice $Invoice the invoice the prepayment is being allocated against.
+ * @property float $AppliedAmount the amount being applied to the invoice.
+ * @property \DateTimeInterface $Date the date the prepayment is applied YYYY-MM-DD (read-only). This will be the latter of the invoice date and the prepayment date.
+ */
 class Allocation extends Remote\Model
 {
-    /**
-     * the invoice the prepayment is being allocated against.
-     *
-     * @property Invoice Invoice
-     */
-
-    /**
-     * the amount being applied to the invoice.
-     *
-     * @property float AppliedAmount
-     */
-
-    /**
-     * the date the prepayment is applied YYYY-MM-DD (read-only). This will be the latter of the invoice
-     * date and the prepayment date.
-     *
-     * @property \DateTimeInterface Date
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/PurchaseOrder.php
+++ b/src/XeroPHP/Models/Accounting/PurchaseOrder.php
@@ -8,160 +8,38 @@ use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 
+/**
+ * @property Contact $Contact The PurchaseOrders endpoint does not create new contacts. You need to provide the ContactID or ContactNumber of an existing contact. For more information on creating contacts see Contacts.
+ * @property LineItem[] $LineItems See LineItems.
+ * @property \DateTimeInterface $Date Date purchase order was issued – YYYY-MM-DD. Learn more.
+ * @property \DateTimeInterface $DeliveryDate Date the goods are to be delivered – YYYY-MM-DD.
+ * @property string $LineAmountTypes Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types.
+ * @property string $PurchaseOrderNumber Unique alpha numeric code identifying purchase order (when missing will auto-generate from your Organisation Invoice Settings).
+ * @property string $Reference Additional reference number.
+ * @property string $BrandingThemeID See BrandingThemes.
+ * @property string $CurrencyCode The currency that purchase order has been raised in (see Currencies).
+ * @property string $Status See Purchase Order Status Codes.
+ * @property bool $SentToContact Boolean to set whether the purchase order should be marked as “sent”. This can be set only on purchase orders that have been approved or billed.
+ * @property string $DeliveryAddress The address the goods are to be delivered to.
+ * @property string $AttentionTo The person that the delivery is going to.
+ * @property string $Telephone The phone number for the person accepting the delivery.
+ * @property string $DeliveryInstructions A free text feild for instructions (500 characters max).
+ * @property \DateTimeInterface $ExpectedArrivalDate The date the goods are expected to arrive.
+ * @property string $PurchaseOrderID Xero generated unique identifier for purchase order.
+ * @property float $CurrencyRate The currency rate for a multicurrency purchase order. As no rate can be specified, the XE.com day rate is used.
+ * @property float $SubTotal Total of purchase order excluding taxes.
+ * @property float $TotalTax Total tax on purchase order.
+ * @property float $Total Total of Purchase Order tax inclusive (i.e. SubTotal + TotalTax).
+ * @property float $TotalDiscount Total of discounts applied on the purchase order line items.
+ * @property bool $HasAttachments boolean to indicate if a purchase order has an attachment.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ */
 class PurchaseOrder extends Remote\Model
 {
     use PDFTrait;
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * The PurchaseOrders endpoint does not create new contacts. You need to provide the ContactID or
-     * ContactNumber of an existing contact. For more information on creating contacts see Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * See LineItems.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * Date purchase order was issued – YYYY-MM-DD. Learn more.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Date the goods are to be delivered – YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface DeliveryDate
-     */
-
-    /**
-     * Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount
-     * Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * Unique alpha numeric code identifying purchase order (when missing will auto-generate from your
-     * Organisation Invoice Settings).
-     *
-     * @property string PurchaseOrderNumber
-     */
-
-    /**
-     * Additional reference number.
-     *
-     * @property string Reference
-     */
-
-    /**
-     * See BrandingThemes.
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * The currency that purchase order has been raised in (see Currencies).
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * See Purchase Order Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Boolean to set whether the purchase order should be marked as “sent”. This can be set only on
-     * purchase orders that have been approved or billed.
-     *
-     * @property bool SentToContact
-     */
-
-    /**
-     * The address the goods are to be delivered to.
-     *
-     * @property string DeliveryAddress
-     */
-
-    /**
-     * The person that the delivery is going to.
-     *
-     * @property string AttentionTo
-     */
-
-    /**
-     * The phone number for the person accepting the delivery.
-     *
-     * @property string Telephone
-     */
-
-    /**
-     * A free text feild for instructions (500 characters max).
-     *
-     * @property string DeliveryInstructions
-     */
-
-    /**
-     * The date the goods are expected to arrive.
-     *
-     * @property \DateTimeInterface ExpectedArrivalDate
-     */
-
-    /**
-     * Xero generated unique identifier for purchase order.
-     *
-     * @property string PurchaseOrderID
-     */
-
-    /**
-     * The currency rate for a multicurrency purchase order. As no rate can be specified, the XE.com day
-     * rate is used.
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * Total of purchase order excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on purchase order.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of Purchase Order tax inclusive (i.e. SubTotal + TotalTax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * Total of discounts applied on the purchase order line items.
-     *
-     * @property float TotalDiscount
-     */
-
-    /**
-     * boolean to indicate if a purchase order has an attachment.
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
     const PURCHASE_ORDER_STATUS_DRAFT = 'DRAFT';
 
     const PURCHASE_ORDER_STATUS_SUBMITTED = 'SUBMITTED';

--- a/src/XeroPHP/Models/Accounting/Quote.php
+++ b/src/XeroPHP/Models/Accounting/Quote.php
@@ -8,131 +8,33 @@ use XeroPHP\Traits\PDFTrait;
 use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Models\Accounting\LineItem;
 
+/**
+ * @property Contact $Contact See Contacts
+ * @property \DateTimeInterface $Date Date quote was issued – YYYY-MM-DD
+ * @property \DateTimeInterface $ExpiryDate Date quote expires – YYYY-MM-DD
+ * @property string $Status 	See Quote Status Codes
+ * @property string $LineAmountTypes See Line Amount Types
+ * @property LineItem[] $LineItems See LineItems. The LineItems collection can contain any number of individual LineItem sub-elements.
+ * @property float $SubTotal Total of quote excluding taxes
+ * @property float $TotalTax Total tax on quote
+ * @property float $Total Total of Quote tax inclusive (i.e. SubTotal + TotalTax)
+ * @property float $TotalDiscount Total of discounts applied on the quote line items
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ * @property string $CurrencyCode The currency that quote has been raised in (see Currencies).
+ * @property float $CurrencyRate The currency rate for a multicurrency quote
+ * @property string $QuoteID Xero generated unique identifier for a quote
+ * @property string $QuoteNumber Unique alpha numeric code identifying a quote
+ * @property string $Reference Additional reference number
+ * @property string $BrandingThemeID See BrandingThemes
+ * @property string $Title The title of the quote
+ * @property string $Summary The summary of the quote
+ * @property string $Terms The terms of the quote
+ */
 class Quote extends Remote\Model
 {
     use PDFTrait;
     use AttachmentTrait;
     use HistoryTrait;
-
-    /**
-     * See Contacts
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * Date quote was issued – YYYY-MM-DD
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * Date quote expires – YYYY-MM-DD
-     *
-     * @property \DateTimeInterface ExpiryDate
-     */
-
-    /**
-     * 	See Quote Status Codes
-     *
-     * @property string Status
-     */
-
-    /**
-     * See Line Amount Types
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * See LineItems. The LineItems collection can contain any number of individual LineItem sub-elements.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * Total of quote excluding taxes
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on quote
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of Quote tax inclusive (i.e. SubTotal + TotalTax)
-     *
-     * @property float Total
-     */
-
-    /**
-     * Total of discounts applied on the quote line items
-     *
-     * @property float TotalDiscount
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The currency that quote has been raised in (see Currencies).
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * The currency rate for a multicurrency quote
-     *
-     * @property float CurrencyRate
-     */
-
-    /**
-     * Xero generated unique identifier for a quote
-     *
-     * @property string QuoteID
-     */
-
-    /**
-     * Unique alpha numeric code identifying a quote
-     *
-     * @property string QuoteNumber
-     */
-
-    /**
-     * Additional reference number
-     *
-     * @property string Reference
-     */
-
-    /**
-     * See BrandingThemes
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * The title of the quote
-     *
-     * @property string Title
-     */
-
-    /**
-     * The summary of the quote
-     *
-     * @property string Summary
-     */
-
-    /**
-     * The terms of the quote
-     *
-     * @property string Terms
-     */
 
     const QUOTE_STATUS_DRAFT = 'DRAFT';
 

--- a/src/XeroPHP/Models/Accounting/Receipt.php
+++ b/src/XeroPHP/Models/Accounting/Receipt.php
@@ -7,100 +7,28 @@ use XeroPHP\Traits\HistoryTrait;
 use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 
+/**
+ * @property \DateTimeInterface $Date Date of receipt – YYYY-MM-DD.
+ * @property Contact $Contact See Contacts.
+ * @property LineItem[] $LineItems See LineItems.
+ * @property User $User The user in the organisation that the expense claim receipt is for. See Users.
+ * @property string $Reference Additional reference number.
+ * @property string $LineAmountTypes See Line Amount Types.
+ * @property float $SubTotal Total of receipt excluding taxes.
+ * @property float $TotalTax Total tax on receipt.
+ * @property float $Total Total of receipt tax inclusive (i.e. SubTotal + TotalTax).
+ * @property string $ReceiptID Xero generated unique identifier for receipt.
+ * @property string $Status Current status of receipt – see status types.
+ * @property string $ReceiptNumber Xero generated sequence number for receipt in current claim for a given user.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date UTC format.
+ * @property bool $HasAttachments boolean to indicate if a receipt has an attachment.
+ * @property string $Url URL link to a source document – shown as “Go to [appName]” in the Xero app.
+ */
 class Receipt extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
 
-    /**
-     * Date of receipt – YYYY-MM-DD.
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * See LineItems.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * The user in the organisation that the expense claim receipt is for. See Users.
-     *
-     * @property User User
-     */
-
-    /**
-     * Additional reference number.
-     *
-     * @property string Reference
-     */
-
-    /**
-     * See Line Amount Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * Total of receipt excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on receipt.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of receipt tax inclusive (i.e. SubTotal + TotalTax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * Xero generated unique identifier for receipt.
-     *
-     * @property string ReceiptID
-     */
-
-    /**
-     * Current status of receipt – see status types.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Xero generated sequence number for receipt in current claim for a given user.
-     *
-     * @property string ReceiptNumber
-     */
-
-    /**
-     * Last modified date UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * boolean to indicate if a receipt has an attachment.
-     *
-     * @property bool HasAttachments
-     */
-
-    /**
-     * URL link to a source document – shown as “Go to [appName]” in the Xero app.
-     *
-     * @property string Url
-     */
     const RECEIPT_STATUS_DRAFT = 'DRAFT';
 
     const RECEIPT_STATUS_SUBMITTED = 'SUBMITTED';

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice.php
@@ -8,95 +8,26 @@ use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\LineItem;
 use XeroPHP\Models\Accounting\RepeatingInvoice\Schedule;
 
+/**
+ * @property string $Type See Invoice Types.
+ * @property Contact $Contact See Contacts.
+ * @property Schedule $Schedule See Schedule.
+ * @property LineItem[] $LineItems See LineItems.
+ * @property string $LineAmountTypes Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount Types.
+ * @property string $Reference ACCREC only – additional reference number.
+ * @property string $BrandingThemeID See BrandingThemes.
+ * @property string $CurrencyCode The currency that invoice has been raised in (see Currencies).
+ * @property string $Status One of the following : DRAFT or AUTHORISED – See Invoice Status Codes.
+ * @property float $SubTotal Total of invoice excluding taxes.
+ * @property float $TotalTax Total tax on invoice.
+ * @property float $Total Total of Invoice tax inclusive (i.e. SubTotal + TotalTax).
+ * @property string $RepeatingInvoiceID Xero generated unique identifier for repeating invoice template.
+ * @property bool $HasAttachments boolean to indicate if an invoice has an attachment.
+ */
 class RepeatingInvoice extends Remote\Model
 {
     use AttachmentTrait;
     use HistoryTrait;
-
-    /**
-     * See Invoice Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * See Contacts.
-     *
-     * @property Contact Contact
-     */
-
-    /**
-     * See Schedule.
-     *
-     * @property Schedule Schedule
-     */
-
-    /**
-     * See LineItems.
-     *
-     * @property LineItem[] LineItems
-     */
-
-    /**
-     * Line amounts are exclusive of tax by default if you don’t specify this element. See Line Amount
-     * Types.
-     *
-     * @property string LineAmountTypes
-     */
-
-    /**
-     * ACCREC only – additional reference number.
-     *
-     * @property string Reference
-     */
-
-    /**
-     * See BrandingThemes.
-     *
-     * @property string BrandingThemeID
-     */
-
-    /**
-     * The currency that invoice has been raised in (see Currencies).
-     *
-     * @property string CurrencyCode
-     */
-
-    /**
-     * One of the following : DRAFT or AUTHORISED – See Invoice Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Total of invoice excluding taxes.
-     *
-     * @property float SubTotal
-     */
-
-    /**
-     * Total tax on invoice.
-     *
-     * @property float TotalTax
-     */
-
-    /**
-     * Total of Invoice tax inclusive (i.e. SubTotal + TotalTax).
-     *
-     * @property float Total
-     */
-
-    /**
-     * Xero generated unique identifier for repeating invoice template.
-     *
-     * @property string RepeatingInvoiceID
-     */
-
-    /**
-     * boolean to indicate if an invoice has an attachment.
-     *
-     * @property bool HasAttachments
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc.

--- a/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
+++ b/src/XeroPHP/Models/Accounting/RepeatingInvoice/Schedule.php
@@ -4,51 +4,17 @@ namespace XeroPHP\Models\Accounting\RepeatingInvoice;
 
 use XeroPHP\Remote;
 
+/**
+ * @property int $Period Integer used with the unit e.g. 1 (every 1 week), 2 (every 2 months).
+ * @property string $Unit One of the following : WEEKLY or MONTHLY.
+ * @property int $DueDate Integer used with due date type e.g 20 (of following month), 31 (of current month).
+ * @property string $DueDateType Get the due date type.
+ * @property \DateTimeInterface $StartDate Date the first invoice of the current version of the repeating schedule was generated (changes when repeating invoice is edited).
+ * @property \DateTimeInterface $NextScheduledDate The calendar date of the next invoice in the schedule to be generated.
+ * @property \DateTimeInterface $EndDate Invoice end date – only returned if the template has an end date set.
+ */
 class Schedule extends Remote\Model
 {
-    /**
-     * Integer used with the unit e.g. 1 (every 1 week), 2 (every 2 months).
-     *
-     * @property int Period
-     */
-
-    /**
-     * One of the following : WEEKLY or MONTHLY.
-     *
-     * @property string Unit
-     */
-
-    /**
-     * Integer used with due date type e.g 20 (of following month), 31 (of current month).
-     *
-     * @property int DueDate
-     */
-
-    /**
-     * Get the due date type.
-     *
-     * @property string DueDateType
-     */
-
-    /**
-     * Date the first invoice of the current version of the repeating schedule was generated (changes when
-     * repeating invoice is edited).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * The calendar date of the next invoice in the schedule to be generated.
-     *
-     * @property \DateTimeInterface NextScheduledDate
-     */
-
-    /**
-     * Invoice end date – only returned if the template has an end date set.
-     *
-     * @property \DateTimeInterface EndDate
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/Report/Report.php
+++ b/src/XeroPHP/Models/Accounting/Report/Report.php
@@ -4,44 +4,16 @@ namespace XeroPHP\Models\Accounting\Report;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ReportID Xero identifier.
+ * @property string $ReportName Report Name.
+ * @property string $ReportType Report Type.
+ * @property array $ReportTitles Array of the title of this report (one title will be on multiple lines).
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified date in UTC format.
+ * @property string $Rows All the rows of data contained in the report.
+ */
 abstract class Report extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string ReportID
-     */
-
-    /**
-     * Report Name.
-     *
-     * @property string ReportName
-     */
-
-    /**
-     * Report Type.
-     *
-     * @property string ReportType
-     */
-
-    /**
-     * Array of the title of this report (one title will be on multiple lines).
-     *
-     * @property array ReportTitles
-     */
-
-    /**
-     * Last modified date in UTC format.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * All the rows of data contained in the report.
-     *
-     * @property string Rows
-     */
-
     /**
      * Get the root node name.  Just the unqualified classname.
      *

--- a/src/XeroPHP/Models/Accounting/TaxRate.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate.php
@@ -5,79 +5,22 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\TaxRate\TaxComponent;
 
+/**
+ * @property string $Name Name of tax rate.
+ * @property string $TaxType See Tax Types – can only be used on update calls.
+ * @property TaxComponent[] $TaxComponents See TaxComponents.
+ * @property string $Status See Status Codes.
+ * @property string $ReportTaxType See ReportTaxTypes.
+ * @property bool $CanApplyToAssets Boolean to describe if tax rate can be used for asset accounts i.e. true,false.
+ * @property bool $CanApplyToEquity Boolean to describe if tax rate can be used for equity accounts i.e. true,false.
+ * @property bool $CanApplyToExpenses Boolean to describe if tax rate can be used for expense accounts i.e. true,false.
+ * @property bool $CanApplyToLiabilities Boolean to describe if tax rate can be used for liability accounts i.e. true,false.
+ * @property bool $CanApplyToRevenue Boolean to describe if tax rate can be used for revenue accounts i.e. true,false.
+ * @property float $DisplayTaxRate Tax Rate (decimal to 4dp) e.g 12.5000.
+ * @property float $EffectiveRate Effective Tax Rate (decimal to 4dp) e.g 12.5000.
+ */
 class TaxRate extends Remote\Model
 {
-    /**
-     * Name of tax rate.
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Tax Types – can only be used on update calls.
-     *
-     * @property string TaxType
-     */
-
-    /**
-     * See TaxComponents.
-     *
-     * @property TaxComponent[] TaxComponents
-     */
-
-    /**
-     * See Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * See ReportTaxTypes.
-     *
-     * @property string ReportTaxType
-     */
-
-    /**
-     * Boolean to describe if tax rate can be used for asset accounts i.e. true,false.
-     *
-     * @property bool CanApplyToAssets
-     */
-
-    /**
-     * Boolean to describe if tax rate can be used for equity accounts i.e. true,false.
-     *
-     * @property bool CanApplyToEquity
-     */
-
-    /**
-     * Boolean to describe if tax rate can be used for expense accounts i.e. true,false.
-     *
-     * @property bool CanApplyToExpenses
-     */
-
-    /**
-     * Boolean to describe if tax rate can be used for liability accounts i.e. true,false.
-     *
-     * @property bool CanApplyToLiabilities
-     */
-
-    /**
-     * Boolean to describe if tax rate can be used for revenue accounts i.e. true,false.
-     *
-     * @property bool CanApplyToRevenue
-     */
-
-    /**
-     * Tax Rate (decimal to 4dp) e.g 12.5000.
-     *
-     * @property float DisplayTaxRate
-     */
-
-    /**
-     * Effective Tax Rate (decimal to 4dp) e.g 12.5000.
-     *
-     * @property float EffectiveRate
-     */
     const TAX_STATUS_ACTIVE = 'ACTIVE';
 
     const TAX_STATUS_DELETED = 'DELETED';

--- a/src/XeroPHP/Models/Accounting/TaxRate/TaxComponent.php
+++ b/src/XeroPHP/Models/Accounting/TaxRate/TaxComponent.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\Accounting\TaxRate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name Name of Tax Component.
+ * @property float $Rate Tax Rate (up to 4dp).
+ * @property bool $IsCompound Boolean to describe if Tax rate is compounded.Learn more.
+ */
 class TaxComponent extends Remote\Model
 {
-    /**
-     * Name of Tax Component.
-     *
-     * @property string Name
-     */
-
-    /**
-     * Tax Rate (up to 4dp).
-     *
-     * @property float Rate
-     */
-
-    /**
-     * Boolean to describe if Tax rate is compounded.Learn more.
-     *
-     * @property bool IsCompound
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Accounting/TrackingCategory.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory.php
@@ -4,43 +4,20 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Models\Accounting\TrackingCategory\TrackingOption;
 
+/**
+ * @property string $TrackingCategoryID The Xero identifier for a tracking categorye.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
+ * @property string $Name The name of the tracking category e.g. Department, Region (max length = 100)
+ * @property string $Status The status of a tracking category
+ * @property TrackingOption[] $Options See Tracking Options
+ * @property string $Option Selected Option name
+ */
 class TrackingCategory extends Remote\Model
 {
-
-    /**
-     * The Xero identifier for a tracking categorye.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
-     *
-     * @property string TrackingCategoryID
-     */
-
-    /**
-     * The name of the tracking category e.g. Department, Region (max length = 100)
-     *
-     * @property string Name
-     */
-
-    /**
-     * The status of a tracking category
-     *
-     * @property string Status
-     */
     const TRACKING_CATEGORY_STATUS_ACTIVE = "ACTIVE";
 
     const TRACKING_CATEGORY_STATUS_ARCHIVED = "ARCHIVED";
 
     const TRACKING_CATEGORY_STATUS_DELETED = "DELETED";
-
-    /**
-     * See Tracking Options
-     *
-     * @property TrackingOption[] Options
-     */
-
-    /**
-     * Selected Option name
-     *
-     * @property string Option
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc

--- a/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
+++ b/src/XeroPHP/Models/Accounting/TrackingCategory/TrackingOption.php
@@ -3,26 +3,13 @@ namespace XeroPHP\Models\Accounting\TrackingCategory;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TrackingOptionID The Xero identifier for a tracking optione.g. ae777a87-5ef3-4fa0-a4f0-d10e1f13073a
+ * @property string $Name The name of the tracking option e.g. Marketing, East (max length = 50)
+ * @property string $Status The status of a tracking option
+ */
 class TrackingOption extends Remote\Model
 {
-    /**
-     * The Xero identifier for a tracking optione.g. ae777a87-5ef3-4fa0-a4f0-d10e1f13073a
-     *
-     * @property string TrackingOptionID
-     */
-
-    /**
-     * The name of the tracking option e.g. Marketing, East (max length = 50)
-     *
-     * @property string Name
-     */
-
-    /**
-     * The status of a tracking option
-     *
-     * @property string Status
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc
      *

--- a/src/XeroPHP/Models/Accounting/User.php
+++ b/src/XeroPHP/Models/Accounting/User.php
@@ -4,50 +4,17 @@ namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $UserID Xero identifier.
+ * @property string $EmailAddress Email address of user.
+ * @property string $FirstName First name of user.
+ * @property string $LastName Last name of user.
+ * @property \DateTimeInterface $UpdatedDateUTC Timestamp of last change to user.
+ * @property bool $IsSubscriber Boolean to indicate if user is the subscriber.
+ * @property string $OrganisationRole User role (see Types).
+ */
 class User extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string UserID
-     */
-
-    /**
-     * Email address of user.
-     *
-     * @property string EmailAddress
-     */
-
-    /**
-     * First name of user.
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of user.
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Timestamp of last change to user.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * Boolean to indicate if user is the subscriber.
-     *
-     * @property bool IsSubscriber
-     */
-
-    /**
-     * User role (see Types).
-     *
-     * @property string OrganisationRole
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Assets/AssetType.php
+++ b/src/XeroPHP/Models/Assets/AssetType.php
@@ -5,51 +5,17 @@ namespace XeroPHP\Models\Assets;
 use XeroPHP\Remote;
 use XeroPHP\Models\Assets\AssetType\BookDepreciationSetting;
 
+/**
+ * @property string $assetTypeName The name of the asset type.
+ * @property string $fixedAssetAccountId The asset account for fixed assets of this type.
+ * @property string $depreciationExpenseAccountId The expense account for the depreciation of fixed assets of this type.
+ * @property string $accumulatedDepreciationAccountId The account for accumulated depreciation of fixed assets of this type.
+ * @property BookDepreciationSetting $BookDepreciationSetting See bookDepreciationSetting.
+ * @property string $assetTypeId Xero generated unique identifier for asset types.
+ * @property string $Locks All asset types that have accumulated  depreciation for any assets that use them are deemed ‘locked’ and cannot be removed.
+ */
 class AssetType extends Remote\Model
 {
-    /**
-     * The name of the asset type.
-     *
-     * @property string assetTypeName
-     */
-
-    /**
-     * The asset account for fixed assets of this type.
-     *
-     * @property string fixedAssetAccountId
-     */
-
-    /**
-     * The expense account for the depreciation of fixed assets of this type.
-     *
-     * @property string depreciationExpenseAccountId
-     */
-
-    /**
-     * The account for accumulated depreciation of fixed assets of this type.
-     *
-     * @property string accumulatedDepreciationAccountId
-     */
-
-    /**
-     * See bookDepreciationSetting.
-     *
-     * @property BookDepreciationSetting BookDepreciationSetting
-     */
-
-    /**
-     * Xero generated unique identifier for asset types.
-     *
-     * @property string assetTypeId
-     */
-
-    /**
-     * All asset types that have accumulated  depreciation for any assets that use them are deemed
-     * ‘locked’ and cannot be removed.
-     *
-     * @property string Locks
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
+++ b/src/XeroPHP/Models/Assets/AssetType/BookDepreciationSetting.php
@@ -4,38 +4,15 @@ namespace XeroPHP\Models\Assets\AssetType;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $depreciationMethod The method of depreciation applied to this asset. See Depreciation Methods.
+ * @property string $averagingMethod The method of averaging applied to this asset. See Averaging Methods.
+ * @property float $depreciationRate The rate of depreciation (e.g. 0.05).
+ * @property float[] $effectiveLifeYears The effective life of the assets of this type in years. Not required if using depreciationRate.
+ * @property string $depreciationCalculationMethod See Depreciation Calculation Methods.
+ */
 class BookDepreciationSetting extends Remote\Model
 {
-    /**
-     * The method of depreciation applied to this asset. See Depreciation Methods.
-     *
-     * @property string depreciationMethod
-     */
-
-    /**
-     * The method of averaging applied to this asset. See Averaging Methods.
-     *
-     * @property string averagingMethod
-     */
-
-    /**
-     * The rate of depreciation (e.g. 0.05).
-     *
-     * @property float depreciationRate
-     */
-
-    /**
-     * The effective life of the assets of this type in years. Not required if using depreciationRate.
-     *
-     * @property float[] effectiveLifeYears
-     */
-
-    /**
-     * See Depreciation Calculation Methods.
-     *
-     * @property string depreciationCalculationMethod
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Assets/Setting.php
+++ b/src/XeroPHP/Models/Assets/Setting.php
@@ -4,54 +4,18 @@ namespace XeroPHP\Models\Assets;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $assetNumberPrefix The prefix used for fixed asset numbers (“FA-” by default).
+ * @property string $assetNumberSequence The next available sequence number.
+ * @property \DateTimeInterface $assetStartDate The date depreciation calculations started on registered fixed assets in Xero.
+ * @property \DateTimeInterface $lastDepreciationDate The last depreciation date.
+ * @property string $defaultGainOnDisposalAccountId Default account that gains are posted to.
+ * @property string $defaultLossOnDisposalAccountId Default account that losses are posted to.
+ * @property string $defaultCapitalGainOnDisposalAccount Default account that capital gains are posted to.
+ * @property string $optInForTax
+ */
 class Setting extends Remote\Model
 {
-    /**
-     * The prefix used for fixed asset numbers (“FA-” by default).
-     *
-     * @property string assetNumberPrefix
-     */
-
-    /**
-     * The next available sequence number.
-     *
-     * @property string assetNumberSequence
-     */
-
-    /**
-     * The date depreciation calculations started on registered fixed assets in Xero.
-     *
-     * @property \DateTimeInterface assetStartDate
-     */
-
-    /**
-     * The last depreciation date.
-     *
-     * @property \DateTimeInterface lastDepreciationDate
-     */
-
-    /**
-     * Default account that gains are posted to.
-     *
-     * @property string defaultGainOnDisposalAccountId
-     */
-
-    /**
-     * Default account that losses are posted to.
-     *
-     * @property string defaultLossOnDisposalAccountId
-     */
-
-    /**
-     * Default account that capital gains are posted to.
-     *
-     * @property string defaultCapitalGainOnDisposalAccount
-     */
-
-    /**
-     * @property string optInForTax
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Files/Association.php
+++ b/src/XeroPHP/Models/Files/Association.php
@@ -4,28 +4,13 @@ namespace XeroPHP\Models\Files;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ObjectId The identifier of the object that the file is being associated with (e.g. InvoiceID, BankTransactionID, ContactID).
+ * @property string $ObjectGroup The Object Group that the object is in. These roughly correlate to the endpoints that can be used to retrieve the object via the core accounting API.
+ * @property string $ObjectType The Object Type.
+ */
 class Association extends Remote\Model
 {
-    /**
-     * The identifier of the object that the file is being associated with (e.g. InvoiceID,
-     * BankTransactionID, ContactID).
-     *
-     * @property string ObjectId
-     */
-
-    /**
-     * The Object Group that the object is in. These roughly correlate to the endpoints that can be used to
-     * retrieve the object via the core accounting API.
-     *
-     * @property string ObjectGroup
-     */
-
-    /**
-     * The Object Type.
-     *
-     * @property string ObjectType
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Files/File.php
+++ b/src/XeroPHP/Models/Files/File.php
@@ -4,57 +4,18 @@ namespace XeroPHP\Models\Files;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name The name of the file.
+ * @property Folder $FolderId The ID of the Folder that contains the File.
+ * @property string $MimeType The Mime type of the file.
+ * @property string $Size The file size in bytes.
+ * @property \DateTimeInterface $CreatedDateUTC UTC timestamp of the file creation.
+ * @property \DateTimeInterface $UpdatedDateUTC UTC timestamp of the last modified date.
+ * @property string $User The Xero User that created the file. Note: For Files uploaded via the API this will always be “System Generated”.
+ * @property string $Id Xero unique identifier for a file.
+ */
 class File extends Remote\Model
 {
-    /**
-     * The name of the file.
-     *
-     * @property string Name
-     */
-
-    /**
-     * The ID of the Folder that contains the File.
-     *
-     * @property Folder FolderId
-     */
-
-    /**
-     * The Mime type of the file.
-     *
-     * @property string MimeType
-     */
-
-    /**
-     * The file size in bytes.
-     *
-     * @property string Size
-     */
-
-    /**
-     * UTC timestamp of the file creation.
-     *
-     * @property \DateTimeInterface CreatedDateUTC
-     */
-
-    /**
-     * UTC timestamp of the last modified date.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The Xero User that created the file. Note: For Files uploaded via the API this will always be
-     * “System Generated”.
-     *
-     * @property string User
-     */
-
-    /**
-     * Xero unique identifier for a file.
-     *
-     * @property string Id
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Files/Folder.php
+++ b/src/XeroPHP/Models/Files/Folder.php
@@ -4,52 +4,17 @@ namespace XeroPHP\Models\Files;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name The name of the folder.
+ * @property string $FileCount The number of files in the folder.
+ * @property string $Email The email address used to email files to the inbox. Only the inbox will have this element.
+ * @property bool $IsInbox Boolean to indicate if the folder is the Inbox. The Inbox cannot be renamed or deleted.
+ * @property string $Id Xero unique identifier for a folder.
+ * @property File[] $Files The Files that are contained in the Folder. Note: The Files element is only returned when using the /Folders/{FolderId}/Files endpoint.
+ * @property string $FolderId You can specify an individual record by appending the FolderId to the endpoint, i.e. GET https://…/Folders/{FolderId}.
+ */
 class Folder extends Remote\Model
 {
-    /**
-     * The name of the folder.
-     *
-     * @property string Name
-     */
-
-    /**
-     * The number of files in the folder.
-     *
-     * @property string FileCount
-     */
-
-    /**
-     * The email address used to email files to the inbox. Only the inbox will have this element.
-     *
-     * @property string Email
-     */
-
-    /**
-     * Boolean to indicate if the folder is the Inbox. The Inbox cannot be renamed or deleted.
-     *
-     * @property bool IsInbox
-     */
-
-    /**
-     * Xero unique identifier for a folder.
-     *
-     * @property string Id
-     */
-
-    /**
-     * The Files that are contained in the Folder. Note: The Files element is only returned when using the
-     * /Folders/{FolderId}/Files endpoint.
-     *
-     * @property File[] Files
-     */
-
-    /**
-     * You can specify an individual record by appending the FolderId to the endpoint, i.e. GET
-     * https://…/Folders/{FolderId}.
-     *
-     * @property string FolderId
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee.php
@@ -11,187 +11,39 @@ use XeroPHP\Models\PayrollAU\Employee\OpeningBalance;
 use XeroPHP\Models\PayrollAU\Employee\TaxDeclaration;
 use XeroPHP\Models\PayrollAU\Employee\SuperMembership;
 
+/**
+ * @property string $FirstName First name of employee (max length = 35).
+ * @property string $LastName Last name of employee (max length = 35).
+ * @property \DateTimeInterface $DateOfBirth Date of birth of the employee (YYYY-MM-DD).
+ * @property HomeAddress $HomeAddress Employee home address. See HomeAddress.
+ * @property \DateTimeInterface $StartDate If you aren’t sure of the exact start date for an employee, you can just enter the start of the current financial year (YYYY-MM-DD).
+ * @property string $Title Title of the employee (max length = 10).
+ * @property string $MiddleNames Middle name(s) of the employee (max length = 35).
+ * @property string $Email The email address for the employee (max length = 100).
+ * @property string $Gender The employee’s gender (M or F).
+ * @property string $Mobile Employee mobile number (max length = 50).
+ * @property bool $IsAuthorisedToApproveLeave Boolean (true / false) – set this to true if the employee is authorised to approve other employees’ leave requests.
+ * @property bool $IsAuthorisedToApproveTimesheets Booelan – set this to true if the employee is authorised to approve timesheets.
+ * @property string $JobTitle JobTitle of the employee (max length = 50).
+ * @property string $Classification Employees under an award scheme will be covered by a modern award classification. If you record a classification, it will be included on your payslips (max length = 100).
+ * @property string $OrdinaryEarningsRateID Xero unique identifier for earnings rate.
+ * @property string $PayrollCalendarID Xero unique identifier for payroll calendar for the employee.
+ * @property string $EmployeeGroupName The Employee Group allows you to report on payroll expenses and liabilities for each group of employees.
+ * @property BankAccount[] $BankAccounts See BankAccount.
+ * @property PayTemplate $PayTemplate See PayTemplate.
+ * @property OpeningBalance[] $OpeningBalances See OpeningBalances.
+ * @property LeaveBalance[] $LeaveBalances See LeaveBalances.
+ * @property SuperMembership[] $SuperMemberships See SuperMemberships.
+ * @property \DateTimeInterface $TerminationDate Employee Termination Date (YYYY-MM-DD).
+ * @property string $TerminationReason Employee Termination Reason
+ * @property string $EmployeeID Xero unique identifier for an Employee.
+ * @property string $Status See Employee Status Types.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified timestamp.
+ * @property string $TwitterUserName Employee’s twitter name, entered as @twittername (max length = 50).
+ * @property string $Occupation Deprecated: this property has been removed from the Xero API.
+ */
 class Employee extends Remote\Model
 {
-    /**
-     * First name of employee (max length = 35).
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of employee (max length = 35).
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Date of birth of the employee (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface DateOfBirth
-     */
-
-    /**
-     * Employee home address. See HomeAddress.
-     *
-     * @property HomeAddress HomeAddress
-     */
-
-    /**
-     * If you aren’t sure of the exact start date for an employee, you can just enter the start of the
-     * current financial year (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * Title of the employee (max length = 10).
-     *
-     * @property string Title
-     */
-
-    /**
-     * Middle name(s) of the employee (max length = 35).
-     *
-     * @property string MiddleNames
-     */
-
-    /**
-     * The email address for the employee (max length = 100).
-     *
-     * @property string Email
-     */
-
-    /**
-     * The employee’s gender (M or F).
-     *
-     * @property string Gender
-     */
-
-    /**
-     * Employee mobile number (max length = 50).
-     *
-     * @property string Mobile
-     */
-
-    /**
-     * Employee’s twitter name, entered as @twittername (max length = 50).
-     *
-     * @property string TwitterUserName
-     */
-
-    /**
-     * Boolean (true / false) – set this to true if the employee is authorised to approve other
-     * employees’ leave requests.
-     *
-     * @property bool IsAuthorisedToApproveLeave
-     */
-
-    /**
-     * Booelan – set this to true if the employee is authorised to approve timesheets.
-     *
-     * @property bool IsAuthorisedToApproveTimesheets
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string Occupation
-     *
-     * @deprecated
-     */
-
-    /**
-     * JobTitle of the employee (max length = 50).
-     *
-     * @property string JobTitle
-     */
-
-    /**
-     * Employees under an award scheme will be covered by a modern award classification. If you record a
-     * classification, it will be included on your payslips (max length = 100).
-     *
-     * @property string Classification
-     */
-
-    /**
-     * Xero unique identifier for earnings rate.
-     *
-     * @property string OrdinaryEarningsRateID
-     */
-
-    /**
-     * Xero unique identifier for payroll calendar for the employee.
-     *
-     * @property string PayrollCalendarID
-     */
-
-    /**
-     * The Employee Group allows you to report on payroll expenses and liabilities for each group of
-     * employees.
-     *
-     * @property string EmployeeGroupName
-     */
-
-    /**
-     * See BankAccount.
-     *
-     * @property BankAccount[] BankAccounts
-     */
-
-    /**
-     * See PayTemplate.
-     *
-     * @property PayTemplate PayTemplate
-     */
-
-    /**
-     * See OpeningBalances.
-     *
-     * @property OpeningBalance[] OpeningBalances
-     */
-
-    /**
-     * See LeaveBalances.
-     *
-     * @property LeaveBalance[] LeaveBalances
-     */
-
-    /**
-     * See SuperMemberships.
-     *
-     * @property SuperMembership[] SuperMemberships
-     */
-
-    /**
-     * Employee Termination Date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface TerminationDate
-     */
-
-    /**
-     * Employee Termination Reason
-     *
-     * @property string TerminationReason
-     */
-
-    /**
-     * Xero unique identifier for an Employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * See Employee Status Types.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Last modified timestamp.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
     const STATEABBREVIATION_ACT = 'ACT';
 
     const STATEABBREVIATION_NSW = 'NSW';

--- a/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/BankAccount.php
@@ -4,46 +4,16 @@ namespace XeroPHP\Models\PayrollAU\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $StatementText The text that will appear on your employee’s bank statement when they receive payment (max length = 18).
+ * @property string $AccountName The name of the account (max length = 32).
+ * @property string $BSB The BSB number of the account (length = 6).
+ * @property string $AccountNumber The account number (max length = 9).
+ * @property string $Remainder If this account is the Remaining bank account.
+ * @property float $Amount Fixed amounts (for example, if an employee wants to have $100 of their salary transferred to one account, and the remaining amount to another).
+ */
 class BankAccount extends Remote\Model
 {
-    /**
-     * The text that will appear on your employee’s bank statement when they receive payment (max length
-     * = 18).
-     *
-     * @property string StatementText
-     */
-
-    /**
-     * The name of the account (max length = 32).
-     *
-     * @property string AccountName
-     */
-
-    /**
-     * The BSB number of the account (length = 6).
-     *
-     * @property string BSB
-     */
-
-    /**
-     * The account number (max length = 9).
-     *
-     * @property string AccountNumber
-     */
-
-    /**
-     * If this account is the Remaining bank account.
-     *
-     * @property string Remainder
-     */
-
-    /**
-     * Fixed amounts (for example, if an employee wants to have $100 of their salary transferred to one
-     * account, and the remaining amount to another).
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/HomeAddress.php
@@ -4,44 +4,16 @@ namespace XeroPHP\Models\PayrollAU\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $AddressLine1 Address line 1 for employee home address (max length = 50).
+ * @property string $AddressLine2 Address line 2 for employee home address (max length = 50).
+ * @property string $City Suburb for employee home address (max length = 50).
+ * @property string $Region State abbreviation for employee home address.
+ * @property string $PostalCode PostCode for employee home address (max length = 4).
+ * @property string $Country Country of HomeAddress.
+ */
 class HomeAddress extends Remote\Model
 {
-    /**
-     * Address line 1 for employee home address (max length = 50).
-     *
-     * @property string AddressLine1
-     */
-
-    /**
-     * Address line 2 for employee home address (max length = 50).
-     *
-     * @property string AddressLine2
-     */
-
-    /**
-     * Suburb for employee home address (max length = 50).
-     *
-     * @property string City
-     */
-
-    /**
-     * State abbreviation for employee home address.
-     *
-     * @property string Region
-     */
-
-    /**
-     * PostCode for employee home address (max length = 4).
-     *
-     * @property string PostalCode
-     */
-
-    /**
-     * Country of HomeAddress.
-     *
-     * @property string Country
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/LeaveBalance.php
@@ -5,32 +5,14 @@ namespace XeroPHP\Models\PayrollAU\Employee;
 use XeroPHP\Remote;
 use XeroPHP\Models\PayrollAU\PayItem;
 
+/**
+ * @property string $LeaveName The name of the leave type.
+ * @property string $LeaveTypeID Identifier of the leave type (see PayItems).
+ * @property string $NumberOfUnits The balance of the leave available.
+ * @property PayItem[] $TypeOfUnits The type of units as specified by the LeaveType (see PayItems).
+ */
 class LeaveBalance extends Remote\Model
 {
-    /**
-     * The name of the leave type.
-     *
-     * @property string LeaveName
-     */
-
-    /**
-     * Identifier of the leave type (see PayItems).
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * The balance of the leave available.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * The type of units as specified by the LeaveType (see PayItems).
-     *
-     * @property PayItem[] TypeOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/OpeningBalance.php
@@ -7,98 +7,25 @@ use XeroPHP\Models\PayrollAU\Payslip\EarningsLine;
 use XeroPHP\Models\PayrollAU\Payslip\DeductionLine;
 use XeroPHP\Models\PayrollAU\Payslip\ReimbursementLine;
 
+/**
+ * @property \DateTimeInterface $OpeningBalanceDate Opening Balance Date. (YYYY-MM-DD).
+ * @property string $Tax Opening Balance tax.
+ * @property EarningsLine[] $EarningsLines The EarningsLines of the OpeningBalance.
+ * @property DeductionLine[] $DeductionLines The DeductionLines of the OpeningBalance.
+ * @property string $SuperLines The SuperLines of the OpeningBalance.
+ * @property ReimbursementLine[] $ReimbursementLines The ReimbursementLines of the OpeningBalance.
+ * @property string $LeaveLines The LeaveLines of the OpeningBalance.
+ * @property string $EarningsRateID Xero earnings rate identifier.
+ * @property float $Amount Reimbursement type amount.
+ * @property string $DeductionTypeID Xero deduction type identifier.
+ * @property string $SuperMembershipID Xero super membership ID.
+ * @property string $CalculationType Calculation type for Super line.
+ * @property string $ReimbursementTypeID Xero reimbursement type identifier.
+ * @property string $LeaveTypeID Xero leave type identifier.
+ * @property string $NumberOfUnits Leave number of units.
+ */
 class OpeningBalance extends Remote\Model
 {
-    /**
-     * Opening Balance Date. (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface OpeningBalanceDate
-     */
-
-    /**
-     * Opening Balance tax.
-     *
-     * @property string Tax
-     */
-
-    /**
-     * The EarningsLines of the OpeningBalance.
-     *
-     * @property EarningsLine[] EarningsLines
-     */
-
-    /**
-     * The DeductionLines of the OpeningBalance.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * The SuperLines of the OpeningBalance.
-     *
-     * @property string SuperLines
-     */
-
-    /**
-     * The ReimbursementLines of the OpeningBalance.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * The LeaveLines of the OpeningBalance.
-     *
-     * @property string LeaveLines
-     */
-
-    /**
-     * Xero earnings rate identifier.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * Reimbursement type amount.
-     *
-     * @property float Amount
-     */
-
-    /**
-     * Xero deduction type identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * Xero super membership ID.
-     *
-     * @property string SuperMembershipID
-     */
-
-    /**
-     * Calculation type for Super line.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * Xero reimbursement type identifier.
-     *
-     * @property string ReimbursementTypeID
-     */
-
-    /**
-     * Xero leave type identifier.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * Leave number of units.
-     *
-     * @property string NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -9,38 +9,15 @@ use XeroPHP\Models\PayrollAU\Employee\PayTemplate\EarningsLine;
 use XeroPHP\Models\PayrollAU\Employee\PayTemplate\DeductionLine;
 use XeroPHP\Models\PayrollAU\Employee\PayTemplate\ReimbursementLine;
 
+/**
+ * @property EarningsLine[] $EarningsLines The earnings rate lines.
+ * @property DeductionLine[] $DeductionLines The deduction type lines.
+ * @property SuperLine[] $SuperLines The superannuation fund lines.
+ * @property ReimbursementLine[] $ReimbursementLines The reimbursement type lines.
+ * @property LeaveLine[] $LeaveLines The leave type lines.
+ */
 class PayTemplate extends Remote\Model
 {
-    /**
-     * The earnings rate lines.
-     *
-     * @property EarningsLine[] EarningsLines
-     */
-
-    /**
-     * The deduction type lines.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * The superannuation fund lines.
-     *
-     * @property SuperLine[] SuperLines
-     */
-
-    /**
-     * The reimbursement type lines.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * The leave type lines.
-     *
-     * @property LeaveLine[] LeaveLines
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/DeductionLine.php
@@ -4,36 +4,19 @@ namespace XeroPHP\Models\PayrollAU\Employee\PayTemplate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $DeductionTypeID Xero deduction type identifier.
+ * @property string $CalculationType See Deduction Type Calculation Type.
+ * @property string $Percentage The percentage of deduction line.
+ * @property float $Amount The deduction amount.
+ */
 class DeductionLine extends Remote\Model
 {
-    /**
-     * Xero deduction type identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * See Deduction Type Calculation Type.
-     *
-     * @property string CalculationType
-     */
     const DEDUCTION_TYPE_FIXEDAMOUNT = "FIXEDAMOUNT";
 
     const DEDUCTION_TYPE_PRETAX = "PRETAX";
 
     const DEDUCTION_TYPE_POSTTAX = "POSTTAX";
-
-    /**
-     * The percentage of deduction line.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * The deduction amount.
-     *
-     * @property float Amount
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc.

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/EarningsLine.php
@@ -4,43 +4,16 @@ namespace XeroPHP\Models\PayrollAU\Employee\PayTemplate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsRateID Xero earnings rate identifier.
+ * @property string $CalculationType See Earnings Rate Calculation Type.
+ * @property string $NumberOfUnitsPerWeek Hours per week for the EarningsLine. Applicable for ANNUALSALARY CalculationType.
+ * @property string $AnnualSalary Annual Salary of employee.
+ * @property float $RatePerUnit Rate per unit of the EarningsLine.
+ * @property string $NormalNumberOfUnits Normal number of units for EarningsLine.  Applicable when RateType is “MULTIPLE”.
+ */
 class EarningsLine extends Remote\Model
 {
-    /**
-     * Xero earnings rate identifier.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * See Earnings Rate Calculation Type.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * Hours per week for the EarningsLine. Applicable for ANNUALSALARY CalculationType.
-     *
-     * @property string NumberOfUnitsPerWeek
-     */
-
-    /**
-     * Annual Salary of employee.
-     *
-     * @property string AnnualSalary
-     */
-
-    /**
-     * Rate per unit of the EarningsLine.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Normal number of units for EarningsLine.  Applicable when RateType is “MULTIPLE”.
-     *
-     * @property string NormalNumberOfUnits
-     */
     const EARNINGSRATECALCULATIONTYPE_USEEARNINGSRATE = 'USEEARNINGSRATE';
 
     const EARNINGSRATECALCULATIONTYPE_ENTEREARNINGSRATE = 'ENTEREARNINGSRATE';

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/LeaveLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/LeaveLine.php
@@ -4,44 +4,16 @@ namespace XeroPHP\Models\PayrollAU\Employee\PayTemplate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $LeaveTypeID Xero leave type identifier.
+ * @property string $CalculationType See Superannuation Calculation Types.
+ * @property string $AnnualNumberOfUnits Hours of leave accrued each year.
+ * @property string $FullTimeNumberOfUnitsPerPeriod Normal ordinary earnings number of units for leave line.
+ * @property string $NumberOfUnits Number of units for leave line.
+ * @property string $EntitlementFinalPayPayoutType See Final Pay Payout Types If you do not provide any value then by Default it will be NOTPAIDOUT.
+ */
 class LeaveLine extends Remote\Model
 {
-    /**
-     * Xero leave type identifier.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * See Superannuation Calculation Types.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * Hours of leave accrued each year.
-     *
-     * @property string AnnualNumberOfUnits
-     */
-
-    /**
-     * Normal ordinary earnings number of units for leave line.
-     *
-     * @property string FullTimeNumberOfUnitsPerPeriod
-     */
-
-    /**
-     * Number of units for leave line.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * See Final Pay Payout Types If you do not provide any value then by Default it will be NOTPAIDOUT.
-     *
-     * @property string EntitlementFinalPayPayoutType
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/ReimbursementLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollAU\Employee\PayTemplate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ReimbursementTypeID Xero reimbursement type identifier.
+ * @property string $Description The description of the reimbursement type.
+ * @property float $Amount The amount of the reimbursement type.
+ */
 class ReimbursementLine extends Remote\Model
 {
-    /**
-     * Xero reimbursement type identifier.
-     *
-     * @property string ReimbursementTypeID
-     */
-
-    /**
-     * The description of the reimbursement type.
-     *
-     * @property string Description
-     */
-
-    /**
-     * The amount of the reimbursement type.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate/SuperLine.php
@@ -4,50 +4,17 @@ namespace XeroPHP\Models\PayrollAU\Employee\PayTemplate;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SuperMembershipID Xero superannuation fund membership identifier.
+ * @property string $ContributionType See Superannuation Contribution Type.
+ * @property string $CalculationType See Superannuation Calculation Types.
+ * @property string $ExpenseAccountCode  Account code for the Expense Account. i.e 478.
+ * @property string $LiabilityAccountCode  Account code for the Liability Account. i.e 826.
+ * @property string $MinimumMonthlyEarnings Minimum monthly earnings. Applies for Percentage of Earnings calculation type only.
+ * @property string $Percentage The percentage of the SuperLine. Applies on Percentage of Earnings CalculationType.
+ */
 class SuperLine extends Remote\Model
 {
-    /**
-     * Xero superannuation fund membership identifier.
-     *
-     * @property string SuperMembershipID
-     */
-
-    /**
-     * See Superannuation Contribution Type.
-     *
-     * @property string ContributionType
-     */
-
-    /**
-     * See Superannuation Calculation Types.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     *  Account code for the Expense Account. i.e 478.
-     *
-     * @property string ExpenseAccountCode
-     */
-
-    /**
-     *  Account code for the Liability Account. i.e 826.
-     *
-     * @property string LiabilityAccountCode
-     */
-
-    /**
-     * Minimum monthly earnings. Applies for Percentage of Earnings calculation type only.
-     *
-     * @property string MinimumMonthlyEarnings
-     */
-
-    /**
-     * The percentage of the SuperLine. Applies on Percentage of Earnings CalculationType.
-     *
-     * @property string Percentage
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/SuperMembership.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/SuperMembership.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SuperFundID Xero identifier for super fund.
+ * @property string $EmployeeNumber The memberhsip number assigned to the employee by the super fund.
+ * @property string $SuperMembershipID Xero unique identifier for Super membership.
+ * @property string $EmployeeID The Xero identifier for an employee e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ */
 class SuperMembership extends Remote\Model
 {
-    /**
-     * Xero identifier for super fund.
-     *
-     * @property string SuperFundID
-     */
-
-    /**
-     * The memberhsip number assigned to the employee by the super fund.
-     *
-     * @property string EmployeeNumber
-     */
-
-    /**
-     * Xero unique identifier for Super membership.
-     *
-     * @property string SuperMembershipID
-     */
-
-    /**
-     * The Xero identifier for an employee e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string EmployeeID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/TaxDeclaration.php
@@ -4,94 +4,24 @@ namespace XeroPHP\Models\PayrollAU\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EmployeeID Xero employee identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $EmploymentBasis See Employment Basis Types.
+ * @property string $TFNExemptionType See TFN Exemption Types.
+ * @property string $TaxFileNumber The tax file number e.g 123123123.
+ * @property string $AustralianResidentForTaxPurposes If the employee is Australian resident for tax purposes. e.g true or false.
+ * @property string $TaxFreeThresholdClaimed If tax free threshold claimed. e.g true or false.
+ * @property float $TaxOffsetEstimatedAmount If has tax offset estimated then the tax offset estimated amount. e.g 100.
+ * @property bool $HasHELPDebt If employee has HECS or HELP dept. e.g true or false.
+ * @property bool $HasSFSSDebt If employee has financial supplement dept. e.g true or false.
+ * @property bool $HasTradeSupportLoanDebt If employee has trade support loan. e.g true or false.
+ * @property string $UpwardVariationTaxWithholdingAmount If the employee has requested that additional tax be withheld each pay run. e.g 50.
+ * @property string $EligibleToReceiveLeaveLoading If the employee is eligible to receive an additional percentage on top of ordinary earnings when they take leave (typically 17.5%). e.g true or false.
+ * @property string $ApprovedWithholdingVariationPercentage If the employee has approved withholding variation. e.g (0 – 100).
+ * @property bool $HasTSLDebt Deprecated: this property has been removed from the Xero API.
+ */
 class TaxDeclaration extends Remote\Model
 {
-    /**
-     * Xero employee identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * See Employment Basis Types.
-     *
-     * @property string EmploymentBasis
-     */
-
-    /**
-     * See TFN Exemption Types.
-     *
-     * @property string TFNExemptionType
-     */
-
-    /**
-     * The tax file number e.g 123123123.
-     *
-     * @property string TaxFileNumber
-     */
-
-    /**
-     * If the employee is Australian resident for tax purposes. e.g true or false.
-     *
-     * @property string AustralianResidentForTaxPurposes
-     */
-
-    /**
-     * If tax free threshold claimed. e.g true or false.
-     *
-     * @property string TaxFreeThresholdClaimed
-     */
-
-    /**
-     * If has tax offset estimated then the tax offset estimated amount. e.g 100.
-     *
-     * @property float TaxOffsetEstimatedAmount
-     */
-
-    /**
-     * If employee has HECS or HELP dept. e.g true or false.
-     *
-     * @property bool HasHELPDebt
-     */
-
-    /**
-     * If employee has financial supplement dept. e.g true or false.
-     *
-     * @property bool HasSFSSDebt
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property bool HasTSLDebt
-     *
-     * @deprecated
-     */
-
-    /**
-     * If employee has trade support loan. e.g true or false.
-     *
-     * @property bool HasTradeSupportLoanDebt
-     */
-
-    /**
-     * If the employee has requested that additional tax be withheld each pay run. e.g 50.
-     *
-     * @property string UpwardVariationTaxWithholdingAmount
-     */
-
-    /**
-     * If the employee is eligible to receive an additional percentage on top of ordinary earnings when
-     * they take leave (typically 17.5%). e.g true or false.
-     *
-     * @property string EligibleToReceiveLeaveLoading
-     */
-
-    /**
-     * If the employee has approved withholding variation. e.g (0 – 100).
-     *
-     * @property string ApprovedWithholdingVariationPercentage
-     */
     const EMPLOYMENTBASIS_FULLTIME = 'FULLTIME';
 
     const EMPLOYMENTBASIS_PARTTIME = 'PARTTIME';

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication.php
@@ -5,55 +5,18 @@ namespace XeroPHP\Models\PayrollAU;
 use XeroPHP\Remote;
 use XeroPHP\Models\PayrollAU\LeaveApplication\LeavePeriod;
 
+/**
+ * @property string $LeaveApplicationID Xero identifier.
+ * @property string $EmployeeID The Xero identifier for Payroll Employee.
+ * @property string $LeaveTypeID The Xero identifier for Leave Type.
+ * @property string $Title The title of the leave (max length = 50).
+ * @property \DateTimeInterface $StartDate Start date of the leave (YYYY-MM-DD).
+ * @property \DateTimeInterface $EndDate End date of the leave (YYYY-MM-DD).
+ * @property string $Description The Description of the Leave (max length = 200).
+ * @property LeavePeriod[] $LeavePeriods The leave period information.
+ */
 class LeaveApplication extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string LeaveApplicationID
-     */
-
-    /**
-     * The Xero identifier for Payroll Employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * The Xero identifier for Leave Type.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * The title of the leave (max length = 50).
-     *
-     * @property string Title
-     */
-
-    /**
-     * Start date of the leave (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * End date of the leave (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface EndDate
-     */
-
-    /**
-     * The Description of the Leave (max length = 200).
-     *
-     * @property string Description
-     */
-
-    /**
-     * The leave period information.
-     *
-     * @property LeavePeriod[] LeavePeriods
-     */
     const LEAVE_PERIOD_STATUS_SCHEDULED = 'Scheduled';
 
     const LEAVE_PERIOD_STATUS_PROCESSED = 'Processed';

--- a/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
+++ b/src/XeroPHP/Models/PayrollAU/LeaveApplication/LeavePeriod.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\LeaveApplication;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $NumberOfUnits The Number of Units for the leave.
+ * @property \DateTimeInterface $PayPeriodEndDate The Pay Period End Date (YYYY-MM-DD).
+ * @property \DateTimeInterface $PayPeriodStartDate The Pay Period Start Date (YYYY-MM-DD).
+ * @property string $LeavePeriodStatus See LeavePeriodStatus.
+ */
 class LeavePeriod extends Remote\Model
 {
-    /**
-     * The Number of Units for the leave.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * The Pay Period End Date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PayPeriodEndDate
-     */
-
-    /**
-     * The Pay Period Start Date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PayPeriodStartDate
-     */
-
-    /**
-     * See LeavePeriodStatus.
-     *
-     * @property string LeavePeriodStatus
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/PayItem.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem.php
@@ -8,32 +8,14 @@ use XeroPHP\Models\PayrollAU\PayItem\EarningsRate;
 use XeroPHP\Models\PayrollAU\PayItem\DeductionType;
 use XeroPHP\Models\PayrollAU\PayItem\ReimbursementType;
 
+/**
+ * @property EarningsRate[] $EarningsRates See EarningsRates.
+ * @property DeductionType[] $DeductionTypes See DeductionTypes.
+ * @property LeaveType[] $LeaveTypes See LeaveTypes.
+ * @property ReimbursementType[] $ReimbursementTypes See ReimbursementTypes.
+ */
 class PayItem extends Remote\Model
 {
-    /**
-     * See EarningsRates.
-     *
-     * @property EarningsRate[] EarningsRates
-     */
-
-    /**
-     * See DeductionTypes.
-     *
-     * @property DeductionType[] DeductionTypes
-     */
-
-    /**
-     * See LeaveTypes.
-     *
-     * @property LeaveType[] LeaveTypes
-     */
-
-    /**
-     * See ReimbursementTypes.
-     *
-     * @property ReimbursementType[] ReimbursementTypes
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/DeductionType.php
@@ -4,40 +4,15 @@ namespace XeroPHP\Models\PayrollAU\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name Name of the deduction type (max length = 50).
+ * @property string $AccountCode See Accounts.
+ * @property float $ReducesTax Indicates that this is a pre-tax deduction that will reduce the amount of tax you withhold from an employee.
+ * @property string $ReducesSuper Most deductions don’t reduce your superannuation guarantee contribution liability, so typically you will not set any value for this.
+ * @property string $DeductionTypeID Xero identifier.
+ */
 class DeductionType extends Remote\Model
 {
-    /**
-     * Name of the deduction type (max length = 50).
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Indicates that this is a pre-tax deduction that will reduce the amount of tax you withhold from an
-     * employee.
-     *
-     * @property float ReducesTax
-     */
-
-    /**
-     * Most deductions don’t reduce your superannuation guarantee contribution liability, so typically
-     * you will not set any value for this.
-     *
-     * @property string ReducesSuper
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/EarningsRate.php
@@ -4,82 +4,26 @@ namespace XeroPHP\Models\PayrollAU\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name Name of the earnings rate (max length = 100).
+ * @property string $AccountCode See Accounts.
+ * @property string $TypeOfUnits Type of units used to record earnings (max length = 50). Only When RateType is RATEPERUNIT.
+ * @property bool $IsExemptFromTax Most payments are subject to tax, so you should only set this value if you are sure that a payment is exempt from PAYG withholding.
+ * @property bool $IsExemptFromSuper See the ATO website for details of which payments are exempt from SGC.
+ * @property string $EarningsType See EarningsTypes.
+ * @property string $EarningsRateID Xero identifier.
+ * @property string $RateType See RateTypes.
+ * @property float $RatePerUnit Default rate per unit (optional). Only applicable if RateType is RATEPERUNIT.
+ * @property float $Multiplier This is the multiplier used to calculate the rate per unit, based on the employee’s ordinary earnings rate. For example, for time and a half enter 1.5. Only applicable if RateType is MULTIPLE.
+ * @property bool $AccrueLeave Indicates that this earnings rate should accrue leave. Only applicable if RateType is MULTIPLE.
+ * @property string $AllowanceType Option AllowanceType for ALLOWANCE EarningsType EarningsRate. Used to group allowances for reporting to the ATO. Undocumented. Only applicable if EarningsType is ALLOWANCE.
+ * @property string $AllowanceCategory An optional category that can be added when AllowanceType is OTHER
+ * @property string $EarningsType The rate's Earnings Type
+ * @property string $RateType The rate's Rate Type
+ * @property string $EmploymentTerminationPaymentType A required Payment Type when RateType is EMPLOYMENTTERMINATIONPAYMENT
+ */
 class EarningsRate extends Remote\Model
 {
-    /**
-     * Name of the earnings rate (max length = 100).
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Type of units used to record earnings (max length = 50). Only When RateType is RATEPERUNIT.
-     *
-     * @property string TypeOfUnits
-     */
-
-    /**
-     * Most payments are subject to tax, so you should only set this value if you are sure that a payment
-     * is exempt from PAYG withholding.
-     *
-     * @property bool IsExemptFromTax
-     */
-
-    /**
-     * See the ATO website for details of which payments are exempt from SGC.
-     *
-     * @property bool IsExemptFromSuper
-     */
-
-    /**
-     * See EarningsTypes.
-     *
-     * @property string EarningsType
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * See RateTypes.
-     *
-     * @property string RateType
-     */
-
-    /**
-     * Default rate per unit (optional). Only applicable if RateType is RATEPERUNIT.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * This is the multiplier used to calculate the rate per unit, based on the employee’s ordinary
-     * earnings rate. For example, for time and a half enter 1.5. Only applicable if RateType is MULTIPLE.
-     *
-     * @property float Multiplier
-     */
-
-    /**
-     * Indicates that this earnings rate should accrue leave. Only applicable if RateType is MULTIPLE.
-     *
-     * @property bool AccrueLeave
-     */
-
-    /**
-     * Option AllowanceType for ALLOWANCE EarningsType EarningsRate.
-     * Used to group allowances for reporting to the ATO. Undocumented. Only applicable if EarningsType is ALLOWANCE.
-     *
-     * @property string AllowanceType
-     */
     const ALLOWANCETYPE_CAR = 'CAR';
 
     const ALLOWANCETYPE_TRANSPORT = 'TRANSPORT';
@@ -99,12 +43,6 @@ class EarningsRate extends Remote\Model
     const ALLOWANCETYPE_QUALIFICATIONS = 'QUALIFICATIONS';
 
     const ALLOWANCETYPE_OTHER = 'OTHER';
-
-    /**
-     * An optional category that can be added when AllowanceType is OTHER
-     *
-     * @property string AllowanceCategory
-     */
     const ALLOWANCECATEGORY_NONDEDUCTIBLE = 'NONDEDUCTIBLE';
 
     const ALLOWANCECATEGORY_UNIFORM = 'UNIFORM';
@@ -118,12 +56,6 @@ class EarningsRate extends Remote\Model
     const ALLOWANCECATEGORY_GENERAL = 'GENERAL';
 
     const ALLOWANCECATEGORY_OTHER = 'OTHER';
-
-    /**
-     * The rate's Earnings Type
-     *
-     * @property string EarningsType
-     */
     const EARNINGSTYPE_ORDINARYTIMEEARNINGS = 'ORDINARYTIMEEARNINGS';
 
     const EARNINGSTYPE_OVERTIMEEARNINGS = 'OVERTIMEEARNINGS';
@@ -154,23 +86,11 @@ class EarningsRate extends Remote\Model
      * @deprecated this Earning Type is no longer used
      */
     const EARNINGSTYPE_FIXED = 'FIXED';
-
-    /**
-     * The rate's Rate Type
-     *
-     * @property string RateType
-     */
     const RATETYPE_FIXEDAMOUNT = 'FIXEDAMOUNT';
 
     const RATETYPE_MULTIPLE = 'MULTIPLE';
 
     const RATETYPE_RATEPERUNIT = 'RATEPERUNIT';
-
-    /**
-     * A required Payment Type when RateType is EMPLOYMENTTERMINATIONPAYMENT
-     *
-     * @property string EmploymentTerminationPaymentType
-     */
     const EMPLOYMENTTERMINATIONPAYMENTTYPE_O = 'O';
 
     const EMPLOYMENTTERMINATIONPAYMENTTYPE_R = 'R';

--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -4,52 +4,17 @@ namespace XeroPHP\Models\PayrollAU\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name Name of the leave type (max length = 50).
+ * @property string $TypeOfUnits The type of units by which leave entitlements are normally tracked. These are typically the same as the type of units used for the employee’s ordinary earnings rate.
+ * @property string $IsPaidLeave Set this to indicate that an employee will be paid when taking this type of leave.
+ * @property string $ShowOnPayslip Set this if you want a balance for this leave type to be shown on your employee’s payslips.
+ * @property string $LeaveTypeID Xero identifier.
+ * @property string $NormalEntitlement The number of units the employee is entitled to each year.
+ * @property float $LeaveLoadingRate Enter an amount here if your organisation pays an additional percentage on top of ordinary earnings when your employees take leave (typically 17.5%).
+ */
 class LeaveType extends Remote\Model
 {
-    /**
-     * Name of the leave type (max length = 50).
-     *
-     * @property string Name
-     */
-
-    /**
-     * The type of units by which leave entitlements are normally tracked. These are typically the same as
-     * the type of units used for the employee’s ordinary earnings rate.
-     *
-     * @property string TypeOfUnits
-     */
-
-    /**
-     * Set this to indicate that an employee will be paid when taking this type of leave.
-     *
-     * @property string IsPaidLeave
-     */
-
-    /**
-     * Set this if you want a balance for this leave type to be shown on your employee’s payslips.
-     *
-     * @property string ShowOnPayslip
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * The number of units the employee is entitled to each year.
-     *
-     * @property string NormalEntitlement
-     */
-
-    /**
-     * Enter an amount here if your organisation pays an additional percentage on top of ordinary earnings
-     * when your employees take leave (typically 17.5%).
-     *
-     * @property float LeaveLoadingRate
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/ReimbursementType.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollAU\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name Name of the reimbursement type (max length = 50).
+ * @property string $AccountCode See Accounts.
+ * @property string $ReimbursementTypeID Xero identifier.
+ */
 class ReimbursementType extends Remote\Model
 {
-    /**
-     * Name of the reimbursement type (max length = 50).
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string AccountCode
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string ReimbursementTypeID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/PayRun.php
+++ b/src/XeroPHP/Models/PayrollAU/PayRun.php
@@ -4,94 +4,27 @@ namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PayrollCalendarID See PayrollCalendars.
+ * @property string $PayRunID Xero identifier for pay run.
+ * @property \DateTimeInterface $PayRunPeriodStartDate Period Start Date for the PayRun (YYYY-MM-DD).
+ * @property \DateTimeInterface $PayRunPeriodEndDate Period End Date for the PayRun (YYYY-MM-DD).
+ * @property string $PayRunStatus See PayRun Status types.
+ * @property \DateTimeInterface $PaymentDate Payment Date for the PayRun (YYYY-MM-DD).
+ * @property string $PayslipMessage Payslip message for the PayRun.
+ * @property Payslip[] $Payslips See Payslip.
+ * @property float $Wages Total Wages for the PayRun.
+ * @property float $Deductions Total Deduction for the PayRun.
+ * @property float $Tax Total Tax for the PayRun.
+ * @property float $Super Total Super for the PayRun.
+ * @property float $Reimbursement Total Reimbursement for the PayRun.
+ * @property float $NetPay Total NetPay for the PayRun.
+ */
 class PayRun extends Remote\Model
 {
-    /**
-     * See PayrollCalendars.
-     *
-     * @property string PayrollCalendarID
-     */
-
-    /**
-     * Xero identifier for pay run.
-     *
-     * @property string PayRunID
-     */
-
-    /**
-     * Period Start Date for the PayRun (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PayRunPeriodStartDate
-     */
-
-    /**
-     * Period End Date for the PayRun (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PayRunPeriodEndDate
-     */
-
-    /**
-     * See PayRun Status types.
-     *
-     * @property string PayRunStatus
-     */
     const STATUS_POSTED = 'POSTED';
     
     const STATUS_DRAFT = 'DRAFT';
-
-    /**
-     * Payment Date for the PayRun (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PaymentDate
-     */
-
-    /**
-     * Payslip message for the PayRun.
-     *
-     * @property string PayslipMessage
-     */
-
-    /**
-     * See Payslip.
-     *
-     * @property Payslip[] Payslips
-     */
-
-    /**
-     * Total Wages for the PayRun.
-     *
-     * @property float Wages
-     */
-
-    /**
-     * Total Deduction for the PayRun.
-     *
-     * @property float Deductions
-     */
-
-    /**
-     * Total Tax for the PayRun.
-     *
-     * @property float Tax
-     */
-
-    /**
-     * Total Super for the PayRun.
-     *
-     * @property float Super
-     */
-
-    /**
-     * Total Reimbursement for the PayRun.
-     *
-     * @property float Reimbursement
-     */
-
-    /**
-     * Total NetPay for the PayRun.
-     *
-     * @property float NetPay
-     */
 
     /**
      * Get the resource uri of the class (Contacts) etc.

--- a/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
+++ b/src/XeroPHP/Models/PayrollAU/PayrollCalendar.php
@@ -4,44 +4,16 @@ namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PayrollCalendarID Xero identifier.
+ * @property string $Name Name of the Payroll Calendar (max length = 100).
+ * @property string $CalendarType See Payroll Calendar types.
+ * @property \DateTimeInterface $StartDate The start date of the upcoming pay period. The end date will be calculated based upon this date, and the calendar type selected (YYYY-MM-DD), more details.
+ * @property \DateTimeInterface $UpdatedDateUTC The date the calendar was last updated
+ * @property \DateTimeInterface $PaymentDate The date on which employees will be paid for the upcoming pay period (YYYY-MM-DD), more details.
+ */
 class PayrollCalendar extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string PayrollCalendarID
-     */
-
-    /**
-     * Name of the Payroll Calendar (max length = 100).
-     *
-     * @property string Name
-     */
-
-    /**
-     * See Payroll Calendar types.
-     *
-     * @property string CalendarType
-     */
-
-    /**
-     * The start date of the upcoming pay period. The end date will be calculated based upon this date, and
-     * the calendar type selected (YYYY-MM-DD), more details.
-     *
-     * @property \DateTimeInterface StartDate
-     */
-    
-    /**
-     * The date the calendar was last updated
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * The date on which employees will be paid for the upcoming pay period (YYYY-MM-DD), more details.
-     *
-     * @property \DateTimeInterface PaymentDate
-     */
     const CALENDARTYPE_WEEKLY = 'WEEKLY';
 
     const CALENDARTYPE_FORTNIGHTLY = 'FORTNIGHTLY';

--- a/src/XeroPHP/Models/PayrollAU/Payslip.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip.php
@@ -12,134 +12,31 @@ use XeroPHP\Models\PayrollAU\Payslip\ReimbursementLine;
 use XeroPHP\Models\PayrollAU\Payslip\SuperannuationLine;
 use XeroPHP\Models\PayrollAU\Payslip\TimesheetEarningsLine;
 
+/**
+ * @property string $EmployeeID Xero identifier for payroll employee.
+ * @property string $PayRunID Xero identifier for payroll payrun.
+ * @property string $PayslipID Xero identifier for payroll payslip.
+ * @property EarningsLine[] $EarningsLines See EarningsLine.
+ * @property TimesheetEarningsLine[] $TimesheetEarningsLines See TimesheetEarningsLine.
+ * @property DeductionLine[] $DeductionLines See DeductionLine.
+ * @property LeaveAccrualLine[] $LeaveAccrualLines See LeaveAccrualLine.
+ * @property ReimbursementLine[] $ReimbursementLines See ReimbursementLine – see PayItems.
+ * @property SuperannuationLine[] $SuperannuationLines See SuperannuationLine.
+ * @property TaxLine[] $TaxLines See TaxLine.
+ * @property string $FirstName Employee first name.
+ * @property string $LastName Employee last name.
+ * @property string $EmployeeGroup Employee Group name.
+ * @property \DateTimeInterface $LastEdited Last edited.
+ * @property float $Wages The Total Wages for the PayRun.
+ * @property float $Deductions The Total Deductions for the PayRun.
+ * @property float $NetPay The Total NetPay for the PayRun.
+ * @property float $Tax The Total Tax for the PayRun.
+ * @property float $Super The Total Super for the PayRun.
+ * @property float $Reimbursements The Total Reimbursement for the PayRun.
+ * @property LeaveEarningsLine[] $LeaveEarningsLines See LeaveEarningsLine.
+ */
 class Payslip extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * Xero identifier for payroll payrun.
-     *
-     * @property string PayRunID
-     */
-
-    /**
-     * Xero identifier for payroll payslip.
-     *
-     * @property string PayslipID
-     */
-
-    /**
-     * See EarningsLine.
-     *
-     * @property EarningsLine[] EarningsLines
-     */
-
-    /**
-     * See TimesheetEarningsLine.
-     *
-     * @property TimesheetEarningsLine[] TimesheetEarningsLines
-     */
-
-    /**
-     * See DeductionLine.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * See LeaveAccrualLine.
-     *
-     * @property LeaveAccrualLine[] LeaveAccrualLines
-     */
-
-    /**
-     * See ReimbursementLine – see PayItems.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * See SuperannuationLine.
-     *
-     * @property SuperannuationLine[] SuperannuationLines
-     */
-
-    /**
-     * See TaxLine.
-     *
-     * @property TaxLine[] TaxLines
-     */
-
-    /**
-     * Employee first name.
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Employee last name.
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Employee Group name.
-     *
-     * @property string EmployeeGroup
-     */
-
-    /**
-     * Last edited.
-     *
-     * @property \DateTimeInterface LastEdited
-     */
-
-    /**
-     * The Total Wages for the PayRun.
-     *
-     * @property float Wages
-     */
-
-    /**
-     * The Total Deductions for the PayRun.
-     *
-     * @property float Deductions
-     */
-
-    /**
-     * The Total NetPay for the PayRun.
-     *
-     * @property float NetPay
-     */
-
-    /**
-     * The Total Tax for the PayRun.
-     *
-     * @property float Tax
-     */
-
-    /**
-     * The Total Super for the PayRun.
-     *
-     * @property float Super
-     */
-
-    /**
-     * The Total Reimbursement for the PayRun.
-     *
-     * @property float Reimbursements
-     */
-
-    /**
-     * See LeaveEarningsLine.
-     *
-     * @property LeaveEarningsLine[] LeaveEarningsLines
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/DeductionLine.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $DeductionTypeID Xero identifier for payroll earnings rate.
+ * @property float $CalculationType Rate per unit for earnings rate.
+ * @property string $Percentage The Percentage of the Deduction Line.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ */
 class DeductionLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings rate.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float CalculationType
-     */
-
-    /**
-     * The Percentage of the Deduction Line.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/EarningsLine.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsRateID Xero identifier for payroll earnings rate.
+ * @property float $RatePerUnit Rate per unit for earnings rate.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ * @property float $FixedAmount Earnings rate amount.  Only applicable if the EarningsRate RateType is Fixed.
+ */
 class EarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings rate.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
-    /**
-     * Earnings rate amount.  Only applicable if the EarningsRate RateType is Fixed.
-     *
-     * @property float FixedAmount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveAccrualLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $LeaveTypeID Xero identifier for the Leave type.
+ * @property string $NumberOfUnits Number of units for the Leave line.
+ * @property string $AutoCalculate If you want to auto calculate leave.
+ */
 class LeaveAccrualLine extends Remote\Model
 {
-    /**
-     * Xero identifier for the Leave type.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * Number of units for the Leave line.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * If you want to auto calculate leave.
-     *
-     * @property string AutoCalculate
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/LeaveEarningsLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsRateID Xero identifier for payroll earnings rate.
+ * @property float $RatePerUnit Rate per unit for earnings rate.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ */
 class LeaveEarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings rate.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/ReimbursementLine.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ReimbursementTypeID Xero identifier for payroll reimbursement type.
+ * @property string $Description Reimbursement lines description (max length 50).
+ * @property string $ExpenseAccount Reimbursement expense account. For posted pay run you should be able to see expense account code.
+ * @property float $Amount Reimbursement amount.
+ */
 class ReimbursementLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll reimbursement type.
-     *
-     * @property string ReimbursementTypeID
-     */
-
-    /**
-     * Reimbursement lines description (max length 50).
-     *
-     * @property string Description
-     */
-
-    /**
-     * Reimbursement expense account. For posted pay run you should be able to see expense account code.
-     *
-     * @property string ExpenseAccount
-     */
-
-    /**
-     * Reimbursement amount.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/SuperannuationLine.php
@@ -4,62 +4,19 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SuperMembershipID Xero identifier for payroll super fund membership ID.
+ * @property string $ContributionType Superannuation contribution type.
+ * @property string $CalculationType Superannuation calculation type.
+ * @property string $MinimumMonthlyEarnings Superannuation minimum monthly earnings.
+ * @property string $ExpenseAccountCode Superannuation expense account code.
+ * @property string $LiabilityAccountCode Superannuation liability account code.
+ * @property \DateTimeInterface $PaymentDateForThisPeriod Superannuation payment date for the current period (YYYY-MM-DD).
+ * @property string $Percentage Superannuation percentage.
+ * @property float $Amount Superannuation amount.
+ */
 class SuperannuationLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll super fund membership ID.
-     *
-     * @property string SuperMembershipID
-     */
-
-    /**
-     * Superannuation contribution type.
-     *
-     * @property string ContributionType
-     */
-
-    /**
-     * Superannuation calculation type.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * Superannuation minimum monthly earnings.
-     *
-     * @property string MinimumMonthlyEarnings
-     */
-
-    /**
-     * Superannuation expense account code.
-     *
-     * @property string ExpenseAccountCode
-     */
-
-    /**
-     * Superannuation liability account code.
-     *
-     * @property string LiabilityAccountCode
-     */
-
-    /**
-     * Superannuation payment date for the current period (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PaymentDateForThisPeriod
-     */
-
-    /**
-     * Superannuation percentage.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * Superannuation amount.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TaxLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TaxLine.php
@@ -4,33 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TaxTypeName Name of the tax type.
+ * @property string $Description Description of the tax line.
+ * @property float $Amount The tax line amount.
+ * @property string $LiabilityAccount The tax line liability account code. For posted pay run you should be able to see liability account code.
+ */
 class TaxLine extends Remote\Model
 {
-    /**
-     * Name of the tax type.
-     *
-     * @property string TaxTypeName
-     */
-
-    /**
-     * Description of the tax line.
-     *
-     * @property string Description
-     */
-
-    /**
-     * The tax line amount.
-     *
-     * @property float Amount
-     */
-
-    /**
-     * The tax line liability account code. For posted pay run you should be able to see liability account
-     * code.
-     *
-     * @property string LiabilityAccount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Payslip/TimesheetEarningsLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollAU\Payslip;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsRateID Xero identifier for payroll earnings rate.
+ * @property float $RatePerUnit Rate per unit for earnings rate.
+ * @property float $NumberOfUnits The Number of Units of the Timesheet Earnings Line.
+ */
 class TimesheetEarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings rate.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * The Number of Units of the Timesheet Earnings Line.
-     *
-     * @property float NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Setting.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting.php
@@ -6,27 +6,13 @@ use XeroPHP\Remote;
 use XeroPHP\Models\PayrollAU\Setting\Account;
 use XeroPHP\Models\PayrollAU\Setting\TrackingCategory;
 
+/**
+ * @property Account[] $Accounts Payroll Account details for SuperExpense, SuperLiabilty, WagesExpense, PAYGLiability & WagesPayable. See Accounts.
+ * @property TrackingCategory[] $TrackingCategories Tracking categories for Employee’s and Timesheet’s.  See Tracking Categories.
+ * @property string $DaysInPayrollYear Number of days in the Payroll year.
+ */
 class Setting extends Remote\Model
 {
-    /**
-     * Payroll Account details for SuperExpense, SuperLiabilty, WagesExpense, PAYGLiability & WagesPayable.
-     *  See Accounts.
-     *
-     * @property Account[] Accounts
-     */
-
-    /**
-     * Tracking categories for Employee’s and Timesheet’s.  See Tracking Categories.
-     *
-     * @property TrackingCategory[] TrackingCategories
-     */
-
-    /**
-     * Number of days in the Payroll year.
-     *
-     * @property string DaysInPayrollYear
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Setting/Account.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/Account.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $AccountID Xero account identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $Type See Account Types.
+ * @property string $Code Customer defined account code eg. 200.
+ * @property string $Name Name of account.
+ */
 class Account extends Remote\Model
 {
-    /**
-     * Xero account identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * See Account Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * Customer defined account code eg. 200.
-     *
-     * @property string Code
-     */
-
-    /**
-     * Name of account.
-     *
-     * @property string Name
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Setting/EmployeeGroup.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/EmployeeGroup.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TrackingCategoryID Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $TrackingCategoryName Name of tracking category.
+ */
 class EmployeeGroup extends Remote\Model
 {
-    /**
-     * Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string TrackingCategoryID
-     */
-
-    /**
-     * Name of tracking category.
-     *
-     * @property string TrackingCategoryName
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Setting/TimesheetCategory.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/TimesheetCategory.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TrackingCategoryID Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $TrackingCategoryName Name of tracking category.
+ */
 class TimesheetCategory extends Remote\Model
 {
-    /**
-     * Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string TrackingCategoryID
-     */
-
-    /**
-     * Name of tracking category.
-     *
-     * @property string TrackingCategoryName
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Setting/TrackingCategory.php
+++ b/src/XeroPHP/Models/PayrollAU/Setting/TrackingCategory.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollAU\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property EmployeeGroup $employeeGroups Employee Groups tracking category
+ * @property TimesheetCategory $timesheetCategories Timesheet Categories tracking category
+ */
 class TrackingCategory extends Remote\Model
 {
-    /**
-     * Employee Groups tracking category
-     *
-     * @property EmployeeGroup employeeGroups
-     */
-
-    /**
-     * Timesheet Categories tracking category
-     *
-     * @property TimesheetCategory timesheetCategories
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SuperFundID Xero identifier.
+ * @property string $Type REGULATED see Super Fund Types.
+ * @property string $ABN The ABN of the Regulated SuperFund.
+ * @property string $USI The USI of the Regulated SuperFund.
+ */
 class SuperFund extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string SuperFundID
-     */
-
-    /**
-     * REGULATED see Super Fund Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * The ABN of the Regulated SuperFund.
-     *
-     * @property string ABN
-     */
-
-    /**
-     * The USI of the Regulated SuperFund.
-     *
-     * @property string USI
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/SuperFund/SuperFund.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFund/SuperFund.php
@@ -4,63 +4,20 @@ namespace XeroPHP\Models\PayrollAU\SuperFund;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Type SMSF see Super Fund Types.
+ * @property string $Name Name of the super fund (max length = 76) e.g Clive Monk Superannuation Fund.
+ * @property string $ABN ABN of the self managed super fund. (max length = 11) e.g 839182848805.
+ * @property string $BSB BSB of the self managed super fund. (max length = 6) e.g 123123.
+ * @property string $AccountNumber The account number for the self managed super fund. (max length = 9) e.g 234324324.
+ * @property string $AccountName The account name for the self managed super fund (max length = 32) e.g Clive Monk Superannuation Fund.
+ * @property string $ElectronicServiceAddress The electronic service address for the self managed super fund (max length = 16).
+ * @property string $SuperFundID Xero identifier e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $EmployerNumber Some funds assign a unique number to each employer (max length = 20).
+ * @property string $SPIN
+ */
 class SuperFund extends Remote\Model
 {
-    /**
-     * SMSF see Super Fund Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * Name of the super fund (max length = 76) e.g Clive Monk Superannuation Fund.
-     *
-     * @property string Name
-     */
-
-    /**
-     * ABN of the self managed super fund. (max length = 11) e.g 839182848805.
-     *
-     * @property string ABN
-     */
-
-    /**
-     * BSB of the self managed super fund. (max length = 6) e.g 123123.
-     *
-     * @property string BSB
-     */
-
-    /**
-     * The account number for the self managed super fund. (max length = 9) e.g 234324324.
-     *
-     * @property string AccountNumber
-     */
-
-    /**
-     * The account name for the self managed super fund (max length = 32) e.g Clive Monk Superannuation
-     * Fund.
-     *
-     * @property string AccountName
-     */
-
-    /**
-     * The electronic service address for the self managed super fund (max length = 16).
-     *
-     * @property string ElectronicServiceAddress
-     */
-
-    /**
-     * Xero identifier e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string SuperFundID
-     */
-
-    /**
-     * Some funds assign a unique number to each employer (max length = 20).
-     *
-     * @property string EmployerNumber
-     */
-
     /**
      * The SPIN of the Regulated SuperFund. This field has been deprecated.  It will only be present for
      * legacy superfunds.  New superfunds will not have a SPIN value.  The USI field should be used instead

--- a/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
+++ b/src/XeroPHP/Models/PayrollAU/SuperFundProduct.php
@@ -4,35 +4,14 @@ namespace XeroPHP\Models\PayrollAU;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ABN The ABN of the Regulated SuperFund (e.g 40022701955).
+ * @property string $USI The USI of the Regulated SuperFund (e.g 40022701955001).
+ * @property string $ProductName The name of the Regulated SuperFund.
+ * @property string $SPIN The SPIN of the Regulated SuperFund. (e.g NML0117AU) This field has been deprecated. New superfunds will not have a SPIN value. The USI field should be used instead of SPIN.
+ */
 class SuperFundProduct extends Remote\Model
 {
-    /**
-     * The ABN of the Regulated SuperFund (e.g 40022701955).
-     *
-     * @property string ABN
-     */
-
-    /**
-     * The USI of the Regulated SuperFund (e.g 40022701955001).
-     *
-     * @property string USI
-     */
-
-    /**
-     * The SPIN of the Regulated SuperFund. (e.g NML0117AU) This field has been deprecated.  New superfunds
-     * will not have a SPIN value.  The USI field should be used instead of SPIN.
-     *
-     * @property string SPIN
-     *
-     * @deprecated
-     */
-
-    /**
-     * The name of the Regulated SuperFund.
-     *
-     * @property string ProductName
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollAU/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet.php
@@ -5,49 +5,17 @@ namespace XeroPHP\Models\PayrollAU;
 use XeroPHP\Remote;
 use XeroPHP\Models\PayrollAU\Timesheet\TimesheetLine;
 
+/**
+ * @property string $EmployeeID The Xero identifier for an employee.
+ * @property \DateTimeInterface $StartDate Period start date (YYYY-MM-DD).
+ * @property \DateTimeInterface $EndDate Period end date (YYYY-MM-DD).
+ * @property TimesheetLine[] $TimesheetLines See TimesheetLines.
+ * @property string $Status See Timesheet Status Codes.
+ * @property string $Hours Timesheet total hours.
+ * @property string $TimesheetID The Xero identifier for a Payroll Timesheet.
+ */
 class Timesheet extends Remote\Model
 {
-    /**
-     * The Xero identifier for an employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * Period start date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * Period end date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface EndDate
-     */
-
-    /**
-     * See TimesheetLines.
-     *
-     * @property TimesheetLine[] TimesheetLines
-     */
-
-    /**
-     * See Timesheet Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Timesheet total hours.
-     *
-     * @property string Hours
-     */
-
-    /**
-     * The Xero identifier for a Payroll Timesheet.
-     *
-     * @property string TimesheetID
-     */
     const STATUS_DRAFT = 'DRAFT';
 
     const STATUS_PROCESSED = 'PROCESSED';

--- a/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollAU/Timesheet/TimesheetLine.php
@@ -4,27 +4,13 @@ namespace XeroPHP\Models\PayrollAU\Timesheet;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsRateID The Xero identifier for an Earnings Rate.
+ * @property string $TrackingItemID The Xero identifier for a Tracking Category <TrackingOptionID>. The <TrackingOptionID> must belong to the TrackingCategory selected as <TimesheetCategories> under Payroll Settings.
+ * @property float[] $NumberOfUnits Number of units of a Timesheet line.
+ */
 class TimesheetLine extends Remote\Model
 {
-    /**
-     * The Xero identifier for an Earnings Rate.
-     *
-     * @property string EarningsRateID
-     */
-
-    /**
-     * The Xero identifier for a Tracking Category <TrackingOptionID>. The <TrackingOptionID> must belong
-     * to the TrackingCategory selected as <TimesheetCategories> under Payroll Settings.
-     *
-     * @property string TrackingItemID
-     */
-
-    /**
-     * Number of units of a Timesheet line.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUK/Employee/Leave.php
+++ b/src/XeroPHP/Models/PayrollUK/Employee/Leave.php
@@ -5,43 +5,16 @@ namespace XeroPHP\Models\PayrollUK\Employee;
 use XeroPHP\Models\PayrollUK\Employee\Leave\Period;
 use XeroPHP\Remote;
 
+/**
+ * @property string $LeaveID Xero identifier.
+ * @property string $LeaveTypeID The Xero identifier for Leave Type.
+ * @property \DateTimeInterface $StartDate Start date of the leave (YYYY-MM-DD).
+ * @property \DateTimeInterface $EndDate End date of the leave (YYYY-MM-DD).
+ * @property string $Description The Description of the Leave (max length = 200).
+ * @property Period[] $Periods The leave period information.
+ */
 class Leave extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string LeaveID
-     */
-
-    /**
-     * The Xero identifier for Leave Type.
-     *
-     * @property string LeaveTypeID
-     */
-
-    /**
-     * Start date of the leave (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * End date of the leave (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface EndDate
-     */
-
-    /**
-     * The Description of the Leave (max length = 200).
-     *
-     * @property string Description
-     */
-
-    /**
-     * The leave period information.
-     *
-     * @property Period[] Periods
-     */
     const LEAVE_PERIOD_STATUS_SCHEDULED = 'Scheduled';
 
     const LEAVE_PERIOD_STATUS_PROCESSED = 'Processed';

--- a/src/XeroPHP/Models/PayrollUK/Employee/Leave/Period.php
+++ b/src/XeroPHP/Models/PayrollUK/Employee/Leave/Period.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollUK\Employee\Leave;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $NumberOfUnits The Number of Units for the leave.
+ * @property \DateTimeInterface $PeriodEndDate The Period End Date (YYYY-MM-DD).
+ * @property \DateTimeInterface $PeriodStartDate The Period Start Date (YYYY-MM-DD).
+ * @property string $PeriodStatus See PeriodStatus.
+ */
 class Period extends Remote\Model
 {
-    /**
-     * The Number of Units for the leave.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * The Period End Date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PeriodEndDate
-     */
-
-    /**
-     * The Period Start Date (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface PeriodStartDate
-     */
-
-    /**
-     * See PeriodStatus.
-     *
-     * @property string PeriodStatus
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee.php
@@ -12,183 +12,39 @@ use XeroPHP\Models\PayrollUS\Employee\MailingAddress;
 use XeroPHP\Models\PayrollUS\Employee\OpeningBalance;
 use XeroPHP\Models\PayrollUS\Employee\TimeOffBalance;
 
+/**
+ * @property string $FirstName First name of employee (max length = 35).
+ * @property string $LastName Last name of employee (max length = 35).
+ * @property \DateTimeInterface $DateOfBirth Date of birth of employee (YYYY-MM-DD).
+ * @property HomeAddress $HomeAddress Employee home address. See HomeAddress.
+ * @property string $MiddleNames Middle name(s) of the employee (max length = 35).
+ * @property string $JobTitle Job Title of the employee.
+ * @property string $Email Employee email address.
+ * @property string $Gender Gender of employee (M or F).
+ * @property MailingAddress $MailingAddress See MailingAddress.
+ * @property string $Phone Phone number of employee.
+ * @property string $EmployeeNumber Employee Number.
+ * @property string $SocialSecurityNumber Social Security Number of the employee (xxx-xx-xxxx).
+ * @property \DateTimeInterface $StartDate Start date of employee (YYYY-MM-DD).
+ * @property \DateTimeInterface $TerminationDate Termination date of employee (YYYY-MM-DD). Note this is only returned when retrieving an individual Employee with a Status of TERMINATED.
+ * @property string $PayScheduleID Xero unique identifier – PayScheduleID for the employee.
+ * @property string $EmployeeGroupName Employee group name.
+ * @property string $EmploymentBasis See Employment Basis Types.
+ * @property string $HolidayGroupID HolidayGroupID of the employee.
+ * @property bool $IsAuthorisedToApproveTimeOff Boolean to specify if employee is authorised to approve time off.
+ * @property bool $IsAuthorisedToApproveTimesheets Boolean to specify if employee is authorised to approve timesheets.
+ * @property SalaryAndWage[] $SalaryAndWages See SalaryAndWages.
+ * @property WorkLocation[] $WorkLocations See WorkLocations.
+ * @property PaymentMethod $PaymentMethod See PaymentMethods.
+ * @property PayTemplate $PayTemplate See PayTemplate.
+ * @property OpeningBalance[] $OpeningBalances See OpeningBalances.
+ * @property TimeOffBalance[] $TimeOffBalances See TimeOffBalances.
+ * @property string $EmployeeID Xero unique identifier for an Employee.
+ * @property string $Status See Employee Status Types.
+ * @property \DateTimeInterface $UpdatedDateUTC Last modified timestamp.
+ */
 class Employee extends Remote\Model
 {
-    /**
-     * First name of employee (max length = 35).
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Last name of employee (max length = 35).
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Date of birth of employee (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface DateOfBirth
-     */
-
-    /**
-     * Employee home address. See HomeAddress.
-     *
-     * @property HomeAddress HomeAddress
-     */
-
-    /**
-     * Middle name(s) of the employee (max length = 35).
-     *
-     * @property string MiddleNames
-     */
-
-    /**
-     * Job Title of the employee.
-     *
-     * @property string JobTitle
-     */
-
-    /**
-     * Employee email address.
-     *
-     * @property string Email
-     */
-
-    /**
-     * Gender of employee (M or F).
-     *
-     * @property string Gender
-     */
-
-    /**
-     * See MailingAddress.
-     *
-     * @property MailingAddress MailingAddress
-     */
-
-    /**
-     * Phone number of employee.
-     *
-     * @property string Phone
-     */
-
-    /**
-     * Employee Number.
-     *
-     * @property string EmployeeNumber
-     */
-
-    /**
-     * Social Security Number of the employee (xxx-xx-xxxx).
-     *
-     * @property string SocialSecurityNumber
-     */
-
-    /**
-     * Start date of employee (YYYY-MM-DD).
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * Termination date of employee (YYYY-MM-DD). Note this is only returned when retrieving an individual
-     * Employee with a Status of TERMINATED.
-     *
-     * @property \DateTimeInterface TerminationDate
-     */
-
-    /**
-     * Xero unique identifier – PayScheduleID for the employee.
-     *
-     * @property string PayScheduleID
-     */
-
-    /**
-     * Employee group name.
-     *
-     * @property string EmployeeGroupName
-     */
-
-    /**
-     * See Employment Basis Types.
-     *
-     * @property string EmploymentBasis
-     */
-
-    /**
-     * HolidayGroupID of the employee.
-     *
-     * @property string HolidayGroupID
-     */
-
-    /**
-     * Boolean to specify if employee is authorised to approve time off.
-     *
-     * @property bool IsAuthorisedToApproveTimeOff
-     */
-
-    /**
-     * Boolean to specify if employee is authorised to approve timesheets.
-     *
-     * @property bool IsAuthorisedToApproveTimesheets
-     */
-
-    /**
-     * See SalaryAndWages.
-     *
-     * @property SalaryAndWage[] SalaryAndWages
-     */
-
-    /**
-     * See WorkLocations.
-     *
-     * @property WorkLocation[] WorkLocations
-     */
-
-    /**
-     * See PaymentMethods.
-     *
-     * @property PaymentMethod PaymentMethod
-     */
-
-    /**
-     * See PayTemplate.
-     *
-     * @property PayTemplate PayTemplate
-     */
-
-    /**
-     * See OpeningBalances.
-     *
-     * @property OpeningBalance[] OpeningBalances
-     */
-
-    /**
-     * See TimeOffBalances.
-     *
-     * @property TimeOffBalance[] TimeOffBalances
-     */
-
-    /**
-     * Xero unique identifier for an Employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * See Employee Status Types.
-     *
-     * @property string Status
-     */
-
-    /**
-     * Last modified timestamp.
-     *
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/BankAccount.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/BankAccount.php
@@ -4,51 +4,17 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $AccountHolderName The name of bank account holder exactly how the bank has it.
+ * @property string $StatementText The text that will appear on your employee’s bank statement when they receive payment.
+ * @property string $AccountType See Account Types.
+ * @property string $RoutingNumber Bank routing number is the nine digit number used to identify a financial institution.
+ * @property string $AccountNumber The account number for the bank account.
+ * @property float $Amount Fixed amounts (for example, if an employee wants to have $100 of their salary transferred to one account, and the remaining amount to another).
+ * @property string $Remainder Set it to true if this bank account should be the Remainder bank account.
+ */
 class BankAccount extends Remote\Model
 {
-    /**
-     * The name of bank account holder exactly how the bank has it.
-     *
-     * @property string AccountHolderName
-     */
-
-    /**
-     * The text that will appear on your employee’s bank statement when they receive payment.
-     *
-     * @property string StatementText
-     */
-
-    /**
-     * See Account Types.
-     *
-     * @property string AccountType
-     */
-
-    /**
-     * Bank routing number is the nine digit number used to identify a financial institution.
-     *
-     * @property string RoutingNumber
-     */
-
-    /**
-     * The account number for the bank account.
-     *
-     * @property string AccountNumber
-     */
-
-    /**
-     * Fixed amounts (for example, if an employee wants to have $100 of their salary transferred to one
-     * account, and the remaining amount to another).
-     *
-     * @property float Amount
-     */
-
-    /**
-     * Set it to true if this bank account should be the Remainder bank account.
-     *
-     * @property string Remainder
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/HomeAddress.php
@@ -4,50 +4,17 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $StreetAddress Street Address for employee home address.
+ * @property string $SuiteOrAptOrUnit Suite, Apartment or Unit information for employee home address.
+ * @property string $City City for employee home address.
+ * @property string $State State abbreviation for employee home address.
+ * @property string $Zip Zip (Post code) for employee home address.
+ * @property string $Lattitude The Latitude of employee home address.
+ * @property string $Longitude The Longitude of employee home address.
+ */
 class HomeAddress extends Remote\Model
 {
-    /**
-     * Street Address for employee home address.
-     *
-     * @property string StreetAddress
-     */
-
-    /**
-     * Suite, Apartment or Unit information for employee home address.
-     *
-     * @property string SuiteOrAptOrUnit
-     */
-
-    /**
-     * City for employee home address.
-     *
-     * @property string City
-     */
-
-    /**
-     * State abbreviation for employee home address.
-     *
-     * @property string State
-     */
-
-    /**
-     * Zip (Post code) for employee home address.
-     *
-     * @property string Zip
-     */
-
-    /**
-     * The Latitude of employee home address.
-     *
-     * @property string Lattitude
-     */
-
-    /**
-     * The Longitude of employee home address.
-     *
-     * @property string Longitude
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/MailingAddress.php
@@ -4,50 +4,17 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $StreetAddress Street Address for employee home address.
+ * @property string $SuiteOrAptOrUnit Suite, Apartment or Unit information for employee home address.
+ * @property string $City City for employee home address.
+ * @property string $State State abbreviation for employee home address.
+ * @property string $Zip Zip (Post code) for employee home address.
+ * @property string $Lattitude The Latitude of employee home address.
+ * @property string $Longitude The Longitude of employee home address.
+ */
 class MailingAddress extends Remote\Model
 {
-    /**
-     * Street Address for employee home address.
-     *
-     * @property string StreetAddress
-     */
-
-    /**
-     * Suite, Apartment or Unit information for employee home address.
-     *
-     * @property string SuiteOrAptOrUnit
-     */
-
-    /**
-     * City for employee home address.
-     *
-     * @property string City
-     */
-
-    /**
-     * State abbreviation for employee home address.
-     *
-     * @property string State
-     */
-
-    /**
-     * Zip (Post code) for employee home address.
-     *
-     * @property string Zip
-     */
-
-    /**
-     * The Latitude of employee home address.
-     *
-     * @property string Lattitude
-     */
-
-    /**
-     * The Longitude of employee home address.
-     *
-     * @property string Longitude
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/OpeningBalance.php
@@ -8,62 +8,20 @@ use XeroPHP\Models\PayrollUS\Paystub\EarningsLine;
 use XeroPHP\Models\PayrollUS\Paystub\DeductionLine;
 use XeroPHP\Models\PayrollUS\Paystub\ReimbursementLine;
 
+/**
+ * @property EarningsLine[] $EarningsLines The EarningsLines of the OpeningBalance.
+ * @property BenefitLine[] $BenefitLines The BenefitLines of the OpeningBalance.
+ * @property DeductionLine[] $DeductionLines The DeductionLines of the OpeningBalance.
+ * @property ReimbursementLine[] $ReimbursementLines The ReimbursementLines of the OpeningBalance.
+ * @property string $EarningsTypeID Xero earnings rate identifier.
+ * @property float $Amount Reimbursement type amount.
+ * @property string $BenefitTypeID Xero benefit type identifier.
+ * @property string $DeductionTypeID Xero deduction type identifier.
+ * @property string $ReimbursementTypeID Xero reimbursement type identifier.
+ * @property string $EmployeeID
+ */
 class OpeningBalance extends Remote\Model
 {
-    /**
-     * The EarningsLines of the OpeningBalance.
-     *
-     * @property EarningsLine[] EarningsLines
-     */
-
-    /**
-     * The BenefitLines of the OpeningBalance.
-     *
-     * @property BenefitLine[] BenefitLines
-     */
-
-    /**
-     * The DeductionLines of the OpeningBalance.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * The ReimbursementLines of the OpeningBalance.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * Xero earnings rate identifier.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * Reimbursement type amount.
-     *
-     * @property float Amount
-     */
-
-    /**
-     * Xero benefit type identifier.
-     *
-     * @property string BenefitTypeID
-     */
-
-    /**
-     * Xero deduction type identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * Xero reimbursement type identifier.
-     *
-     * @property string ReimbursementTypeID
-     */
-
     /**
      * This property has been removed from the Xero API.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PayTemplate.php
@@ -7,97 +7,25 @@ use XeroPHP\Models\PayrollUS\Paystub\BenefitLine;
 use XeroPHP\Models\PayrollUS\Paystub\DeductionLine;
 use XeroPHP\Models\PayrollUS\Paystub\ReimbursementLine;
 
+/**
+ * @property float[] $EarningsLines The earnings rate lines.
+ * @property DeductionLine[] $DeductionLines The deduction type lines.
+ * @property ReimbursementLine[] $ReimbursementLines The reimbursement type lines.
+ * @property BenefitLine[] $BenefitLines The benefit type lines.
+ * @property string $EarningsTypeID Xero earnings rate identifier.
+ * @property string $UnitsOrHours The Units or Hours for the earnings line.
+ * @property float $RatePerUnit Rate per unit for the EarningsLine.
+ * @property float $Amount The amount of the reimbursement type.
+ * @property string $DeductionTypeID Xero deduction type identifier.
+ * @property string $CalculationType See Benefit Line Calculation Type.
+ * @property float $EmployeeMax Maximum amount an employee can receive.
+ * @property string $Percentage The percentage of deduction line.
+ * @property string $ReimbursementTypeID Xero identifier for reimbursement type.
+ * @property string $Description The description of the reimbursement line.
+ * @property string $BenefitTypeID Xero identifier for benefit type.
+ */
 class PayTemplate extends Remote\Model
 {
-    /**
-     * The earnings rate lines.
-     *
-     * @property float[] EarningsLines
-     */
-
-    /**
-     * The deduction type lines.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * The reimbursement type lines.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * The benefit type lines.
-     *
-     * @property BenefitLine[] BenefitLines
-     */
-
-    /**
-     * Xero earnings rate identifier.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * The Units or Hours for the earnings line.
-     *
-     * @property string UnitsOrHours
-     */
-
-    /**
-     * Rate per unit for the EarningsLine.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * The amount of the reimbursement type.
-     *
-     * @property float Amount
-     */
-
-    /**
-     * Xero deduction type identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * See Benefit Line Calculation Type.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * Maximum amount an employee can receive.
-     *
-     * @property float EmployeeMax
-     */
-
-    /**
-     * The percentage of deduction line.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * Xero identifier for reimbursement type.
-     *
-     * @property string ReimbursementTypeID
-     */
-
-    /**
-     * The description of the reimbursement line.
-     *
-     * @property string Description
-     */
-
-    /**
-     * Xero identifier for benefit type.
-     *
-     * @property string BenefitTypeID
-     */
     const DEDUCTION_LINE_CALCULATION_TYPE_FIXEDAMOUNT = 'FIXEDAMOUNT';
 
     const DEDUCTION_LINE_CALCULATION_TYPE_STANDARDAMOUNT = 'STANDARDAMOUNT';

--- a/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/PaymentMethod.php
@@ -4,19 +4,12 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PaymentMethodType See PaymentMethodTypes.
+ * @property BankAccount[] $BankAccounts The Bank accounts for the employee. Only Applies when PaymentMethodType is DIRECTDEPOSIT.
+ */
 class PaymentMethod extends Remote\Model
 {
-    /**
-     * See PaymentMethodTypes.
-     *
-     * @property string PaymentMethodType
-     */
-
-    /**
-     * The Bank accounts for the employee. Only Applies when PaymentMethodType is DIRECTDEPOSIT.
-     *
-     * @property BankAccount[] BankAccounts
-     */
     const PAYMENT_METHOD_TYPE_CHECK = 'CHECK';
 
     const PAYMENT_METHOD_TYPE_MANUAL = 'MANUAL';

--- a/src/XeroPHP/Models/PayrollUS/Employee/SalaryAndWage.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/SalaryAndWage.php
@@ -4,58 +4,18 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $SalaryAndWagesID Xero unique identifier for SalaryAndWage item. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $EarningsTypeID Xero unique identifier for EarningsType item. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $SalaryWagesType See Salary and Wages Types.
+ * @property float $HourlyRate The Hourly rate of the Salary and Wages Type. Applies only when SalaryWagesType is HOURLY.
+ * @property string $AnnualSalary The annual salary for the Salary and wages. Applies only when SalaryWagesType is SALARY.
+ * @property string $StandardHoursPerWeek Number of hours per week.
+ * @property \DateTimeInterface $EffectiveDate The effective date of the Salary and Wages.
+ * @property string $SalaryAndWageID Deprecated: this property has been removed from the Xero API.
+ */
 class SalaryAndWage extends Remote\Model
 {
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string SalaryAndWageID
-     *
-     * @deprecated
-     */
-
-    /**
-     * Xero unique identifier for SalaryAndWage item. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string SalaryAndWagesID
-     */
-
-    /**
-     * Xero unique identifier for EarningsType item. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * See Salary and Wages Types.
-     *
-     * @property string SalaryWagesType
-     */
-
-    /**
-     * The Hourly rate of the Salary and Wages Type. Applies only when SalaryWagesType is HOURLY.
-     *
-     * @property float HourlyRate
-     */
-
-    /**
-     * The annual salary for the Salary and wages. Applies only when SalaryWagesType is SALARY.
-     *
-     * @property string AnnualSalary
-     */
-
-    /**
-     * Number of hours per week.
-     *
-     * @property string StandardHoursPerWeek
-     */
-
-    /**
-     * The effective date of the Salary and Wages.
-     *
-     * @property \DateTimeInterface EffectiveDate
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/TimeOffBalance.php
@@ -5,38 +5,15 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 use XeroPHP\Remote;
 use XeroPHP\Models\PayrollUS\PayItem;
 
+/**
+ * @property string $TimeOffName The name of the leave type.
+ * @property PayItem $TimeOffTypeId Identifier of the leave type (see PayItems).
+ * @property string $NumberOfUnits The balance of the leave available.
+ * @property PayItem[] $TypeOfUnits The type of units as specified by the LeaveType (see PayItems).
+ * @property string $EmployeeID The Xero identifier for an employee e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
+ */
 class TimeOffBalance extends Remote\Model
 {
-    /**
-     * The name of the leave type.
-     *
-     * @property string TimeOffName
-     */
-
-    /**
-     * Identifier of the leave type (see PayItems).
-     *
-     * @property PayItem TimeOffTypeId
-     */
-
-    /**
-     * The balance of the leave available.
-     *
-     * @property string NumberOfUnits
-     */
-
-    /**
-     * The type of units as specified by the LeaveType (see PayItems).
-     *
-     * @property PayItem[] TypeOfUnits
-     */
-
-    /**
-     * The Xero identifier for an employee e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9.
-     *
-     * @property string EmployeeID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Employee/WorkLocation.php
+++ b/src/XeroPHP/Models/PayrollUS/Employee/WorkLocation.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollUS\Employee;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $WorkLocationID Xero unique identifier for WorkLocation. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property bool $IsPrimary Boolean to specify if this work location is the primary work location.
+ */
 class WorkLocation extends Remote\Model
 {
-    /**
-     * Xero unique identifier for WorkLocation. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string WorkLocationID
-     */
-
-    /**
-     * Boolean to specify if this work location is the primary work location.
-     *
-     * @property bool IsPrimary
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/PayItem.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem.php
@@ -9,38 +9,15 @@ use XeroPHP\Models\PayrollUS\PayItem\EarningsType;
 use XeroPHP\Models\PayrollUS\PayItem\DeductionType;
 use XeroPHP\Models\PayrollUS\PayItem\ReimbursementType;
 
+/**
+ * @property EarningsType[] $EarningsTypes See EarningsTypes.
+ * @property BenefitType[] $BenefitTypes See BenefitTypes.
+ * @property DeductionType[] $DeductionTypes See DeductionTypes.
+ * @property ReimbursementType[] $ReimbursementTypes See ReimbursementTypes.
+ * @property TimeOffType[] $TimeOffTypes See TimeOffTypes.
+ */
 class PayItem extends Remote\Model
 {
-    /**
-     * See EarningsTypes.
-     *
-     * @property EarningsType[] EarningsTypes
-     */
-
-    /**
-     * See BenefitTypes.
-     *
-     * @property BenefitType[] BenefitTypes
-     */
-
-    /**
-     * See DeductionTypes.
-     *
-     * @property DeductionType[] DeductionTypes
-     */
-
-    /**
-     * See ReimbursementTypes.
-     *
-     * @property ReimbursementType[] ReimbursementTypes
-     */
-
-    /**
-     * See TimeOffTypes.
-     *
-     * @property TimeOffType[] TimeOffTypes
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/BenefitType.php
@@ -4,64 +4,19 @@ namespace XeroPHP\Models\PayrollUS\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property BenefitType $BenefitType Name of the benefit type (max length = 100).
+ * @property string $BenefitCategory The category defines the tax implications of the benefit type so it is taxed properly. See BenefitCategory.
+ * @property string $LiabilityAccountCode The account to which the amount of the benefit is to be credited.
+ * @property string $ExpenseAccountCode The account to which the amount of the benefit is to be debited.
+ * @property string $BenefitTypeID Xero identifier.
+ * @property float $StandardAmount This is a default amount you can set for all employees assigned to this benefit type.
+ * @property float $CompanyMax The company max is the maximum amount set as a default amount for that particular benefit type for all employees assigned this benefit type in a single year.
+ * @property string $Percentage This is a default percentage you can set for all employees assigned to this benefit type.
+ * @property float $ShowBalanceOnPaystub Set this to true if you want this benefit item amount and YTD balance will show on the employee’s paystubs.
+ */
 class BenefitType extends Remote\Model
 {
-    /**
-     * Name of the benefit type (max length = 100).
-     *
-     * @property BenefitType BenefitType
-     */
-
-    /**
-     * The category defines the tax implications of the benefit type so it is taxed properly. See
-     * BenefitCategory.
-     *
-     * @property string BenefitCategory
-     */
-
-    /**
-     * The account to which the amount of the benefit is to be credited.
-     *
-     * @property string LiabilityAccountCode
-     */
-
-    /**
-     * The account to which the amount of the benefit is to be debited.
-     *
-     * @property string ExpenseAccountCode
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string BenefitTypeID
-     */
-
-    /**
-     * This is a default amount you can set for all employees assigned to this benefit type.
-     *
-     * @property float StandardAmount
-     */
-
-    /**
-     * The company max is the maximum amount set as a default amount for that particular benefit type for
-     * all employees assigned this benefit type in a single year.
-     *
-     * @property float CompanyMax
-     */
-
-    /**
-     * This is a default percentage you can set for all employees assigned to this benefit type.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * Set this to true if you want this benefit item amount and YTD balance will show on the employee’s
-     * paystubs.
-     *
-     * @property float ShowBalanceOnPaystub
-     */
     const BENEFITCATEGORY_AFTERTAXBENEFIT = 'AFTERTAXBENEFIT';
 
     const BENEFITCATEGORY_DEPENDENTCARE = 'DEPENDENTCARE';

--- a/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/DeductionType.php
@@ -4,64 +4,17 @@ namespace XeroPHP\Models\PayrollUS\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property DeductionType $DeductionType Name of the deduction type (max length = 50).
+ * @property string $DeductionCategory The category defines the tax implications of the deduction type so it is taxed properly.
+ * @property float $CalculationType Deductions can be a fixed amount, or they can be calculated as a percentage of the employee’s total earnings. Standard Plan, Catch-up Plan. Only needed DeductionCategory is not AFTERTAXDEDUCTION, DEPENDEDNTCARE, FLEXIBLESPENDINGACCOUNT,HSASINGLEPLAN, HSAFAMILYPLAN, SECTION125PLAN.
+ * @property string $LiabilityAccountCode The computed amount of the deduction is credited to this account. See See Accounts.
+ * @property string $DeductionTypeID Xero identifier.
+ * @property float $StandardAmount This is a default amount you can set for all employees assigned to this deduction type. If you have more than one employee that pays the same amount for health insurance, setting this amount will save you time when setting up the employee deductions. If you choose not to set an amount here, you can enter the amounts to be deducted on a per employee basis. Only applicable when DeductionCategory is AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT, SECTION125PLAN.
+ * @property float $CompanyMax The company max is the maximum amount set as a default amount to be deducted for that particular deduction type for all employees assigned this deduction type in a single year. For example, the IRS publishes limits for certain deduction types each year. You can set a company maximum that is lower than the IRS limit, depending on your plan requirements. If you don’t set a maximum, the deduction will stop automatically when the IRS limit is reached. Only applicable when DeductionCategory is AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT, SECTION125PLAN.
+ */
 class DeductionType extends Remote\Model
 {
-    /**
-     * Name of the deduction type (max length = 50).
-     *
-     * @property DeductionType DeductionType
-     */
-
-    /**
-     * The category defines the tax implications of the deduction type so it is taxed properly.
-     *
-     * @property string DeductionCategory
-     */
-
-    /**
-     * Deductions can be a fixed amount, or they can be calculated as a percentage of the employee’s
-     * total earnings. Standard Plan, Catch-up Plan. Only needed DeductionCategory is not
-     * AFTERTAXDEDUCTION, DEPENDEDNTCARE, FLEXIBLESPENDINGACCOUNT,HSASINGLEPLAN, HSAFAMILYPLAN,
-     * SECTION125PLAN.
-     *
-     * @property float CalculationType
-     */
-
-    /**
-     * The computed amount of the deduction is credited to this account. See See Accounts.
-     *
-     * @property string LiabilityAccountCode
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * This is a default amount you can set for all employees assigned to this deduction type. If you have
-     * more than one employee that pays the same amount for health insurance, setting this amount will save
-     * you time when setting up the employee deductions. If you choose not to set an amount here, you can
-     * enter the amounts to be deducted on a per employee basis. Only applicable when DeductionCategory is
-     * AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT,
-     * SECTION125PLAN.
-     *
-     * @property float StandardAmount
-     */
-
-    /**
-     * The company max is the maximum amount set as a default amount to be deducted for that particular
-     * deduction type for all employees assigned this deduction type in a single year. For example, the IRS
-     * publishes limits for certain deduction types each year. You can set a company maximum that is lower
-     * than the IRS limit, depending on your plan requirements. If you don’t set a maximum, the deduction
-     * will stop automatically when the IRS limit is reached.
-     * Only applicable when DeductionCategory is
-     * AFTERTAXDEDUCTION, DEPENDENTCARE, FLEXIBLESPENDINGACCOUNT,
-     * SECTION125PLAN.
-     *
-     * @property float CompanyMax
-     */
     const CALCULATION_TYPE_CATCHUPPLAN = 'CATCHUPPLAN';
 
     const CALCULATION_TYPE_STANDARDPLAN = 'STANDARDPLAN';

--- a/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/EarningsType.php
@@ -4,89 +4,22 @@ namespace XeroPHP\Models\PayrollUS\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property EarningsType $EarningsType Name of the earnings type (max length = 100).
+ * @property string $ExpenseAccountCode See Accounts.
+ * @property string $EarningsCategory See EarningsCategory.
+ * @property string $RateType Only when EarningsCategory is OVERTIMEEARNINGS, ALLOWANCE, ADDITIONALEARNINGS.
+ * @property string $TypeOfUnits Only when EarningsCategory is ADDITIONALEARNINGS, ALLOWANCE and RateType is RATEPERUNIT.
+ * @property string $EarningsTypeID Xero identifier.
+ * @property float $Multiple This is the multiplier used to calculate the rate per unit, based on the employee’s ordinary earnings type. For example, for time and a half enter 1.5. Only applicable if RateType is MULTIPLE.
+ * @property string $DoNotAccrueTimeOff Set it to true if time off is NOT to be accumulated based on the hours reported to this earnings type.
+ * @property string $IsSupplemental Set it to true if this earnings type qualifies as a supplemental earnings according to the IRS regulations, e.g bonus or commission.
+ * @property float $Amount Optional for EarningsCategory COMMISSION, BONUS, CASHTIPS, NONCASHTIPS, RETROACTIVEPAY, CLERGYHOUSINGALLOWANCE, CLERGYHOUSINGINKIND (this will be the amount that will be added to the employee’s earnings on a per pay period basis). The ALLOWANCE & ADDITIONALEARNINGS EarningsCategory will also have the Amount field when the Rate Type is selected as FIXEDAMOUNT.
+ * @property string $DisplayName Deprecated: this property has been removed from the Xero API.
+ * @property string $EarningsRateID Deprecated: this property has been removed from the Xero API.
+ */
 class EarningsType extends Remote\Model
 {
-    /**
-     * Name of the earnings type (max length = 100).
-     *
-     * @property EarningsType EarningsType
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string DisplayName
-     *
-     * @deprecated
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string ExpenseAccountCode
-     */
-
-    /**
-     * See EarningsCategory.
-     *
-     * @property string EarningsCategory
-     */
-
-    /**
-     * Only when EarningsCategory is OVERTIMEEARNINGS, ALLOWANCE, ADDITIONALEARNINGS.
-     *
-     * @property string RateType
-     */
-
-    /**
-     * Only when EarningsCategory is ADDITIONALEARNINGS, ALLOWANCE and RateType is RATEPERUNIT.
-     *
-     * @property string TypeOfUnits
-     */
-
-    /**
-     * This property has been removed from the Xero API.
-     *
-     * @property string EarningsRateID
-     *
-     * @deprecated
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * This is the multiplier used to calculate the rate per unit, based on the employee’s ordinary
-     * earnings type. For example, for time and a half enter 1.5. Only applicable if RateType is MULTIPLE.
-     *
-     * @property float Multiple
-     */
-
-    /**
-     * Set it to true if time off is NOT to be accumulated based on the hours reported to this earnings
-     * type.
-     *
-     * @property string DoNotAccrueTimeOff
-     */
-
-    /**
-     * Set it to true if this earnings type qualifies as a supplemental earnings according to the IRS
-     * regulations, e.g bonus or commission.
-     *
-     * @property string IsSupplemental
-     */
-
-    /**
-     * Optional for EarningsCategory COMMISSION, BONUS, CASHTIPS, NONCASHTIPS, RETROACTIVEPAY,
-     * CLERGYHOUSINGALLOWANCE, CLERGYHOUSINGINKIND (this will be the amount that will be added to the
-     * employee’s earnings on a per pay period basis). The ALLOWANCE & ADDITIONALEARNINGS
-     * EarningsCategory will also have the Amount field when the Rate Type is selected as FIXEDAMOUNT.
-     *
-     * @property float Amount
-     */
     const RATETYPE_FIXEDAMOUNT = 'FIXEDAMOUNT';
 
     const RATETYPE_MULTIPLE = 'MULTIPLE';

--- a/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/ReimbursementType.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollUS\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property ReimbursementType $ReimbursementType Name of the reimbursement type (max length = 50).
+ * @property string $ExpenseOrLiabilityAccountCode See Accounts.
+ * @property string $ReimbursementTypeID Xero identifier.
+ */
 class ReimbursementType extends Remote\Model
 {
-    /**
-     * Name of the reimbursement type (max length = 50).
-     *
-     * @property ReimbursementType ReimbursementType
-     */
-
-    /**
-     * See Accounts.
-     *
-     * @property string ExpenseOrLiabilityAccountCode
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string ReimbursementTypeID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
+++ b/src/XeroPHP/Models/PayrollUS/PayItem/TimeOffType.php
@@ -4,49 +4,16 @@ namespace XeroPHP\Models\PayrollUS\PayItem;
 
 use XeroPHP\Remote;
 
+/**
+ * @property TimeOffType $TimeOffType Name of the time off type (max length = 50).
+ * @property string $TimeOffCategory Select Unpaid Time Off to indicate that an employee will not get paid when taking this time off type. If Paid Time Off is selected the employee will get paid when taking this time off type and you can accrue the liability on the Balance Sheet.
+ * @property string $ExpenseAccountCode The account to which the amount of the time off is to be debited. Only applies for TimeOffCategory of PAIDTIMEOFF.
+ * @property string $LiabilityAccountCode The computed amount of the time off is credited to this account.
+ * @property string $TimeOffTypeID Xero identifier.
+ * @property string $ShowBalanceToEmployee Set it to true if you want the balance for this time off type to show on the employee’s paystub and in the employee’s My Payroll account.
+ */
 class TimeOffType extends Remote\Model
 {
-    /**
-     * Name of the time off type (max length = 50).
-     *
-     * @property TimeOffType TimeOffType
-     */
-
-    /**
-     * Select Unpaid Time Off to indicate that an employee will not get paid when taking this time off
-     * type.
-     * If Paid Time Off is selected the employee will get paid when taking this time off type and you
-     * can accrue the liability on the Balance Sheet.
-     *
-     * @property string TimeOffCategory
-     */
-
-    /**
-     * The account to which the amount of the time off is to be debited. Only applies for TimeOffCategory
-     * of PAIDTIMEOFF.
-     *
-     * @property string ExpenseAccountCode
-     */
-
-    /**
-     * The computed amount of the time off is credited to this account.
-     *
-     * @property string LiabilityAccountCode
-     */
-
-    /**
-     * Xero identifier.
-     *
-     * @property string TimeOffTypeID
-     */
-
-    /**
-     * Set it to true if you want the balance for this time off type to show on the employee’s paystub
-     * and in the employee’s My Payroll account.
-     *
-     * @property string ShowBalanceToEmployee
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/PayRun.php
+++ b/src/XeroPHP/Models/PayrollUS/PayRun.php
@@ -4,80 +4,22 @@ namespace XeroPHP\Models\PayrollUS;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PayScheduleID Xero Identifier for the Pay Schedule.
+ * @property \DateTimeInterface $PayRunPeriodEndDate Pay run period end date. Needed if it is an unscheduled pay run.
+ * @property string $PayRunStatus See Pay run status types.
+ * @property string $PayRunID Xero identifier for pay run.
+ * @property \DateTimeInterface $PayRunPeriodStartDate Period Start Date for the PayRun.
+ * @property \DateTimeInterface $PaymentDate Payment Date for the PayRun.
+ * @property string $Earnings Total Earnings for the PayRun.
+ * @property string $Deductions Total Deduction for the PayRun.
+ * @property string $Reimbursement Total Reimbursement for the PayRun.
+ * @property string $NetPay Total NetPay for the PayRun.
+ * @property \DateTimeInterface $UpdateDateUTC The update date for the PayRun.
+ * @property string $PayStubs See PayStubs.
+ */
 class PayRun extends Remote\Model
 {
-    /**
-     * Xero Identifier for the Pay Schedule.
-     *
-     * @property string PayScheduleID
-     */
-
-    /**
-     * Pay run period end date. Needed if it is an unscheduled pay run.
-     *
-     * @property \DateTimeInterface PayRunPeriodEndDate
-     */
-
-    /**
-     * See Pay run status types.
-     *
-     * @property string PayRunStatus
-     */
-
-    /**
-     * Xero identifier for pay run.
-     *
-     * @property string PayRunID
-     */
-
-    /**
-     * Period Start Date for the PayRun.
-     *
-     * @property \DateTimeInterface PayRunPeriodStartDate
-     */
-
-    /**
-     * Payment Date for the PayRun.
-     *
-     * @property \DateTimeInterface PaymentDate
-     */
-
-    /**
-     * Total Earnings for the PayRun.
-     *
-     * @property string Earnings
-     */
-
-    /**
-     * Total Deduction for the PayRun.
-     *
-     * @property string Deductions
-     */
-
-    /**
-     * Total Reimbursement for the PayRun.
-     *
-     * @property string Reimbursement
-     */
-
-    /**
-     * Total NetPay for the PayRun.
-     *
-     * @property string NetPay
-     */
-
-    /**
-     * The update date for the PayRun.
-     *
-     * @property \DateTimeInterface UpdateDateUTC
-     */
-
-    /**
-     * See PayStubs.
-     *
-     * @property string PayStubs
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/PaySchedule.php
+++ b/src/XeroPHP/Models/PayrollUS/PaySchedule.php
@@ -4,38 +4,15 @@ namespace XeroPHP\Models\PayrollUS;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $PayScheduleName Name of the Pay Schedule.
+ * @property \DateTimeInterface $PaymentDate The Payment Date of the Pay Schedule.
+ * @property \DateTimeInterface $StartDate The Start Date of the Pay Schedule.
+ * @property string $ScheduleType The ScheduleType defines the frequency in which an employee gets paid.
+ * @property string $PayScheduleId Xero Identifier.
+ */
 class PaySchedule extends Remote\Model
 {
-    /**
-     * Name of the Pay Schedule.
-     *
-     * @property string PayScheduleName
-     */
-
-    /**
-     * The Payment Date of the Pay Schedule.
-     *
-     * @property \DateTimeInterface PaymentDate
-     */
-
-    /**
-     * The Start Date of the Pay Schedule.
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * The ScheduleType defines the frequency in which an employee gets paid.
-     *
-     * @property string ScheduleType
-     */
-
-    /**
-     * Xero Identifier.
-     *
-     * @property string PayScheduleId
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub.php
@@ -11,118 +11,29 @@ use XeroPHP\Models\PayrollUS\Paystub\LeaveEarningsLine;
 use XeroPHP\Models\PayrollUS\Paystub\ReimbursementLine;
 use XeroPHP\Models\PayrollUS\Paystub\TimesheetEarningsLine;
 
+/**
+ * @property string $EmployeeID Xero identifier for payroll employee.
+ * @property string $PaystubID Xero identifier for payroll paystub.
+ * @property string $PayRunID
+ * @property string $FirstName Employee first name.
+ * @property string $LastName Employee last name.
+ * @property string $LastEdited Last edited.
+ * @property float[] $Earnings The Total Earnings for the PayRun.
+ * @property float[] $Deductions The Total Deductions for the PayRun.
+ * @property float $Tax The Total Tax for the PayRun.
+ * @property float[] $Reimbursements The Total Reimbursement for the PayRun.
+ * @property float $NetPay The Total NetPay for the PayRun.
+ * @property \DateTimeInterface $UpdatedDateUTC
+ * @property EarningsLine[] $EarningsLines See EarningsLine.
+ * @property LeaveEarningsLine[] $LeaveEarningsLines See LeaveEarningsLine.
+ * @property TimesheetEarningsLine[] $TimesheetEarningsLines See TimesheetEarningsLine.
+ * @property DeductionLine[] $DeductionLines See DeductionLine.
+ * @property ReimbursementLine[] $ReimbursementLines See ReimbursementLine.
+ * @property BenefitLine[] $BenefitLines See BenefitLine.
+ * @property TimeOffLine[] $TimeOffLines See TimeOffLine.
+ */
 class Paystub extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * Xero identifier for payroll paystub.
-     *
-     * @property string PaystubID
-     */
-
-    /**
-     * @property string PayRunID
-     */
-
-    /**
-     * Employee first name.
-     *
-     * @property string FirstName
-     */
-
-    /**
-     * Employee last name.
-     *
-     * @property string LastName
-     */
-
-    /**
-     * Last edited.
-     *
-     * @property string LastEdited
-     */
-
-    /**
-     * The Total Earnings for the PayRun.
-     *
-     * @property float[] Earnings
-     */
-
-    /**
-     * The Total Deductions for the PayRun.
-     *
-     * @property float[] Deductions
-     */
-
-    /**
-     * The Total Tax for the PayRun.
-     *
-     * @property float Tax
-     */
-
-    /**
-     * The Total Reimbursement for the PayRun.
-     *
-     * @property float[] Reimbursements
-     */
-
-    /**
-     * The Total NetPay for the PayRun.
-     *
-     * @property float NetPay
-     */
-
-    /**
-     * @property \DateTimeInterface UpdatedDateUTC
-     */
-
-    /**
-     * See EarningsLine.
-     *
-     * @property EarningsLine[] EarningsLines
-     */
-
-    /**
-     * See LeaveEarningsLine.
-     *
-     * @property LeaveEarningsLine[] LeaveEarningsLines
-     */
-
-    /**
-     * See TimesheetEarningsLine.
-     *
-     * @property TimesheetEarningsLine[] TimesheetEarningsLines
-     */
-
-    /**
-     * See DeductionLine.
-     *
-     * @property DeductionLine[] DeductionLines
-     */
-
-    /**
-     * See ReimbursementLine.
-     *
-     * @property ReimbursementLine[] ReimbursementLines
-     */
-
-    /**
-     * See BenefitLine.
-     *
-     * @property BenefitLine[] BenefitLines
-     */
-
-    /**
-     * See TimeOffLine.
-     *
-     * @property TimeOffLine[] TimeOffLines
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/BenefitLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/BenefitLine.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $BenefitTypeID Xero identifier for payroll benefit type.
+ * @property float $Amount Reimbursement amount.
+ */
 class BenefitLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll benefit type.
-     *
-     * @property string BenefitTypeID
-     */
-
-    /**
-     * Reimbursement amount.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/DeductionLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/DeductionLine.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $DeductionTypeID Xero identifier for payroll earnings type.
+ * @property string $CalculationType Calculation Type code.
+ * @property string $Percentage The Percentage of the Deduction Line.
+ * @property float $Amount Deduction amount.
+ */
 class DeductionLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings type.
-     *
-     * @property string DeductionTypeID
-     */
-
-    /**
-     * Calculation Type code.
-     *
-     * @property string CalculationType
-     */
-
-    /**
-     * The Percentage of the Deduction Line.
-     *
-     * @property string Percentage
-     */
-
-    /**
-     * Deduction amount.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/EarningsLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsTypeID Xero identifier for payroll earnings type.
+ * @property float $RatePerUnit Rate per unit for earnings rate.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ */
 class EarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings type.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/LeaveEarningsLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsTypeID Xero identifier for payroll earnings type.
+ * @property float $RatePerUnit Rate per unit for earnings rate.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ */
 class LeaveEarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings type.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * Rate per unit for earnings rate.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/ReimbursementLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/ReimbursementLine.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ReimbursementTypeID Xero identifier for payroll reimbursement type.
+ * @property string $Description Reimbursement lines description (max length 50).
+ * @property string $ExpenseAccount Reimbursement expense account. For posted pay run you should be able to see expense account code.
+ * @property float $Amount Reimbursement amount.
+ */
 class ReimbursementLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll reimbursement type.
-     *
-     * @property string ReimbursementTypeID
-     */
-
-    /**
-     * Reimbursement lines description (max length 50).
-     *
-     * @property string Description
-     */
-
-    /**
-     * Reimbursement expense account. For posted pay run you should be able to see expense account code.
-     *
-     * @property string ExpenseAccount
-     */
-
-    /**
-     * Reimbursement amount.
-     *
-     * @property float Amount
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimeOffLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TimeOffTypeID Xero identifier for payroll time off type.
+ * @property string $Hours Hours of time off.
+ * @property string $Balance Balance for the time off type.
+ */
 class TimeOffLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll time off type.
-     *
-     * @property string TimeOffTypeID
-     */
-
-    /**
-     * Hours of time off.
-     *
-     * @property string Hours
-     */
-
-    /**
-     * Balance for the time off type.
-     *
-     * @property string Balance
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Paystub/TimesheetEarningsLine.php
@@ -4,26 +4,13 @@ namespace XeroPHP\Models\PayrollUS\Paystub;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsTypeID Xero identifier for payroll earnings type.
+ * @property float $RatePerUnit Rate per unit for earnings type.
+ * @property float[] $NumberOfUnits Earnings rate number of units.
+ */
 class TimesheetEarningsLine extends Remote\Model
 {
-    /**
-     * Xero identifier for payroll earnings type.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * Rate per unit for earnings type.
-     *
-     * @property float RatePerUnit
-     */
-
-    /**
-     * Earnings rate number of units.
-     *
-     * @property float[] NumberOfUnits
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Setting.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting.php
@@ -6,20 +6,12 @@ use XeroPHP\Remote;
 use XeroPHP\Models\PayrollUS\Setting\Account;
 use XeroPHP\Models\PayrollUS\Setting\TrackingCategory;
 
+/**
+ * @property Account[] $Accounts Payroll Account details for Bank, WagesPayable and WagesExpense. See Accounts.
+ * @property TrackingCategory[] $TrackingCategories Tracking categories for Employees and Timesheets. See Tracking Categories.
+ */
 class Setting extends Remote\Model
 {
-    /**
-     * Payroll Account details for Bank, WagesPayable and WagesExpense. See Accounts.
-     *
-     * @property Account[] Accounts
-     */
-
-    /**
-     * Tracking categories for Employees and Timesheets. See Tracking Categories.
-     *
-     * @property TrackingCategory[] TrackingCategories
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Setting/Account.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting/Account.php
@@ -4,32 +4,14 @@ namespace XeroPHP\Models\PayrollUS\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $AccountID Xero account identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $Type See Account Types.
+ * @property string $Code Customer defined account code eg. 200.
+ * @property string $Name Name of account.
+ */
 class Account extends Remote\Model
 {
-    /**
-     * Xero account identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string AccountID
-     */
-
-    /**
-     * See Account Types.
-     *
-     * @property string Type
-     */
-
-    /**
-     * Customer defined account code eg. 200.
-     *
-     * @property string Code
-     */
-
-    /**
-     * Name of account.
-     *
-     * @property string Name
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Setting/TrackingCategory.php
+++ b/src/XeroPHP/Models/PayrollUS/Setting/TrackingCategory.php
@@ -4,20 +4,12 @@ namespace XeroPHP\Models\PayrollUS\Setting;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $TrackingCategoryID Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
+ * @property string $TrackingCategoryName Name of tracking category.
+ */
 class TrackingCategory extends Remote\Model
 {
-    /**
-     * Xero tracking category identifier. e.g c56b19ef-75bf-45e8-98a4-e699a96609f7.
-     *
-     * @property string TrackingCategoryID
-     */
-
-    /**
-     * Name of tracking category.
-     *
-     * @property string TrackingCategoryName
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/Timesheet.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet.php
@@ -5,49 +5,17 @@ namespace XeroPHP\Models\PayrollUS;
 use XeroPHP\Remote;
 use XeroPHP\Models\PayrollUS\Timesheet\TimesheetLine;
 
+/**
+ * @property string $EmployeeID The Xero identifier for an employee.
+ * @property \DateTimeInterface $StartDate Period start date.
+ * @property \DateTimeInterface $EndDate Period end date.
+ * @property TimesheetLine[] $TimesheetLines See TimesheetLines.
+ * @property string $Status See Timesheet Status Codes.
+ * @property string $TimesheetID The Xero identifier for a Payroll Timesheet.
+ * @property string $Hours Timesheet total hours.
+ */
 class Timesheet extends Remote\Model
 {
-    /**
-     * The Xero identifier for an employee.
-     *
-     * @property string EmployeeID
-     */
-
-    /**
-     * Period start date.
-     *
-     * @property \DateTimeInterface StartDate
-     */
-
-    /**
-     * Period end date.
-     *
-     * @property \DateTimeInterface EndDate
-     */
-
-    /**
-     * See TimesheetLines.
-     *
-     * @property TimesheetLine[] TimesheetLines
-     */
-
-    /**
-     * See Timesheet Status Codes.
-     *
-     * @property string Status
-     */
-
-    /**
-     * The Xero identifier for a Payroll Timesheet.
-     *
-     * @property string TimesheetID
-     */
-
-    /**
-     * Timesheet total hours.
-     *
-     * @property string Hours
-     */
     const STATUS_DRAFT = 'DRAFT';
 
     const STATUS_PROCESSED = 'PROCESSED';

--- a/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
+++ b/src/XeroPHP/Models/PayrollUS/Timesheet/TimesheetLine.php
@@ -4,34 +4,14 @@ namespace XeroPHP\Models\PayrollUS\Timesheet;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $EarningsTypeID The Xero identifier for an Earnings Type.
+ * @property string $TrackingItemID The Xero identifier for a Tracking Category <TrackingOptionID>. The <TrackingOptionID> must belong to the TrackingCategory selected as <TimesheetCategories> under Payroll Settings.
+ * @property float[] $NumberOfUnits Number of units of a Timesheet line.
+ * @property string $WorkLocationID The Xero identifier for a Work Location, which must have been added for this employee under Payroll -> Employees -> Employment.
+ */
 class TimesheetLine extends Remote\Model
 {
-    /**
-     * The Xero identifier for an Earnings Type.
-     *
-     * @property string EarningsTypeID
-     */
-
-    /**
-     * The Xero identifier for a Tracking Category <TrackingOptionID>. The <TrackingOptionID> must belong
-     * to the TrackingCategory selected as <TimesheetCategories> under Payroll Settings.
-     *
-     * @property string TrackingItemID
-     */
-
-    /**
-     * Number of units of a Timesheet line.
-     *
-     * @property float[] NumberOfUnits
-     */
-
-    /**
-     * The Xero identifier for a Work Location, which must have been added for this employee under Payroll
-     * -> Employees -> Employment.
-     *
-     * @property string WorkLocationID
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/PayrollUS/WorkLocation.php
+++ b/src/XeroPHP/Models/PayrollUS/WorkLocation.php
@@ -4,56 +4,18 @@ namespace XeroPHP\Models\PayrollUS;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $StreetAddress Street address of the work location (max length = 400).
+ * @property string $City The city name of the address (max length = 50).
+ * @property string $State The state name of the address.
+ * @property string $Latitude The latitude of the address.
+ * @property string $Longitude The longitude of the address.
+ * @property string $WorkLocationID Xero identifier for a work location.
+ * @property string $SuitOrAptOrUnit Suite or apartment or unit information (max length = 50).
+ * @property string $IsPrimary Set to true to make this the primary work location.
+ */
 class WorkLocation extends Remote\Model
 {
-    /**
-     * Street address of the work location (max length = 400).
-     *
-     * @property string StreetAddress
-     */
-
-    /**
-     * The city name of the address (max length = 50).
-     *
-     * @property string City
-     */
-
-    /**
-     * The state name of the address.
-     *
-     * @property string State
-     */
-
-    /**
-     * The latitude of the address.
-     *
-     * @property string Latitude
-     */
-
-    /**
-     * The longitude of the address.
-     *
-     * @property string Longitude
-     */
-
-    /**
-     * Xero identifier for a work location.
-     *
-     * @property string WorkLocationID
-     */
-
-    /**
-     * Suite or apartment or unit information (max length = 50).
-     *
-     * @property string SuitOrAptOrUnit
-     */
-
-    /**
-     * Set to true to make this the primary work location.
-     *
-     * @property string IsPrimary
-     */
-
     /**
      * Get the resource uri of the class (Contacts) etc.
      *

--- a/src/XeroPHP/Models/Plan.php
+++ b/src/XeroPHP/Models/Plan.php
@@ -6,33 +6,14 @@ use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
 
+/**
+ * @property string $id The unique identifier for the plan
+ * @property string $name The name of the plan, this will display as the plan name in the plan selection UI
+ * @property string $status Status of the plan the user is subscribed to
+ * @property SubscriptionItem[] $subscriptionItems List of the subscription items belongin got the plan. This will return all relevant items for the current billing period
+ */
 class Plan extends Model
 {
-
-    /**
-     * The unique identifier for the plan
-     *
-     * @property string id
-     */
-
-    /**
-     * The name of the plan, this will display as the plan name in the plan selection UI
-     *
-     * @property string $name
-     */
-
-    /**
-     * Status of the plan the user is subscribed to
-     *
-     * @property string $status
-     */
-
-    /**
-     * List of the subscription items belongin got the plan. This will return all relevant items for the current billing period
-     *
-     * @property SubscriptionItem[] $subscriptionItems
-     */
-
     public static function getSupportedMethods()
     {
         return [

--- a/src/XeroPHP/Models/PracticeManager/Client.php
+++ b/src/XeroPHP/Models/PracticeManager/Client.php
@@ -14,84 +14,70 @@ use XeroPHP\Models\PracticeManager\Client\Type;
 use XeroPHP\Remote;
 use XeroPHP\Traits\PracticeManager\CustomFieldValueTrait;
 
+/**
+ * @property string $ID
+ * @property string $Name
+ * @property string $Title
+ * @property string $FirstName
+ * @property string $LastName
+ * @property string $OtherName
+ * @property string $DateOfBirth
+ * @property string $Email
+ * @property string $Address
+ * @property string $City
+ * @property string $Region
+ * @property string $PostCode
+ * @property string $Country
+ * @property string $PostalAddress
+ * @property string $PostalCity
+ * @property string $PostalRegion
+ * @property string $PostalPostCode
+ * @property string $PostalCountry
+ * @property string $Phone
+ * @property string $Fax
+ * @property string $Website
+ * @property string $ReferralSource
+ * @property string $ExportCode
+ * @property string $IsProspect
+ * @property string $IsDeleted
+ * @property string $IsArchived
+ * @property string $TaxNumber where the tax number is masked with *** except last 3 digits
+ * @property string $CompanyNumber
+ * @property string $BusinessNumber
+ * @property string $BranchNumber
+ * @property string $BusinessStructure e.g. Individual, Company, Trust, etc
+ * @property string $BalanceMonth
+ * @property string $PrepareGST Yes or No
+ * @property string $GSTRegistered Yes or No
+ * @property string $GSTPeriod Monthly, 2 Monthly, 6 Monthly
+ * @property string $GSTBasis Standard Option, Estimate Option, Ratio Option
+ * @property string $ProvisionalTaxBasis
+ * @property string $ProvisionalTaxRatio
+ * @property string $SignedTaxAuthority Yes or No
+ * @property string $TaxAgent
+ * @property string $AgencyStatus With EOT, Without EOT, Unlinked
+ * @property string $ReturnType IR3, IR3NR, IR4, IR6, IR7, IR9, PTS
+ *
+ * The following fields apply to AU clients only.
+ * @property string $PrepareActivityStatement Yes or No
+ * @property string $PrepareTaxReturn Yes or No
+ * @property string $ActiveAtoClient
+ * @property string $ClientCode
+ * @property string $AgencyStatus
+ *
+ * @property Contact[] $Contacts
+ * @property AccountManager $AccountManager
+ * @property JobManager $JobManager
+ * @property AutoBasOptInCriteria $AutoBasOptInCriteria
+ * @property Type $Type
+ * @property BillingClient $BillingClient
+ * @property Note[] $Notes
+ * @property Group[] $Groups
+ * @property Relationship[] $Relationship
+ */
 class Client extends Remote\Model
 {
     use CustomFieldValueTrait;
-
-    /**
-     * @property string ID
-     * @property string Name
-     * @property string Title
-     * @property string FirstName
-     * @property string LastName
-     * @property string OtherName
-     * @property string DateOfBirth
-     * @property string Email
-     * @property string Address
-     * @property string City
-     * @property string Region
-     * @property string PostCode
-     * @property string Country
-     * @property string PostalAddress
-     * @property string PostalCity
-     * @property string PostalRegion
-     * @property string PostalPostCode
-     * @property string PostalCountry
-     * @property string Phone
-     * @property string Fax
-     * @property string Website
-     * @property string ReferralSource
-     * @property string ExportCode
-     * @property string IsProspect
-     * @property string IsDeleted
-     * @property string IsArchived
-     * where the tax number is masked with *** except last 3 digits
-     * @property string TaxNumber
-     * @property string CompanyNumber
-     * @property string BusinessNumber
-     * @property string BranchNumber
-     * e.g. Individual, Company, Trust, etc
-     * @property string BusinessStructure
-     * @property string BalanceMonth
-     * Yes or No
-     * @property string PrepareGST
-     * Yes or No
-     * @property string GSTRegistered
-     * Monthly, 2 Monthly, 6 Monthly
-     * @property string GSTPeriod
-     * Invoice, Payment, Hybrid
-     * @property string GSTBasis
-     * Standard Option, Estimate Option, Ratio Option
-     * @property string ProvisionalTaxBasis
-     * @property string ProvisionalTaxRatio
-     * Yes or No
-     * @property string SignedTaxAuthority
-     * @property string TaxAgent
-     * With EOT, Without EOT, Unlinked
-     * @property string AgencyStatus
-     * IR3, IR3NR, IR4, IR6, IR7, IR9, PTS
-     * @property string ReturnType
-     * The following fields apply to AU clients only
-     * Yes or No
-     * @property string PrepareActivityStatement
-     * Yes or No
-     * @property string PrepareTaxReturn
-     * @property string ActiveAtoClient
-     * @property string ClientCode
-     * @property string AgencyStatus
-     * @property string AgencyStatus
-     *
-     * Related Objects
-     * @property Contact[] Contacts
-     * @property AccountManager AccountManager
-     * @property JobManager JobManager
-     * @property AutoBasOptInCriteria AutoBasOptInCriteria
-     * @property Type Type
-     * @property BillingClient BillingClient
-     * @property Note[] Notes
-     * @property Group[] Groups
-     * @property Relationship[] Relationship
-     */
 
     /**
      * Get the resource uri of the class (Clients) etc.

--- a/src/XeroPHP/Models/PracticeManager/Client/Contact.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Contact.php
@@ -5,6 +5,17 @@ namespace XeroPHP\Models\PracticeManager\Client;
 use XeroPHP\Remote;
 use XeroPHP\Traits\PracticeManager\CustomFieldValueTrait;
 
+/**
+ * @property string $ID
+ * @property string $IsPrimary
+ * @property string $Name
+ * @property string $Salutation
+ * @property string $Addressee
+ * @property string $Mobile
+ * @property string $Email
+ * @property string $Phone
+ * @property string $Position
+ */
 class Contact extends Remote\Model
 {
     use CustomFieldValueTrait;
@@ -24,17 +35,6 @@ class Contact extends Remote\Model
           <Position />
         </Contact>
      *
-     */
-    /**
-     * @property string ID
-     * @property string IsPrimary
-     * @property string Name
-     * @property string Salutation
-     * @property string Addressee
-     * @property string Mobile
-     * @property string Email
-     * @property string Phone
-     * @property string Position
      */
 
     /**

--- a/src/XeroPHP/Models/PracticeManager/Client/Note.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Note.php
@@ -4,16 +4,15 @@ namespace XeroPHP\Models\PracticeManager\Client;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Title
+ * @property string $Text
+ * @property string $Folder
+ * @property \DateTimeInterface $Date
+ * @property string $CreatedBy
+ */
 class Note extends Remote\Model
 {
-    /**
-     * @property string Title
-     * @property string Text
-     * @property string Folder
-     * @property \DateTimeInterface Date
-     * @property string CreatedBy
-     */
-
     /**
      * Get the resource uri of the class (Notes) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Client/Relationship.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Relationship.php
@@ -4,20 +4,16 @@ namespace XeroPHP\Models\PracticeManager\Client;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Type
+ * @property RelatedClient $RelatedClient Only set for Shareholder and Owner relationships
+ * @property string $NumberOfShares Only set for Shareholder and Owner relationships
+ * @property string $Percentage
+ * @property string $StartDate
+ * @property string $EndDate
+ */
 class Relationship extends Remote\Model
 {
-    /**
-     * @property string Type
-     * @property RelatedClient RelatedClient
-     * Only set for Shareholder and Owner relationships
-     * @property string NumberOfShares
-     * Only set for Shareholder and Owner relationships
-     * @property string Percentage
-     *
-     * @property string StartDate
-     * @property string EndDate
-     */
-
     /**
      * Get the resource uri of the class (Relationships) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Client/Type.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Type.php
@@ -4,16 +4,14 @@ namespace XeroPHP\Models\PracticeManager\Client;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Name
+ * @property string $CostMarkup
+ * @property string $PaymentTerm EG DayOfMonth or WithinDays
+ * @property string $PaymentDay
+ */
 class Type extends Remote\Model
 {
-    /**
-     * @property string Name
-     * @property string CostMarkup
-     * EG DayOfMonth or WithinDays
-     * @property string PaymentTerm
-     * @property string PaymentDay
-     */
-
     /**
      * Get the resource uri of the class (Types) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/CustomField.php
+++ b/src/XeroPHP/Models/PracticeManager/CustomField.php
@@ -12,92 +12,24 @@ use XeroPHP\Models\PracticeManager\Client\Relationship;
 use XeroPHP\Models\PracticeManager\Client\Type;
 use XeroPHP\Remote;
 
+/**
+ * @property string $ID Xero identifier.
+ * @property string $Name Name of Custom Field
+ * @property string $Type Type of Custom Field
+ * @property string $LinkUrl Link Url
+ * @property string $Options Custom Field Options for Dropdown lists
+ * @property bool $UseClient In Use for Clients
+ * @property bool $UseContact In Use for Client Contacts
+ * @property bool $UseSupplier In Use for Suppliers
+ * @property bool $UseJob In Use for Jobs
+ * @property bool $UseLead In Use for Leads
+ * @property bool $UseJobTask In Use for Job Tasks
+ * @property bool $UseJobCost In Use for Job Costing
+ * @property bool $UseJobTime In Use for Job Time
+ * @property string $ValueElement Identifies XML element for accessing the field value during GET or PUT - valid values are: Text | Decimal | Number | Boolean | Date
+ */
 class CustomField extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string ID
-     */
-
-    /**
-     * Name of Custom Field
-     *
-     * @property string Name
-     */
-
-    /**
-     * Type of Custom Field
-     *
-     * @property string Type
-     */
-
-    /**
-     * Link Url
-     *
-     * @property string LinkUrl
-     */
-
-    /**
-     * Custom Field Options for Dropdown lists
-     *
-     * @property string Options
-     */
-
-    /**
-     * In Use for Clients
-     *
-     * @property bool UseClient
-     */
-
-    /**
-     * In Use for Client Contacts
-     *
-     * @property bool UseContact
-     */
-
-    /**
-     * In Use for Suppliers
-     *
-     * @property bool UseSupplier
-     */
-
-    /**
-     * In Use for Jobs
-     *
-     * @property bool UseJob
-     */
-
-    /**
-     * In Use for Leads
-     *
-     * @property bool UseLead
-     */
-
-    /**
-     * In Use for Job Tasks
-     *
-     * @property bool UseJobTask
-     */
-
-    /**
-     * In Use for Job Costing
-     *
-     * @property bool UseJobCost
-     */
-
-    /**
-     * In Use for Job Time
-     *
-     * @property bool UseJobTime
-     */
-
-    /**
-     * Identifies XML element for accessing the field value during GET or PUT - valid values are: Text | Decimal | Number | Boolean | Date
-     *
-     * @property string ValueElement
-     */
-
     /**
      * Get the resource uri of the class (Clients) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/CustomFieldValue.php
+++ b/src/XeroPHP/Models/PracticeManager/CustomFieldValue.php
@@ -4,50 +4,17 @@ namespace XeroPHP\Models\PracticeManager;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ID ID of Custom Field
+ * @property string $Name Name of Custom Field
+ * @property string $Date Date Value - Only present when the Custom Field is this Type
+ * @property string $Number Number Value - Only present when the Custom Field is this Type Url
+ * @property string $Decimal Decimal Value - Only present when the Custom Field is this Type
+ * @property bool $Boolean Boolean Value - Only present when the Custom Field is this Type
+ * @property bool $Text Text Value - Only present when the Custom Field is this Type
+ */
 class CustomFieldValue extends Remote\Model
 {
-    /**
-     * ID of Custom Field
-     *
-     * @property string ID
-     */
-
-    /**
-     * Name of Custom Field
-     *
-     * @property string Name
-     */
-
-    /**
-     * Date Value - Only present when the Custom Field is this Type
-     *
-     * @property string Date
-     */
-
-    /**
-     * Number Value - Only present when the Custom Field is this Type Url
-     *
-     * @property string Number
-     */
-
-    /**
-     * Decimal Value - Only present when the Custom Field is this Type
-     *
-     * @property string Decimal
-     */
-
-    /**
-     * Boolean Value - Only present when the Custom Field is this Type
-     *
-     * @property bool Boolean
-     */
-
-    /**
-     * Text Value - Only present when the Custom Field is this Type
-     *
-     * @property bool Text
-     */
-
     /**
      * @var mixed
      */

--- a/src/XeroPHP/Models/PracticeManager/Invoice.php
+++ b/src/XeroPHP/Models/PracticeManager/Invoice.php
@@ -8,105 +8,26 @@ use XeroPHP\Models\PracticeManager\Invoice\Job;
 use XeroPHP\Models\PracticeManager\Invoice\Task;
 use XeroPHP\Remote;
 
+/**
+ * @property string $InternalID Xero identifier.
+ * @property string $ID Invoice Number.
+ * @property string $Type Type of Invoice
+ * @property string $Status Status of Invoice - Approved, Paid, Draft, Cancelled
+ * @property string $JobText JobText of Invoice
+ * @property \DateTimeInterface $Date Date of Invoice
+ * @property \DateTimeInterface $DueDate DueDate of Invoice
+ * @property float $Amount Amount of Invoice
+ * @property float $AmountTax AmountTax of Invoice
+ * @property float $AmountIncludingTax AmountIncludingTax of Invoice
+ * @property float $AmountPaid AmountPaid of Invoice
+ * @property float $AmountOutstanding AmountOutstanding of Invoice
+ * @property \XeroPHP\Models\PracticeManager\Invoice\Client $Client Client of Invoice
+ * @property \XeroPHP\Models\PracticeManager\Invoice\Contact $Contact Contact of Invoice
+ * @property \XeroPHP\Models\PracticeManager\Invoice\Job[] $Jobs Jobs of Invoice
+ * @property \XeroPHP\Models\PracticeManager\Invoice\Task[] $Tasks Tasks of Invoice
+ */
 class Invoice extends Remote\Model
 {
-    /**
-     * Xero identifier.
-     *
-     * @property string InternalID
-     */
-
-    /**
-     * Invoice Number.
-     *
-     * @property string ID
-     */
-
-    /**
-     * Type of Invoice
-     *
-     * @property string Type
-     */
-
-    /**
-     * Status of Invoice - Approved, Paid, Draft, Cancelled
-     *
-     * @property string Status
-     */
-
-    /**
-     * JobText of Invoice
-     *
-     * @property string JobText
-     */
-
-    /**
-     * Date of Invoice
-     *
-     * @property \DateTimeInterface Date
-     */
-
-    /**
-     * DueDate of Invoice
-     *
-     * @property \DateTimeInterface DueDate
-     */
-
-    /**
-     * Amount of Invoice
-     *
-     * @property float Amount
-     */
-
-    /**
-     * AmountTax of Invoice
-     *
-     * @property float AmountTax
-     */
-
-    /**
-     * AmountIncludingTax of Invoice
-     *
-     * @property float AmountIncludingTax
-     */
-
-    /**
-     * AmountPaid of Invoice
-     *
-     * @property float AmountPaid
-     */
-
-    /**
-     * AmountOutstanding of Invoice
-     *
-     * @property float AmountOutstanding
-     */
-
-    /**
-     * Client of Invoice
-     *
-     * @property \XeroPHP\Models\PracticeManager\Invoice\Client Client
-     */
-
-    /**
-     * Contact of Invoice
-     *
-     * @property \XeroPHP\Models\PracticeManager\Invoice\Contact Contact
-     */
-
-    /**
-     * Jobs of Invoice
-     *
-     * @property \XeroPHP\Models\PracticeManager\Invoice\Job[] Jobs
-     */
-
-    /**
-     * Tasks of Invoice
-     *
-     * @property \XeroPHP\Models\PracticeManager\Invoice\Task[] Tasks
-     */
-
-
     /**
      * Get the resource uri of the class (Clients) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Invoice/Cost.php
+++ b/src/XeroPHP/Models/PracticeManager/Invoice/Cost.php
@@ -4,21 +4,20 @@ namespace XeroPHP\Models\PracticeManager\Invoice;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $Description
+ * @property string $Note
+ * @property string $Code
+ * @property string $Billable
+ * @property float $Quantity
+ * @property float $UnitCost
+ * @property float $UnitPrice
+ * @property float $Amount
+ * @property float $AmountTax
+ * @property float $AmountIncludingTax
+ */
 class Cost extends Remote\Model
 {
-    /**
-     * @property string Description
-     * @property string Note
-     * @property string Code
-     * @property string Billable
-     * @property float Quantity
-     * @property float UnitCost
-     * @property float UnitPrice
-     * @property float Amount
-     * @property float AmountTax
-     * @property float AmountIncludingTax
-     */
-
     /**
      * Get the resource uri of the class (Costs) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Invoice/Job.php
+++ b/src/XeroPHP/Models/PracticeManager/Invoice/Job.php
@@ -4,17 +4,16 @@ namespace XeroPHP\Models\PracticeManager\Invoice;
 
 use XeroPHP\Remote;
 
+/**
+ * @property int $ID
+ * @property string $Name
+ * @property string $Description
+ * @property string $ClientOrderNumber
+ * @property Task[] $Tasks
+ * @property Cost[] $Costs
+ */
 class Job extends Remote\Model
 {
-    /**
-     * @property int ID
-     * @property string Name
-     * @property string Description
-     * @property string ClientOrderNumber
-     * @property Task[] Tasks
-     * @property Cost[] Costs
-     */
-
     /**
      * Get the resource uri of the class (Jobs) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Invoice/Task.php
+++ b/src/XeroPHP/Models/PracticeManager/Invoice/Task.php
@@ -4,20 +4,19 @@ namespace XeroPHP\Models\PracticeManager\Invoice;
 
 use XeroPHP\Remote;
 
+/**
+ * @property int $ID
+ * @property string $Name
+ * @property string $Description
+ * @property float $Minutes
+ * @property float $BillableRate
+ * @property string $Billable
+ * @property float $Amount
+ * @property float $AmountTax
+ * @property float $AmountIncludingTax
+ */
 class Task extends Remote\Model
 {
-    /**
-     * @property int ID
-     * @property string Name
-     * @property string Description
-     * @property float Minutes
-     * @property float BillableRate
-     * @property string Billable
-     * @property float Amount
-     * @property float AmountTax
-     * @property float AmountIncludingTax
-     */
-
     /**
      * Get the resource uri of the class (Tasks) etc.
      *

--- a/src/XeroPHP/Models/PracticeManager/Model/IdAndNameModel.php
+++ b/src/XeroPHP/Models/PracticeManager/Model/IdAndNameModel.php
@@ -4,13 +4,12 @@ namespace XeroPHP\Models\PracticeManager\Model;
 
 use XeroPHP\Remote;
 
+/**
+ * @property string $ID
+ * @property string $Name
+ */
 abstract class IdAndNameModel extends Remote\Model
 {
-    /**
-     * @property string ID
-     * @property string Name
-     */
-
     /**
      * Get the resource uri of the class (AccountManagers) etc.
      *

--- a/src/XeroPHP/Models/Price.php
+++ b/src/XeroPHP/Models/Price.php
@@ -6,26 +6,12 @@ use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
 
+/**
+ * @property int $id The unique identifier for the price
+ * @property int $amount The net (before tax) amount of the price
+ * @property string $currency The currency of the price
+ */
 class Price extends Model {
-
-    /**
-     * The unique identifier for the price
-     * 
-     * @property int $id
-     */
-
-    /**
-     * The net (before tax) amount of the price
-     * 
-     * @property int $amount
-     */
-
-    /**
-     * The currency of the price
-     * 
-     * @property string $currency
-     */
-
     public static function getProperties()
     {
         return [

--- a/src/XeroPHP/Models/Product.php
+++ b/src/XeroPHP/Models/Product.php
@@ -6,26 +6,12 @@ use XeroPHP\Remote\Model;
 use XeroPHP\Remote\Request;
 use XeroPHP\Remote\URL;
 
+/**
+ * @property int $id The unique identifier for the price
+ * @property string $name The name of the product
+ * @property string $type The currency of the pricing model of the product. FIXED, PER_SEAT
+ */
 class Product extends Model {
-
-    /**
-     * The unique identifier for the price
-     * 
-     * @property int $id
-     */
-
-    /**
-     * The name of the product
-     * 
-     * @property string $name
-     */
-
-    /**
-     * The currency of the pricing model of the product. FIXED, PER_SEAT
-     * 
-     * @property string $type
-     */
-
     public static function getProperties()
     {
         return [

--- a/src/XeroPHP/Models/Subscription.php
+++ b/src/XeroPHP/Models/Subscription.php
@@ -8,57 +8,16 @@ use XeroPHP\Remote\URL;
 
 /**
  * Property ref: https://developer.xero.com/documentation/api/xero-app-store/subscriptions/#get-subscription
+ * @property int $id The unique identifier for the subscription
+ * @property string $currentPeriodEnd Date when the current subscription period ends
+ * @property string $endDate If the subscription has been canceled, this is the date when the subscription ends. If null, the subscription is active and has not been cancelled
+ * @property bool $testMode Boolean used to indicate if the subscription is in test mode
+ * @property string $organisationId The Xero generated unique identifier for the organisation
+ * @property Plan[] $plans THe plan which has been subscribed to. See Plan
+ * @property string $startDate Date when the subscription was first created
+ * @property string $status Status of the subscription. ACTIVE, CANCELLED, PAST_DUE
  */
 class Subscription extends Model {
-
-    /**
-     * The unique identifier for the subscription
-     * 
-     * @property int $id
-     */
-
-    /**
-     * Date when the current subscription period ends
-     *
-     * @property string $currentPeriodEnd
-     */
-
-    /** 
-     * If the subscription has been canceled, this is the date when the subscription ends. If null, the subscription is active and has not been cancelled
-     *
-     * @property string $endDate
-     */    
-
-    /**
-     * Boolean used to indicate if the subscription is in test mode
-     * 
-     * @property bool $testMode
-     */
-
-    /**
-     * The Xero generated unique identifier for the organisation
-     * 
-     * @property string $organisationId
-     */
-
-    /**
-     * THe plan which has been subscribed to. See Plan
-     * 
-     * @property Plan[] $plans
-     */
-
-    /**
-     * Date when the subscription was first created
-     * 
-     * @property string $startDate
-     */
-
-    /**
-     * Status of the subscription. ACTIVE, CANCELLED, PAST_DUE
-     * 
-     * @property string $status
-     */
-
     const SUBSCRIPTION_STATUS_ACTIVE = 'ACTIVE';
 
     const SUBSCRIPTION_STATUS_CANCELLED = 'CANCELLED';

--- a/src/XeroPHP/Models/SubscriptionItem.php
+++ b/src/XeroPHP/Models/SubscriptionItem.php
@@ -8,45 +8,14 @@ use XeroPHP\Remote\URL;
 
 /**
  * Property ref: https://developer.xero.com/documentation/api/xero-app-store/subscriptions/#get-subscription
+ * @property int $id The unique identifier for the subscription
+ * @property Price $price The price of the product subscribed to
+ * @property string $endDate Date when the subscription to this product will end
+ * @property string $startDate Start date for the subscription to this item. Note: this may be in the future for downgrades or reduced number of seats that haven't taken effect yet
+ * @property string $status Status of the subscription items the user is subscribed to
+ * @property Product $product The product subscribed to
  */
 class SubscriptionItem extends Model {
-
-    /**
-     * The unique identifier for the subscription
-     * 
-     * @property int $id
-     */
-
-    /**
-     * The price of the product subscribed to
-     *
-     * @property Price $price
-     */
-
-    /** 
-     * Date when the subscription to this product will end
-     *
-     * @property string $endDate
-     */    
-
-    /**
-     * Start date for the subscription to this item. Note: this may be in the future for downgrades or reduced number of seats that haven't taken effect yet
-     * 
-     * @property string $startDate
-     */
-
-    /**
-     * Status of the subscription items the user is subscribed to
-     * 
-     * @property string $status
-     */
-
-    /**
-     * The product subscribed to
-     * 
-     * @property Product $product
-     */
-
     public static function getProperties()
     {
         return [


### PR DESCRIPTION
I whipped up some sloppy regular expressions and fixed most of this automatically, although the formatting wasn't entirely consistent so I had to clean up some mess afterwards.

Note that you can't actually mark a magic `@property` as `@deprecated` in PHPDoc syntax, so I've just written "Deprecated: this property has been removed from the Xero API." in those properties' descriptions instead. I think this may not be ideal - if those properties have indeed been removed from Xero's API entirely, and trying to access them using xero-php will error, then the magic properties should probably be removed from xero-php as well. That way, tooling like PHPStan will know the property no longer exists and alert users that are still trying to use it. If those properties are technically deprecated but still safe to access, then it's fine to keep them in xero-php with a note indicating they were deprecated.