### PR TITLE
Change Files\Object to Files\FileObject

### DIFF
--- a/src/XeroPHP/Models/Files/FileObject.php
+++ b/src/XeroPHP/Models/Files/FileObject.php
@@ -2,7 +2,7 @@
 
 namespace XeroPHP\Models\Files;
 
-class Object
+class FileObject
 {
     const OBJECT_GROUP_ACCOUNT = 'Account';
 


### PR DESCRIPTION
Fix for issue [Error accessing XeroPHP\Models\Files\Object](https://github.com/calcinai/xero-php/issues/947)

Rename of XeroPHP\Models\Files\Object to XeroPHP\Models\Files\FileObject to fix use of restricted word.

I have checked as best I can for references in the package for XeroPHP\Models\Files\Object.

Happy to here any feedback on how to do this better.