### PR TITLE
pass through response to NotFoundException

### DIFF
--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -21,6 +21,8 @@ class Request
 
     const CONTENT_TYPE_XML = 'text/xml';
 
+    const CONTENT_TYPE_APPLICATION_XML = 'application/xml';
+
     const CONTENT_TYPE_JSON = 'application/json';
 
     const CONTENT_TYPE_PDF = 'application/pdf';

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -132,7 +132,7 @@ class Response
                 throw new ForbiddenException();
 
             case self::STATUS_NOT_FOUND:
-                throw new NotFoundException();
+                throw (new NotFoundException())->setResponse($this);
 
             case self::STATUS_INTERNAL_ERROR:
                 throw new InternalErrorException();
@@ -253,6 +253,7 @@ class Response
 
             switch ($content_type) {
                 case Request::CONTENT_TYPE_XML:
+                case Request::CONTENT_TYPE_APPLICATION_XML:
                     $this->parseXML();
                     break;
 


### PR DESCRIPTION
Hi there, 

We've found in our application of the `LangleyFoxall\XeroLaravel` library that Xero often returns important information in the error response bodies that is important for us to store and present options for our users to solve their issue. 

This PR solves one major blocker for us which attaches the response body and parses it correctly from Xero to the NotFoundException so errors can be read out.

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/bb0b412a-762c-4b98-a207-a99f8712d645" />

This lets us do things like this:
```php
try {
    $xero->payrollAUPayrollCalendars()->get();
} catch (Exception\NotFoundException $e) {
    dd(
        $e->response->getRootError(),
    );
}
```

and get out super helpful responses like:
```
array:3 [
  "code" => "0"
  "type" => "Error"
  "message" => "Payroll has not been provisioned"
]
```