### PR TITLE
fix: handle invalid response codes for PDF resolution

### DIFF
--- a/src/XeroPHP/Traits/PDFTrait.php
+++ b/src/XeroPHP/Traits/PDFTrait.php
@@ -3,6 +3,7 @@
 namespace XeroPHP\Traits;
 
 use XeroPHP\Exception;
+use XeroPHP\Remote\Response;
 use XeroPHP\Remote\URL;
 use XeroPHP\Remote\Request;
 
@@ -21,7 +22,13 @@ trait PDFTrait
             throw new Exception('PDF files are only available to objects that exist remotely.');
         }
 
-        return $this->buildPDFRequest()->send()->getResponseBody();
+        $response = $this->buildPDFRequest()->send();
+
+        if ($response->getStatus() !== Response::STATUS_OK) {
+            throw new Exception('Failed to retrieve PDF file.');
+        }
+
+        return $response->getResponseBody();
     }
 
     /**


### PR DESCRIPTION
Recently came across an issue with our implementation of downloadable PDF invoices in Xero, while Xero API was unavailable we were unable to retrieve the PDF and our implementation downloaded the 500 page from xero instead of the invoice PDF. Could some handling like this be added?

Much appreciated..