### PR TITLE
Remove Boolean conversion on Contact

### DIFF
--- a/src/XeroPHP/Models/PracticeManager/Client/Contact.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Contact.php
@@ -15,7 +15,7 @@ class Contact extends Remote\Model
             <ID>142</ID>
           </Client>
           <Name>Wyett E Coyote</Name>
-          <IsPrimary>yes</IsPrimary> <!-- If multiple contacts defined, method will interpret last primary client as Primary -->
+          <IsPrimary>Yes</IsPrimary> <!-- If multiple contacts defined, method will interpret last primary client as Primary -->
           <Salutation />
           <Addressee />
           <Mobile />

--- a/src/XeroPHP/Models/PracticeManager/Client/Contact.php
+++ b/src/XeroPHP/Models/PracticeManager/Client/Contact.php
@@ -142,24 +142,18 @@ class Contact extends Remote\Model
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function getIsPrimary()
     {
-        return $this->_data['IsPrimary'] == 'yes';
+        return $this->_data['IsPrimary'];
     }
 
     /**
-     * @param string|bool $value
+     * @param string $value
      *
      * @return Contact
      */
     public function setIsPrimary($value)
     {
-        // Convert value to ENUM Yes or No
-        $value = $value === true || $value == 'yes' ? 'yes' : 'no';
-
         $this->propertyUpdated('IsPrimary', $value);
         $this->_data['IsPrimary'] = $value;
 

--- a/tests/Remote/ModelTest.php
+++ b/tests/Remote/ModelTest.php
@@ -116,7 +116,7 @@ class ModelTest extends \PHPUnit_Framework_TestCase
       <Contacts>
         <Contact>
           <ID>220</ID>
-          <IsPrimary>yes</IsPrimary>
+          <IsPrimary>Yes</IsPrimary>
           <Name>Samantha Benecke</Name> 
           <Salutation>Sam</Salutation> 
           <Addressee>Mrs S Benecke</Addressee> 


### PR DESCRIPTION
So the boolean conversion on Contact that i introduced years ago is actually wrong. 

I'm changing it to just return the underlying data instead of trying to be clever. 

It's a breaking change i guess, but it's never actually worked. Not sure too many people actually use this for Xero Practice Manager. 

