### PR TITLE
Add missing LeaveCategoryCode to the LeaveType Model

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
+++ b/src/XeroPHP/Models/PayrollAU/PayItem/LeaveType.php
@@ -32,6 +32,26 @@ class LeaveType extends Remote\Model
      */
 
     /**
+     * Set this to indicate the category of leave. This is a required field
+     * https://developer.xero.com/documentation/api/payrollau/payitems#post-payitems--elements-for-leavetypes
+     * Valid options are from LeaveCategoryCode
+     * - ANNUALLEAVE
+     * - LONGSERVICELEAVE
+     * - PERSONALSICKCARERSLEAVE
+     * - ROSTEREDDAYOFF
+     * - TIMEOFFINLIEU
+     * - COMPASSIONATEANDBEREAVEMENTLEAVE
+     * - STUDYLEAVE
+     * - FAMILYANDDOMESTICVIOLENCELEAVE
+     * - SPECIALPAIDLEAVE
+     * - COMMUNITYSERVICELEAVE
+     * - JURYDUTYLEAVE
+     * - DEFENCERESERVELEAVE
+     *
+     * @property string LeaveCategoryCode
+     */
+
+    /**
      * Xero identifier.
      *
      * @property string LeaveTypeID
@@ -116,6 +136,7 @@ class LeaveType extends Remote\Model
             'TypeOfUnits' => [true, self::PROPERTY_TYPE_STRING, null, true, false],
             'IsPaidLeave' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
             'ShowOnPayslip' => [true, self::PROPERTY_TYPE_STRING, null, false, false],
+            'LeaveCategoryCode' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LeaveTypeID' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'NormalEntitlement' => [false, self::PROPERTY_TYPE_STRING, null, false, false],
             'LeaveLoadingRate' => [false, self::PROPERTY_TYPE_FLOAT, null, false, false],
@@ -200,6 +221,14 @@ class LeaveType extends Remote\Model
     }
 
     /**
+     * @return string
+     */
+    public function getLeaveCategoryCode()
+    {
+        return $this->_data['LeaveCategoryCode'];
+    }
+
+    /**
      * @param string $value
      *
      * @return LeaveType
@@ -208,6 +237,19 @@ class LeaveType extends Remote\Model
     {
         $this->propertyUpdated('ShowOnPayslip', $value);
         $this->_data['ShowOnPayslip'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return LeaveType
+     */
+    public function setLeaveCategoryCode(string $value)
+    {
+        $this->propertyUpdated('LeaveCategoryCode', $value);
+        $this->_data['LeaveCategoryCode'] = $value;
 
         return $this;
     }


### PR DESCRIPTION
This pull request adds support for the `LeaveCategoryCode` property to the `LeaveType` model in the Australian Payroll module. This new property allows specifying the category of leave, aligning with Xero's API requirements and supporting a range of valid leave categories.

**Enhancements to LeaveType model:**

* Added a new property `LeaveCategoryCode` with documentation, listing all valid leave categories as per Xero's API.
* Updated the `getProperties()` method to include the new `LeaveCategoryCode` property in the model's property map.
* Added getter (`getLeaveCategoryCode()`) and setter (`setLeaveCategoryCode(string $value)`) methods for the `LeaveCategoryCode` property, enabling read and write access. [[1]](diffhunk://#diff-8f51ab5c30ed6aa09a293edc899570189a245ebab65d226277cc61fa9b7ea432R223-R230) [[2]](diffhunk://#diff-8f51ab5c30ed6aa09a293edc899570189a245ebab65d226277cc61fa9b7ea432R244-R256)