### PR TITLE
FIX: PHP 8.4 implicitly nullable parameter declarations deprecation

### DIFF
--- a/src/XeroPHP/Remote/Exception/RequiredFieldException.php
+++ b/src/XeroPHP/Remote/Exception/RequiredFieldException.php
@@ -10,7 +10,7 @@ class RequiredFieldException extends Exception
     protected $class;
     protected $field;
 
-    public function __construct($class, $field, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct($class, $field, $message = "", $code = 0, ?Throwable $previous = null)
     {
         $this->class = $class;
         $this->field = $field;

--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -71,7 +71,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
      */
     protected $_application;
 
-    public function __construct(Application $application = null)
+    public function __construct(?Application $application = null)
     {
         $this->_application = $application;
         $this->_dirty = [];
@@ -79,7 +79,7 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
         $this->_associated_objects = [];
     }
 
-    public static function make(Application $application = null)
+    public static function make(?Application $application = null)
     {
         return new static($application);
     }

--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -171,7 +171,7 @@ class Query
      *
      * @return $this
      */
-    public function modifiedAfter(\DateTimeInterface $modifiedAfter = null)
+    public function modifiedAfter(?\DateTimeInterface $modifiedAfter = null)
     {
         if ($modifiedAfter === null) {
             $modifiedAfter = new \DateTime('@0'); // since ever


### PR DESCRIPTION
FYI: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types