### PR TITLE
add history trait to BatchPayment, ManualJournal models

### DIFF
--- a/src/XeroPHP/Models/Accounting/BatchPayment.php
+++ b/src/XeroPHP/Models/Accounting/BatchPayment.php
@@ -3,9 +3,11 @@
 namespace XeroPHP\Models\Accounting;
 
 use XeroPHP\Remote;
+use XeroPHP\Traits\HistoryTrait;
 
 class BatchPayment extends Remote\Model
 {
+    use HistoryTrait;
 
     /**
      * Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06

--- a/src/XeroPHP/Models/Accounting/ManualJournal.php
+++ b/src/XeroPHP/Models/Accounting/ManualJournal.php
@@ -5,10 +5,12 @@ namespace XeroPHP\Models\Accounting;
 use XeroPHP\Remote;
 use XeroPHP\Traits\AttachmentTrait;
 use XeroPHP\Models\Accounting\ManualJournal\JournalLine;
+use XeroPHP\Traits\HistoryTrait;
 
 class ManualJournal extends Remote\Model
 {
     use AttachmentTrait;
+    use HistoryTrait;
 
     /**
      * Xero identifier.


### PR DESCRIPTION
As per Xero documentation, History/Notes can be retrieved for Manual Journals and batch payments.

https://developer.xero.com/documentation/api/accounting/historyandnotes#supported-document-types-for-adding-notes-and-retrieving-history

This PR adds the existing trait to the supported models which were missing the trait