### PR TITLE
Add @return type for Model::offsetUnset()

### DIFF
--- a/src/XeroPHP/Remote/Model.php
+++ b/src/XeroPHP/Remote/Model.php
@@ -599,6 +599,8 @@ abstract class Model implements ObjectInterface, \JsonSerializable, \ArrayAccess
 
     /**
      * @param mixed $offset
+     *
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)


### PR DESCRIPTION
This fixes the following deprecation:

```
User Deprecated: Method "ArrayAccess::offsetUnset()" might add "void" as a
native return type declaration in the future. Do the same in implementation
"XeroPHP\Remote\Model" now to avoid errors or add an explicit @return annotation
to suppress this message.
```

Reported by @baci266 in [#939](https://github.com/calcinai/xero-php/pull/939#issuecomment-3705930533)