### PR TITLE
Allow BadRequestException to contain the response

### DIFF
--- a/src/XeroPHP/Remote/Exception.php
+++ b/src/XeroPHP/Remote/Exception.php
@@ -4,5 +4,15 @@ namespace XeroPHP\Remote;
 
 class Exception extends \XeroPHP\Exception
 {
-    //
+    protected ?Response $response = null;
+
+    public function setResponse(Response $response): self
+    {
+        $this->response = $response;
+        return $this;
+    }
+
+    public function getResponse(): ?Response {
+        return $this->response;
+    }
 }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -107,10 +107,10 @@ class Response
                     $message = sprintf('%s (%s)', $this->root_error['message'], implode(', ', $this->element_errors));
                     $message .= $this->parseBadRequest();
 
-                    throw new BadRequestException($message, $this->root_error['code']);
+                    throw (new BadRequestException($message, $this->root_error['code']))->setResponse($this);
                 }
 
-                throw new BadRequestException();
+                throw (new BadRequestException())->setResponse($this);
 
 
             /** @noinspection PhpMissingBreakStatementInspection */


### PR DESCRIPTION
For debugging/logging purposes, it can be useful to access the raw response when dealing with `BadRequestException` and build an appropriate error message yourself.

Since the `Response` object throws when it's parsed, and `Query` / `Application` only return the response when successful, simply catching remote exceptions doesn't expose the request / response that caused it.

This PR adds a getter/setter on the `Remote/Exception` object for the `Response` that caused it, so caught exceptions can get access to this information:
```php
try {
  $application->save(...);
} catch (BadRequestException $e) {
  $response = $e->getResponse();
  if ($response) {
    logElementErrors($response->getElementErrors());
  }
  ...
}
```

For the sake of limiting breaking changes, I have abstained from adding the `Response` as a constructor option, and only setting the response on the `BadRequestException` (as that is where it's most useful).

Future PRs could re-consider how this is handled (i.e., adding a static `fromResponse` function to all remote exceptions).